### PR TITLE
fix: remove unused code and  test race condition

### DIFF
--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -101,6 +101,10 @@ var _ = Describe("Pod Controller", func() {
 				Eventually(func() error {
 					return k8sClient.Get(ctx, client.ObjectKeyFromObject(workerPod), &corev1.Pod{})
 				}).Should(Satisfy(errors.IsNotFound))
+
+				// Wait for GPU resources to be fully released
+				// This prevents resource conflicts between sequential tests
+				time.Sleep(1 * time.Second)
 			}
 		})
 

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -807,25 +807,3 @@ func (s *GPUFit) validatePreemption(state fwk.CycleState, pod *v1.Pod, nodeInfo 
 
 	return fwk.NewStatus(fwk.Success, "")
 }
-
-// getVictimNodes returns the set of node names where victim pods are currently scheduled.
-// Used to validate same-node constraints for multi-GPU preemption.
-func (s *GPUFit) getVictimNodes(victims sets.Set[types.NamespacedName]) sets.Set[string] {
-	nodeSet := sets.New[string]()
-
-	for victim := range victims {
-		pod := &v1.Pod{}
-		if err := s.client.Get(s.ctx, victim, pod); err != nil {
-			// If pod not found (already deleted), skip - validation will handle this
-			s.logger.V(5).Info("Failed to get victim pod for node check",
-				"victim", victim.String(), "error", err)
-			continue
-		}
-
-		if pod.Spec.NodeName != "" {
-			nodeSet.Insert(pod.Spec.NodeName)
-		}
-	}
-
-	return nodeSet
-}


### PR DESCRIPTION
- refactor(scheduler): remove unused getVictimNodes function Remove getVictimNodes helper that became unused after simplifying preemption validation logic. Fixes unused function linter warning.

- test(controller): fix GPU resource race condition in pod tests Add explicit wait after pod deletion in AfterEach to ensure GPU resources are fully released before next test starts. Prevents intermittent test failures with 'no gpus available or valid in pool after filtering' error.

Fixes #527