### PR TITLE
refactor: name the ResourceSlice controller in setup

### DIFF
--- a/internal/controller/dra/resourceslice_controller.go
+++ b/internal/controller/dra/resourceslice_controller.go
@@ -328,6 +328,7 @@ func (r *ResourceSliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&tfv1.GPUNode{}).
+		Named("resourceslice").
 		Watches(&tfv1.GPU{}, handler.EnqueueRequestsFromMapFunc(
 			func(ctx context.Context, obj client.Object) []reconcile.Request {
 				// Get the owner GPUNode name from GPU labels


### PR DESCRIPTION
- Added a name "resourceslice" to the ResourceSlice controller setup for better identification and management within the controller manager.