### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,5 +1,8 @@
 name: E2E Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/NexusGPU/tensor-fusion/security/code-scanning/36](https://github.com/NexusGPU/tensor-fusion/security/code-scanning/36)

To fix the issue, add a `permissions:` block to the job or workflow to restrict GITHUB_TOKEN access to the minimum required. For this workflow, restricting to `contents: read` will permit checking out code but not allow any writes to the repository. Since the suggestion is to use this as a minimal starting point, and the workflow does not use any other privileged actions (like issues, deployments, or packages), setting `contents: read` is sufficient. The fix can be applied by adding:

- `permissions: contents: read` at either the root level of the workflow (to apply to all jobs), or specifically under the `test-e2e` job in `.github/workflows/test-e2e.yml`.

Given the simple single-job workflow, putting it at the root is most concise and offers clarity for future jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
