### PR TITLE
fix preemption validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= tensorfusion/tensor-fusion-operator:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION ?= 1.31.0
+ENVTEST_K8S_VERSION ?= 1.34.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/internal/gpuallocator/gpuallocator_test.go
+++ b/internal/gpuallocator/gpuallocator_test.go
@@ -783,7 +783,7 @@ var _ = Describe("GPU Allocator", func() {
 			filteredGPUs, _, err := allocator.FilterWithPreempt(smallAllocReq, []*tfv1.AllocRequest{preemptAllocRequest})
 			Expect(err).NotTo(HaveOccurred())
 			// FilterWithPreempt returns all GPUs that satisfy the conditions, not limited to req.Count
-			Expect(len(filteredGPUs)).To(BeNumerically(">=", 1))
+			Expect(filteredGPUs).ToNot(BeEmpty())
 
 			// Deallocate
 			deallocateAndSync(largeGPUs)


### PR DESCRIPTION
- test: fix ginkgo-linter warning in gpuallocator test Replace `Expect(len(filteredGPUs)).To(BeNumerically(">=", 1))` with `Expect(filteredGPUs).ToNot(BeEmpty())` for better readability

- refactor(scheduler): simplify preemption validation logic Remove redundant multi-GPU victim node validation in Filter phase The validation is already handled by CheckQuotaAndFilterSingleNodePreempt which applies SameNodeFilter for multi-GPU requirements

- chore: upgrade ENVTEST_K8S_VERSION from 1.31.0 to 1.34.0