### PR TITLE
fix: add validation for zero GPU resource values

### DIFF
--- a/internal/utils/reconcile.go
+++ b/internal/utils/reconcile.go
@@ -261,8 +261,8 @@ var GPUResourceNames = []corev1.ResourceName{
 
 func containsGPUResources(res corev1.ResourceList) bool {
 	for _, gpuResourceName := range GPUResourceNames {
-		_, ok := res[gpuResourceName]
-		if ok {
+		quantity, ok := res[gpuResourceName]
+		if ok && quantity.Sign() > 0 {
 			return true
 		}
 	}

--- a/internal/utils/reconcile_test.go
+++ b/internal/utils/reconcile_test.go
@@ -1,0 +1,274 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/NexusGPU/tensor-fusion/internal/utils"
+)
+
+func TestContainsGPUResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		res      corev1.ResourceList
+		expected bool
+	}{
+		{
+			name:     "empty resource list",
+			res:      corev1.ResourceList{},
+			expected: false,
+		},
+		{
+			name: "nvidia.com/gpu with positive value",
+			res: corev1.ResourceList{
+				corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+			},
+			expected: true,
+		},
+		{
+			name: "nvidia.com/gpu with zero value",
+			res: corev1.ResourceList{
+				corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("0"),
+			},
+			expected: false,
+		},
+		{
+			name: "amd.com/gpu with positive value",
+			res: corev1.ResourceList{
+				corev1.ResourceName("amd.com/gpu"): resource.MustParse("2"),
+			},
+			expected: true,
+		},
+		{
+			name: "amd.com/gpu with zero value",
+			res: corev1.ResourceList{
+				corev1.ResourceName("amd.com/gpu"): resource.MustParse("0"),
+			},
+			expected: false,
+		},
+		{
+			name: "nvidia.com/gpu with negative value (should not happen in practice but test edge case)",
+			res: corev1.ResourceList{
+				corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("-1"),
+			},
+			expected: false,
+		},
+		{
+			name: "non-GPU resource",
+			res: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1"),
+			},
+			expected: false,
+		},
+		{
+			name: "multiple resources including GPU",
+			res: corev1.ResourceList{
+				corev1.ResourceCPU:                    resource.MustParse("1"),
+				corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+			},
+			expected: true,
+		},
+		{
+			name: "multiple resources with GPU set to zero",
+			res: corev1.ResourceList{
+				corev1.ResourceCPU:                    resource.MustParse("1"),
+				corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("0"),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// containsGPUResources is not exported, so we test it through HasGPUResourceRequest
+			// or we can test it directly if we make it exported, but for now let's test via HasGPUResourceRequest
+			pod := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: tt.res,
+							},
+						},
+					},
+				},
+			}
+			result := utils.HasGPUResourceRequest(pod)
+			assert.Equal(t, tt.expected, result, "HasGPUResourceRequest should return %v for %s", tt.expected, tt.name)
+		})
+	}
+}
+
+func TestHasGPUResourceRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "pod with no containers",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with GPU in requests",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod with GPU in limits (and requests is not nil)",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod with GPU set to zero in requests",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("0"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with GPU set to zero in limits",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("0"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with multiple containers, one with GPU",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "container-1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("1"),
+								},
+							},
+						},
+						{
+							Name: "container-2",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod with multiple containers, all with GPU set to zero",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "container-1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("0"),
+								},
+							},
+						},
+						{
+							Name: "container-2",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceName("amd.com/gpu"): resource.MustParse("0"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with AMD GPU",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceName("amd.com/gpu"): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.HasGPUResourceRequest(tt.pod)
+			assert.Equal(t, tt.expected, result, "HasGPUResourceRequest should return %v for %s", tt.expected, tt.name)
+		})
+	}
+}

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -168,6 +168,7 @@ func (m *TensorFusionPodMutator) Handle(ctx context.Context, req admission.Reque
 	}
 	tfInfo.Profile.Qos = calculateQoSLevel(tfInfo.Profile, pool)
 
+	// If tensor-fusion.ai/enabled is set to true, but both tflops-request/limit and gpu-resource are null (or not set), is it still necessary to create a new workload?
 	workload, err := m.createOrUpdateWorkload(ctx, pod, &tfInfo)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("create tf workload: %w", err))


### PR DESCRIPTION
- Update containsGPUResources to check quantity.Sign() > 0 to exclude zero and negative values
- Add comprehensive test cases for GPU resource validation
- Ensure HasGPUResourceRequest correctly handles zero GPU resource values
- Add test coverage for nvidia.com/gpu and amd.com/gpu resources

This prevents false positives when GPU resources are set to 0, ensuring that only valid positive GPU resource requests are detected.