### PR TITLE
Potential fix for code scanning alert no. 35: Incorrect conversion between integer types

### DIFF
--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"io"
 	"strconv"
+	"math"
 	"sync"
 	"time"
 
@@ -92,8 +93,8 @@ func SetWorkerMetricsByWorkload(pod *corev1.Pod) {
 	metricsItem.TflopsLimit = gpuLimitResource.Tflops.AsApproximateFloat64()
 	metricsItem.VramBytesRequest = gpuRequestResource.Vram.AsApproximateFloat64()
 	metricsItem.VramBytesLimit = gpuLimitResource.Vram.AsApproximateFloat64()
-	if count <= 0 {
-		// handle invalid data if exists
+	if count <= 0 || count > uint64(math.MaxInt32) {
+		// handle invalid or out-of-bounds data
 		metricsItem.GPUCount = 1
 	} else {
 		metricsItem.GPUCount = int(count)


### PR DESCRIPTION
Potential fix for [https://github.com/NexusGPU/tensor-fusion/security/code-scanning/35](https://github.com/NexusGPU/tensor-fusion/security/code-scanning/35)

To fix the problem, we should ensure that the value parsed from the annotation is within the valid range for GPU counts and for the target type (`int`). Since GPU counts should be positive and reasonably bounded, we should check that `count` is greater than zero and less than or equal to a reasonable maximum (e.g., `math.MaxInt32` or a domain-specific maximum GPU count). For safety and to match the bit size, we should use `math.MaxInt32` as the upper bound. If the value is out of bounds, we should set a default value (e.g., 1). The fix should be applied in the `SetWorkerMetricsByWorkload` function in internal/metrics/recorder.go, specifically around lines 95-100. We also need to import the `math` package to access `math.MaxInt32`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
