### PR TITLE
fix: cherry pick c96f2493de4316884992e9bec6d5b329b9df4008 (preemption and multi-GPU scheduling issues)

### DIFF
--- a/internal/gpuallocator/gpuallocator_suite_test.go
+++ b/internal/gpuallocator/gpuallocator_suite_test.go
@@ -198,6 +198,26 @@ var _ = BeforeSuite(func() {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-5",
+				Namespace: "default",
+				Labels: map[string]string{
+					constants.GpuPoolKey:    "test-pool",
+					constants.LabelKeyOwner: "node-1",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-6",
+				Namespace: "default",
+				Labels: map[string]string{
+					constants.GpuPoolKey:    "test-pool",
+					constants.LabelKeyOwner: "node-1",
+				},
+			},
+		},
 	}
 
 	// First create the GPUs without status
@@ -275,6 +295,38 @@ var _ = BeforeSuite(func() {
 				NodeSelector: map[string]string{constants.KubernetesHostNameLabel: "node-3"},
 			},
 		},
+		{
+			name: "gpu-5",
+			status: tfv1.GPUStatus{
+				Phase: tfv1.TensorFusionGPUPhaseRunning,
+				Available: &tfv1.Resource{
+					Tflops: resource.MustParse("100"),
+					Vram:   resource.MustParse("16Gi"),
+				},
+				Capacity: &tfv1.Resource{
+					Tflops: resource.MustParse("100"),
+					Vram:   resource.MustParse("16Gi"),
+				},
+				GPUModel:     "NVIDIA A100",
+				NodeSelector: map[string]string{constants.KubernetesHostNameLabel: "node-1"},
+			},
+		},
+		{
+			name: "gpu-6",
+			status: tfv1.GPUStatus{
+				Phase: tfv1.TensorFusionGPUPhaseRunning,
+				Available: &tfv1.Resource{
+					Tflops: resource.MustParse("100"),
+					Vram:   resource.MustParse("16Gi"),
+				},
+				Capacity: &tfv1.Resource{
+					Tflops: resource.MustParse("100"),
+					Vram:   resource.MustParse("16Gi"),
+				},
+				GPUModel:     "NVIDIA A100",
+				NodeSelector: map[string]string{constants.KubernetesHostNameLabel: "node-1"},
+			},
+		},
 	}
 
 	for _, gs := range gpuStatuses {
@@ -335,10 +387,10 @@ var _ = BeforeSuite(func() {
 			name: "node-1",
 			status: tfv1.GPUNodeStatus{
 				Phase:           tfv1.TensorFusionGPUNodePhaseRunning,
-				TotalTFlops:     resource.MustParse("200"),
-				TotalVRAM:       resource.MustParse("48Gi"),
-				AvailableTFlops: resource.MustParse("180"),
-				AvailableVRAM:   resource.MustParse("48Gi"),
+				TotalTFlops:     resource.MustParse("400"),
+				TotalVRAM:       resource.MustParse("80Gi"),
+				AvailableTFlops: resource.MustParse("380"),
+				AvailableVRAM:   resource.MustParse("80Gi"),
 			},
 		},
 		{

--- a/internal/scheduler/expander/unsched_queue.go
+++ b/internal/scheduler/expander/unsched_queue.go
@@ -59,6 +59,14 @@ func (h *UnscheduledPodHandler) HandleRejectedPod(ctx context.Context, podInfo *
 		return
 	}
 
+	// here if  pod has NominatedNodeName,we should not expand the node,skip
+	// Let Kubernetes scheduler handle the preemption process
+	if pod.Status.NominatedNodeName != "" {
+		h.logger.V(4).Info("Pod has nominated node from preemption, skipping expansion",
+			"pod", klog.KObj(pod), "nominatedNode", pod.Status.NominatedNodeName)
+		return
+	}
+
 	// take snapshot to avoid modify origin Pod info
 	pod = pod.DeepCopy()
 

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -374,9 +374,158 @@ func (s *GPUFit) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, 
 	}
 
 	nodeName := nodeInfo.Node().Name
+
+	// Check if there are higher priority nominated pods waiting for this node's GPU resources
+	// This ensures that low priority pods don't steal GPU resources from pods that have already
+	// won preemption and are waiting for victims to terminate
+	if status := s.checkNominatedPodsGPUReservation(pod, nodeName, filterResult.(*GPUSchedulingStateData)); !status.IsSuccess() {
+		return status
+	}
+
 	if _, ok := filterResult.(*GPUSchedulingStateData).NodeGPUs[nodeName]; !ok {
 		return fwk.NewStatus(fwk.Unschedulable, "GPU not fit")
 	}
+	return fwk.NewStatus(fwk.Success, "")
+}
+
+// checkNominatedPodsGPUReservation checks if there are higher priority TensorFusion pods
+// that have nominated this node and are waiting for GPU resources.
+// If the current pod has lower priority, it should not be scheduled to avoid stealing
+// resources that are essentially "reserved" for the nominated pod.
+func (s *GPUFit) checkNominatedPodsGPUReservation(pod *v1.Pod, nodeName string, schedulingData *GPUSchedulingStateData) *fwk.Status {
+	nominatedPodInfos := s.fh.NominatedPodsForNode(nodeName)
+	if len(nominatedPodInfos) == 0 {
+		return fwk.NewStatus(fwk.Success, "")
+	}
+
+	currentPodPriority := int32(0)
+	if pod.Spec.Priority != nil {
+		currentPodPriority = *pod.Spec.Priority
+	}
+
+	availableGPUs := schedulingData.NodeGPUs[nodeName]
+	if len(availableGPUs) == 0 {
+		return fwk.NewStatus(fwk.Success, "")
+	}
+
+	// Calculate total available GPU resources on this node
+	totalAvailableTflops := resource.Quantity{}
+	totalAvailableVram := resource.Quantity{}
+	for _, gpu := range availableGPUs {
+		if gpu.Status.Available != nil {
+			totalAvailableTflops.Add(gpu.Status.Available.Tflops)
+			totalAvailableVram.Add(gpu.Status.Available.Vram)
+		}
+	}
+
+	// Calculate resources needed by higher priority nominated pods
+	reservedTflops := resource.Quantity{}
+	reservedVram := resource.Quantity{}
+
+	for _, nominatedPodInfo := range nominatedPodInfos {
+		nominatedPod := nominatedPodInfo.GetPod()
+
+		// Skip if it's the same pod
+		if nominatedPod.UID == pod.UID {
+			continue
+		}
+
+		// Only consider TensorFusion worker pods
+		if !utils.IsTensorFusionWorker(nominatedPod) {
+			continue
+		}
+
+		nominatedPodPriority := int32(0)
+		if nominatedPod.Spec.Priority != nil {
+			nominatedPodPriority = *nominatedPod.Spec.Priority
+		}
+
+		// Reserve resources for nominated pods with higher priority
+		// For equal priority: also reserve to give nominated pods precedence (they won preemption)
+		if nominatedPodPriority < currentPodPriority {
+			continue
+		}
+
+		// CRITICAL: If nominated pod has higher priority, ALWAYS block lower priority pods
+		// This prevents preempted pods from restarting and stealing resources
+		if nominatedPodPriority > currentPodPriority {
+			s.logger.Info("Blocking lower priority pod to protect nominated pod's resources",
+				"currentPod", pod.Name,
+				"currentPriority", currentPodPriority,
+				"nominatedPod", nominatedPod.Name,
+				"nominatedPriority", nominatedPodPriority,
+				"node", nodeName)
+		}
+
+		// Get the nominated pod's GPU resource requirements
+		nominatedAllocReq, _, err := s.allocator.ComposeAllocationRequest(nominatedPod)
+		if err != nil {
+			s.logger.V(4).Info("Failed to compose allocation request for nominated pod",
+				"nominatedPod", nominatedPod.Name, "error", err)
+			continue
+		}
+
+		// CRITICAL FIX: For multi-GPU nominated pods with higher priority,
+		// block ALL lower priority pods on this node to prevent partial resource stealing
+		// This prevents the issue where victim pods restart and occupy 1 GPU while
+		// the 2-GPU nominated pod is waiting for both GPUs
+		if nominatedAllocReq.Count > 1 && nominatedPodPriority > currentPodPriority {
+			s.logger.Info("Blocking lower priority pod completely for multi-GPU nominated pod",
+				"currentPod", pod.Name,
+				"currentPriority", currentPodPriority,
+				"nominatedPod", nominatedPod.Name,
+				"nominatedPriority", nominatedPodPriority,
+				"nominatedGPUCount", nominatedAllocReq.Count,
+				"node", nodeName)
+			return fwk.NewStatus(fwk.Unschedulable,
+				fmt.Sprintf("Node reserved for multi-GPU higher priority nominated pod %s (requires %d GPUs)", nominatedPod.Name, nominatedAllocReq.Count))
+		}
+
+		// Add to reserved resources
+		reservedTflops.Add(nominatedAllocReq.Request.Tflops)
+		reservedVram.Add(nominatedAllocReq.Request.Vram)
+
+		s.logger.V(4).Info("Reserving GPU resources for nominated pod",
+			"currentPod", pod.Name,
+			"nominatedPod", nominatedPod.Name,
+			"nominatedPriority", nominatedPodPriority,
+			"currentPriority", currentPodPriority,
+			"reservedTflops", nominatedAllocReq.Request.Tflops.String(),
+			"reservedVram", nominatedAllocReq.Request.Vram.String())
+	}
+
+	// If no resources need to be reserved, allow scheduling
+	if reservedTflops.IsZero() && reservedVram.IsZero() {
+		return fwk.NewStatus(fwk.Success, "")
+	}
+
+	// Check if there are enough resources after reservation
+	remainingTflops := totalAvailableTflops.DeepCopy()
+	remainingVram := totalAvailableVram.DeepCopy()
+	remainingTflops.Sub(reservedTflops)
+	remainingVram.Sub(reservedVram)
+
+	// Get current pod's requirements
+	currentAllocReq, _, err := s.allocator.ComposeAllocationRequest(pod)
+	if err != nil {
+		return fwk.NewStatus(fwk.Error, "failed to compose allocation request: "+err.Error())
+	}
+
+	// Check if remaining resources are sufficient
+	if remainingTflops.Cmp(currentAllocReq.Request.Tflops) < 0 ||
+		remainingVram.Cmp(currentAllocReq.Request.Vram) < 0 {
+		s.logger.Info("GPU resources reserved for higher priority nominated pods",
+			"currentPod", pod.Name,
+			"node", nodeName,
+			"currentPriority", currentPodPriority,
+			"reservedTflops", reservedTflops.String(),
+			"reservedVram", reservedVram.String(),
+			"requiredTflops", currentAllocReq.Request.Tflops.String(),
+			"requiredVram", currentAllocReq.Request.Vram.String())
+		return fwk.NewStatus(fwk.Unschedulable,
+			fmt.Sprintf("GPU resources reserved for higher priority nominated pods on node %s", nodeName))
+	}
+
 	return fwk.NewStatus(fwk.Success, "")
 }
 
@@ -747,6 +896,22 @@ func (s *GPUFit) queueingHint(logger klog.Logger, pod *v1.Pod, oldObj, newObj an
 	// If resource decreased, skip
 	if increaseTflops.Cmp(resource.MustParse("0")) <= 0 && increaseVram.Cmp(resource.MustParse("0")) <= 0 {
 		return fwk.QueueSkip, nil
+	}
+
+	// OPTIMIZATION: For nominated pods (pods that won preemption), immediately requeue
+	// when any GPU resource becomes available on their nominated node.
+	// This significantly reduces the delay after preemption.
+	if pod.Status.NominatedNodeName != "" && newGPU != nil {
+		gpuNodeName := newGPU.Status.NodeSelector[constants.KubernetesHostNameLabel]
+		if gpuNodeName == pod.Status.NominatedNodeName {
+			logger.Info("GPU resource released on nominated node, immediately requeue preempting pod",
+				"pod", klog.KObj(pod),
+				"nominatedNode", pod.Status.NominatedNodeName,
+				"gpu", newGPU.Name,
+				"increaseTflops", increaseTflops.String(),
+				"increaseVram", increaseVram.String())
+			return fwk.Queue, nil
+		}
 	}
 
 	// Compose allocation request for the pod passed in by scheduler framework


### PR DESCRIPTION
 fix: cherry pick(preemption and multi-GPU scheduling issues)
    - gpuallocator: Fix multi-GPU pod preemption scheduling
            Add logic to collect other available GPUs from same node(s) during preemption
            Apply SameNodeFilter for multi-GPU requirements to ensure all GPUs are on same node
            Critical for multi-GPU pods: preemption might release 1 GPU, but node might have other free GPUs that together satisfy the requirement
    - scheduler/expander: Skip expansion for nominated pods
            Add check for pods with NominatedNodeName to avoid triggering node expansion
            Let Kubernetes scheduler handle the preemption process properly
    - scheduler/gpuresources: Implement GPU resource reservation for nominated pods
            Add checkNominatedPodsGPUReservation() to reserve GPU resources for higher priority nominated pods waiting for preemption victims to terminate
            Prevent low priority pods from stealing resources reserved for preemption winners
            Optimize queueingHint to immediately requeue nominated pods when GPU resources are released on their nominated node, significantly reducing post-preemption delay
