### PR TITLE
fix: use PreferNoSchedule taint effect for flexible node isolation

### DIFF
--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -283,7 +283,7 @@ func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
 	tmpl.Spec.NodeName = gpunode.Name
 	// allow job to run at any taint Nodes that marked as NoSchedule
 	tmpl.Spec.Tolerations = append(tmpl.Spec.Tolerations, corev1.Toleration{
-		Key:      string(corev1.TaintEffectNoSchedule),
+		Key:      string(corev1.TaintEffectPreferNoSchedule),
 		Operator: corev1.TolerationOpExists,
 	})
 	tmpl.Spec.EnableServiceLinks = ptr.To(false)
@@ -464,7 +464,7 @@ func (r *GPUNodeReconciler) createHypervisorPod(
 		newPod.Spec.Tolerations = []corev1.Toleration{}
 	}
 	newPod.Spec.Tolerations = append(newPod.Spec.Tolerations, corev1.Toleration{
-		Key:      string(corev1.TaintEffectNoSchedule),
+		Key:      string(corev1.TaintEffectPreferNoSchedule),
 		Operator: corev1.TolerationOpExists,
 	})
 	err = controllerutil.SetControllerReference(node, newPod, r.Scheme)

--- a/internal/gpuallocator/node_capacity.go
+++ b/internal/gpuallocator/node_capacity.go
@@ -116,7 +116,7 @@ func RefreshGPUNodeCapacity(
 		if utils.IsProgressiveMigration() && coreNode != nil {
 			taint := &corev1.Taint{
 				Key:    constants.NodeUsedByTaintKey,
-				Effect: corev1.TaintEffectNoSchedule,
+				Effect: corev1.TaintEffectPreferNoSchedule,
 				Value:  constants.TensorFusionSystemName,
 			}
 			needUpdateNode := false

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -556,7 +556,7 @@ func assignPodLabelsAndAnnotations(isLocalGPU bool, pod *corev1.Pod, pool *tfv1.
 			Key:      constants.NodeUsedByTaintKey,
 			Operator: corev1.TolerationOpEqual,
 			Value:    constants.TensorFusionSystemName,
-			Effect:   corev1.TaintEffectNoSchedule,
+			Effect:   corev1.TaintEffectPreferNoSchedule,
 		})
 	} else {
 		pod.Labels[constants.LabelComponent] = constants.ComponentClient

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -65,7 +65,7 @@ func (wg *WorkerGenerator) GenerateWorkerPod(
 		Key:      constants.NodeUsedByTaintKey,
 		Operator: v1.TolerationOpEqual,
 		Value:    constants.TensorFusionSystemName,
-		Effect:   v1.TaintEffectNoSchedule,
+		Effect:   v1.TaintEffectPreferNoSchedule,
 	})
 
 	// Add labels to identify this pod as part of the workload


### PR DESCRIPTION
Change from NoSchedule to PreferNoSchedule to allow non-TensorFusion pods scheduling when needed, while maintaining preference for TensorFusion workloads. Add automatic taint management based on resource availability.