### PR TITLE
feat: add DRA device taints feature gate and enhance CEL expression generation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -104,6 +104,7 @@ var alertEvaluator *alert.AlertEvaluator
 var schedulerConfigPath string
 var alertEvaluatorReady chan struct{}
 var enableAutoExpander bool
+var enableDRADeviceTaints bool
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -156,6 +157,8 @@ func main() {
 			"refer https://prometheus.io/docs/alerting/latest/configuration")
 	flag.BoolVar(&enableAutoExpander, "enable-auto-expander", false, "if turn on auto expander, "+
 		"TensorFusion will auto expand Nodes then Pending Pods which caused by insufficient GPU resources found")
+	flag.BoolVar(&enableDRADeviceTaints, "enable-dra-device-taints", false, "if turn on DRA device taints feature gate, "+
+		"requires Kubernetes version >= 1.34 and DeviceTaintRule API support")
 
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -528,7 +531,7 @@ func startScheduler(
 
 	cc, scheduler, nodeExpander, err := sched.SetupScheduler(
 		ctx, mgr, schedulerConfigPath, false, k8sVersion,
-		allocator, enableAutoExpander, gpuResourceFitOpt, gpuTopoOpt,
+		allocator, enableAutoExpander, enableDRADeviceTaints, gpuResourceFitOpt, gpuTopoOpt,
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to create tensor fusion scheduler")

--- a/internal/webhook/v1/resourceclaim_webhook.go
+++ b/internal/webhook/v1/resourceclaim_webhook.go
@@ -208,7 +208,8 @@ func (m *ResourceClaimMutator) updateCapacityRequest(resourceClaim *resourcev1.R
 	// Update capacity requests using constants
 	deviceReq.Exactly.Capacity.Requests[constants.DRACapacityTFlops] = gpuRequestResource.Tflops
 	deviceReq.Exactly.Capacity.Requests[constants.DRACapacityVRAM] = gpuRequestResource.Vram
-
+	deviceReq.Exactly.Capacity.Requests[constants.DRACapacityVirtualTFlops] = gpuRequestResource.Tflops
+	deviceReq.Exactly.Capacity.Requests[constants.DRACapacityVirtualVRAM] = gpuRequestResource.Vram
 	return nil
 }
 


### PR DESCRIPTION
- Introduced a new feature gate for DRA device taints, configurable via command-line flag, requiring Kubernetes version >= 1.34.
- Updated the SetupScheduler function to enable DRA feature gates based on Kubernetes version and user configuration.
- Enhanced CEL expression generation in the DRAProcessor to utilize helper functions for better readability and maintainability.
- Modified tests to validate the new DRA feature gate and ensure correct CEL expression generation for various resource conditions.