### PR TITLE
fix: handle pod disabled state and nil pointer in auto migration

### DIFF
--- a/internal/utils/reconcile.go
+++ b/internal/utils/reconcile.go
@@ -208,9 +208,12 @@ func HasGPUResourceRequest(pod *corev1.Pod) bool {
 }
 
 func IsTensorFusionPod(pod *corev1.Pod) bool {
-	return pod.Labels[constants.TensorFusionEnabledLabelKey] == constants.TrueStringValue
+	return pod.Labels != nil && pod.Labels[constants.TensorFusionEnabledLabelKey] == constants.TrueStringValue
 }
 
+func IsTensorFusionPodDisabled(pod *corev1.Pod) bool {
+	return pod.Labels != nil && pod.Labels[constants.TensorFusionEnabledLabelKey] == constants.FalseStringValue
+}
 func IsTensorFusionWorker(pod *corev1.Pod) bool {
 	return pod.Labels[constants.LabelComponent] == constants.ComponentWorker
 }

--- a/internal/webhook/v1/auto_migration.go
+++ b/internal/webhook/v1/auto_migration.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"github.com/NexusGPU/tensor-fusion/internal/config"
+	"github.com/NexusGPU/tensor-fusion/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -31,6 +32,12 @@ import (
 // ShouldAutoMigrateGPUPod determines if a Pod should be automatically migrated to TensorFusion
 // based on the auto migration configuration.
 func ShouldAutoMigrateGPUPod(ctx context.Context, c client.Client, pod *corev1.Pod) (bool, error) {
+
+	// Skip migration if pod explicitly disables TensorFusion via tensor-fusion.ai/enabled=false label
+	if utils.IsTensorFusionPodDisabled(pod) {
+		return false, nil
+	}
+
 	globalConfig := config.GetGlobalConfig()
 	if globalConfig == nil || globalConfig.AutoMigration == nil {
 		return false, nil


### PR DESCRIPTION
Add utils import and IsTensorFusionPodDisabled check in auto_migration.go
Fix nil pointer in IsTensorFusionPod function
Skip auto migration for pods with tensor-fusion.ai/enabled=false label