### PR TITLE
refactor(gpuallocator): remove Pending phase from phase filter

### DIFF
--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -117,7 +117,7 @@ func NewGpuAllocator(ctx context.Context, client client.Client, syncInterval tim
 
 	// Create base filter store with common filters
 	baseRegistry := filter.NewFilterRegistry().With(
-		filter.NewPhaseFilter(tfv1.TensorFusionGPUPhaseRunning, tfv1.TensorFusionGPUPhasePending),
+		filter.NewPhaseFilter(tfv1.TensorFusionGPUPhaseRunning),
 	)
 
 	// Create quota store


### PR DESCRIPTION
Only filter Running phase GPUs in the base filter registry to simplify the filter logic.