### PR TITLE
feat(controller): remove legacy TensorFusion taint and fix toleration

### DIFF
--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -281,9 +281,9 @@ func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
 	}
 	tmpl.Labels[constants.LabelComponent] = constants.ComponentNodeDiscovery
 	tmpl.Spec.NodeName = gpunode.Name
-	// allow job to run at any taint Nodes that marked as NoSchedule
+	// tolerate the nodes that used by TensorFusion system
 	tmpl.Spec.Tolerations = append(tmpl.Spec.Tolerations, corev1.Toleration{
-		Key:      string(corev1.TaintEffectPreferNoSchedule),
+		Key:      constants.NodeUsedByTaintKey,
 		Operator: corev1.TolerationOpExists,
 	})
 	tmpl.Spec.EnableServiceLinks = ptr.To(false)
@@ -463,8 +463,9 @@ func (r *GPUNodeReconciler) createHypervisorPod(
 	if newPod.Spec.Tolerations == nil {
 		newPod.Spec.Tolerations = []corev1.Toleration{}
 	}
+	// tolerate the nodes that used by TensorFusion system
 	newPod.Spec.Tolerations = append(newPod.Spec.Tolerations, corev1.Toleration{
-		Key:      string(corev1.TaintEffectPreferNoSchedule),
+		Key:      constants.NodeUsedByTaintKey,
 		Operator: corev1.TolerationOpExists,
 	})
 	err = controllerutil.SetControllerReference(node, newPod, r.Scheme)

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package controller
 
 import (
+	"github.com/NexusGPU/tensor-fusion/internal/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("Node Controller", func() {
@@ -34,6 +38,118 @@ var _ = Describe("Node Controller", func() {
 				Build()
 			Expect(tfEnv.GetGPUNodeList(0).Items).Should(HaveLen(2))
 			Expect(tfEnv.GetGPUNodeList(1).Items).Should(HaveLen(3))
+		})
+	})
+
+	Context("When removing TensorFusion taint", func() {
+		var (
+			tfEnv      *TensorFusionEnv
+			nodeName   string
+			reconciler *NodeReconciler
+		)
+
+		BeforeEach(func() {
+			tfEnv = NewTensorFusionEnvBuilder().
+				AddPoolWithNodeCount(1).
+				SetGpuCountPerNode(1).
+				Build()
+			nodeName = tfEnv.getNodeName(0, 0)
+			reconciler = &NodeReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: nil,
+			}
+		})
+
+		AfterEach(func() {
+			tfEnv.Cleanup()
+		})
+
+		It("Should remove TensorFusion taint from node", func() {
+			By("Adding TensorFusion taint to node")
+			node := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+
+			taint := corev1.Taint{
+				Key:    constants.NodeUsedByTaintKey,
+				Value:  constants.TensorFusionSystemName,
+				Effect: corev1.TaintEffectNoSchedule,
+			}
+			node.Spec.Taints = append(node.Spec.Taints, taint)
+			Expect(k8sClient.Update(ctx, node)).To(Succeed())
+
+			By("Reconciling the node")
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: nodeName},
+			}
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying taint is removed")
+			Eventually(func(g Gomega) {
+				updatedNode := &corev1.Node{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, updatedNode)).To(Succeed())
+				taintExists := false
+				for _, t := range updatedNode.Spec.Taints {
+					if t.Key == constants.NodeUsedByTaintKey && t.Value == constants.TensorFusionSystemName {
+						taintExists = true
+						break
+					}
+				}
+				g.Expect(taintExists).To(BeFalse(), "TensorFusion taint should be removed")
+			}).Should(Succeed())
+		})
+
+		It("Should not update node when taint does not exist", func() {
+			By("Reconciling the node without taint")
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: nodeName},
+			}
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying node does not have TensorFusion taint")
+			Eventually(func(g Gomega) {
+				updatedNode := &corev1.Node{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, updatedNode)).To(Succeed())
+				// Verify taint removal function didn't cause unnecessary update
+				g.Expect(updatedNode.Spec.Taints).NotTo(ContainElement(HaveField("Key", constants.NodeUsedByTaintKey)))
+			}).Should(Succeed())
+		})
+
+		It("Should handle retry on conflict when removing taint", func() {
+			By("Adding TensorFusion taint to node")
+			node := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+
+			taint := corev1.Taint{
+				Key:    constants.NodeUsedByTaintKey,
+				Value:  constants.TensorFusionSystemName,
+				Effect: corev1.TaintEffectNoSchedule,
+			}
+			node.Spec.Taints = append(node.Spec.Taints, taint)
+			Expect(k8sClient.Update(ctx, node)).To(Succeed())
+
+			By("Reconciling the node (should retry on conflict if needed)")
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: nodeName},
+			}
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying taint is removed after retry")
+			Eventually(func(g Gomega) {
+				updatedNode := &corev1.Node{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, updatedNode)).To(Succeed())
+				taintExists := false
+				for _, t := range updatedNode.Spec.Taints {
+					if t.Key == constants.NodeUsedByTaintKey && t.Value == constants.TensorFusionSystemName {
+						taintExists = true
+						break
+					}
+				}
+				g.Expect(taintExists).To(BeFalse(), "TensorFusion taint should be removed with retry mechanism")
+			}).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
feat(controller): remove legacy TensorFusion taint and fix toleration
- Automatically remove legacy TensorFusion taint from nodes (temporary, remove after v1.50)
- Fix toleration key to use NodeUsedByTaintKey constant instead of TaintEffectPreferNoSchedule
- Add retry mechanism for safe concurrent taint removal
- Add comprehensive test cases for taint removal scenarios
- Improve test suite with auto-download and nil safety checks