### PR TITLE
fix(webhook): transform bash/zsh commands to use sh executor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/NexusGPU/tensor-fusion
 go 1.24.1
 
 require (
+	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/NVIDIA/go-nvml v0.12.4-1
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107
 	github.com/aws/aws-sdk-go-v2 v1.36.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
+al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
 cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -118,6 +120,8 @@ github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 h1:VNqngBF40hVlDloBruUehVYC3ArSgIyScOAyMRqBxRg=

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -555,5 +555,71 @@ var _ = Describe("TensorFusionPodMutator", func() {
 			// There should be at least 2 patches (initContainers and the container env patches)
 			Expect(len(patch)).To(BeNumerically(">=", 2))
 		})
+
+		It("should transform bash/zsh -c commands correctly", func() {
+			// Create a pod with bash and zsh -c commands
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-command-transform",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "bash-container",
+							Image:   "test-image",
+							Command: []string{"bash", "-c", "echo 'hello world' && ls -la"},
+						},
+						{
+							Name:    "zsh-container",
+							Image:   "test-image",
+							Command: []string{"zsh", "-c", "echo 'special chars: $HOME \"quoted\" text'"},
+						},
+						{
+							Name:    "other-container",
+							Image:   "test-image",
+							Command: []string{"sh", "-c", "echo 'this should not change'"},
+						},
+					},
+				},
+			}
+
+			clientConfig := &tfv1.ClientConfig{}
+			containerNames := []string{"bash-container", "zsh-container", "other-container"}
+			nodeSelector := map[string]string{}
+
+			// Call the function that includes the command transformation
+			mutator := &TensorFusionPodMutator{}
+			patches, err := mutator.patchTFClient(pod, clientConfig, containerNames, nodeSelector)
+
+			// Verify results
+			Expect(err).NotTo(HaveOccurred())
+
+			// Check that the patches include command transformations
+			var bashCommandPatchFound, zshCommandPatchFound, otherCommandPatchFound bool
+
+			for _, patch := range patches {
+				// Check for command transformation patches
+				// Command patches are applied to individual elements, not the whole array
+				if patch.Path == "/spec/containers/0/command/0" && patch.Value == "sh" {
+					bashCommandPatchFound = true
+				} else if patch.Path == "/spec/containers/0/command/2" {
+					// Third element (the command string) for bash container
+					Expect(patch.Value).To(ContainSubstring("bash -c"))
+				} else if patch.Path == "/spec/containers/1/command/0" && patch.Value == "sh" {
+					zshCommandPatchFound = true
+				} else if patch.Path == "/spec/containers/1/command/2" {
+					// Third element (the command string) for zsh container
+					Expect(patch.Value).To(ContainSubstring("zsh -c"))
+				} else if patch.Path == "/spec/containers/2/command/0" && patch.Value == "sh" {
+					otherCommandPatchFound = true
+				}
+			}
+
+			// Verify the right patches were found
+			Expect(bashCommandPatchFound).To(BeTrue(), "No patch found for bash command transformation")
+			Expect(zshCommandPatchFound).To(BeTrue(), "No patch found for zsh command transformation")
+			Expect(otherCommandPatchFound).To(BeFalse(), "Unexpected patch found for other container command transformation")
+		})
 	})
 })


### PR DESCRIPTION
Fix for issue #164 by transforming container commands from `bash -c "xx"` or `zsh -c "xx"` to `sh -c bash -c "xx"` or `sh -c zsh -c "xx"` respectively.

Closes #164