### PR TITLE
fix: add validation for zero GPU resource values

### DIFF
--- a/internal/utils/reconcile.go
+++ b/internal/utils/reconcile.go
@@ -272,8 +272,8 @@ var GPUResourceNames = []corev1.ResourceName{
 
 func containsGPUResources(res corev1.ResourceList) bool {
 	for _, gpuResourceName := range GPUResourceNames {
-		_, ok := res[gpuResourceName]
-		if ok {
+		quantity, ok := res[gpuResourceName]
+		if ok && quantity.Sign() > 0 {
 			return true
 		}
 	}

--- a/internal/utils/reconcile_test.go
+++ b/internal/utils/reconcile_test.go
@@ -1,0 +1,281 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/NexusGPU/tensor-fusion/internal/utils"
+)
+
+var _ = Describe("Reconcile Utils", func() {
+	Describe("HasGPUResourceRequest", func() {
+		It("should return true when pod has nvidia.com/gpu request with positive quantity", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeTrue())
+		})
+
+		It("should return true when pod has amd.com/gpu request with positive quantity", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"amd.com/gpu": resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeTrue())
+		})
+
+		It("should return true when pod has GPU resource in Limits and Requests is not nil", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeTrue())
+		})
+
+		It("should return false when pod has nvidia.com/gpu with zero quantity", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("0"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeFalse())
+		})
+
+		It("should return false when pod has amd.com/gpu with zero quantity", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"amd.com/gpu": resource.MustParse("0"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeFalse())
+		})
+
+		It("should return false when pod has no GPU resources", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeFalse())
+		})
+
+		It("should return false when pod has no resource requirements", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeFalse())
+		})
+
+		It("should return true when multiple containers and one has GPU resource", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container-1",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+							},
+						},
+						{
+							Name: "test-container-2",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeTrue())
+		})
+
+		It("should return true when GPU resource is in both Requests and Limits", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("1"),
+								},
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeTrue())
+		})
+
+		It("should return false when Requests is nil but Limits has zero GPU", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
+								},
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("0"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeFalse())
+		})
+
+		It("should return false when Requests is nil even if Limits has GPU", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(utils.HasGPUResourceRequest(pod)).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
- Update containsGPUResources to check quantity.Sign() > 0 to exclude zero and negative values
- Add comprehensive test cases for GPU resource validation
- Ensure HasGPUResourceRequest correctly handles zero GPU resource values
- Add test coverage for nvidia.com/gpu and amd.com/gpu resources