### PR TITLE
fix: support per-container GPU allocation for multi-container pods

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -76,8 +76,14 @@ const (
 	ComputeRequestAnnotation = Domain + "/compute-percent-request"
 	ComputeLimitAnnotation   = Domain + "/compute-percent-limit"
 
-	WorkloadProfileAnnotation = Domain + "/workload-profile"
-	InjectContainerAnnotation = Domain + "/inject-container"
+	WorkloadProfileAnnotation   = Domain + "/workload-profile"
+	InjectContainerAnnotation   = Domain + "/inject-container"
+	ContainerGPUCountAnnotation = Domain + "/container-gpu-count"
+	// ContainerGPUsAnnotation maps container name to GPU IDs for multi-container scenarios
+	// Format: {"containerName1": ["gpu-id1", "gpu-id2"], "containerName2": ["gpu-id3"]}
+	// By default, all containers share the same GPUs (PodLevelResources behavior)
+	// When this annotation exists, each container gets its specific GPU IDs, while percent/vram remain the same
+	ContainerGPUsAnnotation   = Domain + "/container-gpus"
 	IsLocalGPUAnnotation      = Domain + "/is-local-gpu"
 	QoSLevelAnnotation        = Domain + "/qos"
 	EmbeddedWorkerAnnotation  = Domain + "/embedded-worker"

--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -196,6 +196,15 @@ func AppendTFWorkerLabelsAndAnnotationsAfterTemplate(
 		}), ",")
 	}
 	annotations[constants.IsolationModeAnnotation] = string(workload.Spec.Isolation)
+
+	// Pass through container-gpu-count annotation from workload to worker pod
+	// This preserves per-container GPU count information for multi-container scenarios
+	if workload.Annotations != nil {
+		if containerGPUCount, ok := workload.Annotations[constants.ContainerGPUCountAnnotation]; ok && containerGPUCount != "" {
+			annotations[constants.ContainerGPUCountAnnotation] = containerGPUCount
+		}
+	}
+
 	return labels, annotations
 }
 

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -294,6 +294,14 @@ func (m *TensorFusionPodMutator) createOrUpdateWorkload(
 			workload.Annotations[constants.DisableFeaturesAnnotation] = pod.Labels[constants.DisableFeaturesAnnotation]
 		}
 
+		// Pass through container-gpu-count annotation from client pod to workload
+		// This preserves per-container GPU count information for multi-container scenarios
+		if pod.Annotations != nil {
+			if containerGPUCount, ok := pod.Annotations[constants.ContainerGPUCountAnnotation]; ok && containerGPUCount != "" {
+				workload.Annotations[constants.ContainerGPUCountAnnotation] = containerGPUCount
+			}
+		}
+
 		if tfInfo.PodControllerRef != nil {
 			workload.OwnerReferences = []metav1.OwnerReference{*tfInfo.PodControllerRef}
 		}


### PR DESCRIPTION
This commit implements per-container GPU allocation to correctly handle pods with multiple containers requesting GPUs.

**Problem:**
- Webhook only counted GPU requests from the first container, causing incorrect total GPU count for multi-container pods
- After webhook removes native GPU limits, scheduler couldn't determine which container needs how many GPUs
- All containers shared the same GPU IDs regardless of individual needs

**Solution:**

1. **Webhook (tf_parser.go)**
   - Fix GPU count accumulation: iterate all containers and sum GPU requests
   - Store per-container GPU requirements in JSON annotation `tensor-fusion.ai/container-gpu-count: {"container1":2,"container2":1}`
   - Add ParseContainerGPUCounts() helper function

2. **Scheduler (gpuresources.go)**
   - Implement per-container GPU allocation in PostBind phase
   - Add allocateGPUsToContainers() to distribute GPU IDs based on container requirements
   - Store allocation result in annotation `tensor-fusion.ai/container-gpus: {"container1":["gpu-1","gpu-2"],...}`
   - Deterministic allocation using sorted container names

3. **Propagation (pod_webhook.go, compose.go)**
   - Propagate container-gpu-count annotation from Pod -> Workload -> Worker
   - Ensure allocation info reaches the final scheduled worker pod

4. **Constants (constants.go)**
   - Add ContainerGPUCountAnnotation for per-container requirements
   - Add ContainerGPUsAnnotation for per-container GPU ID assignments

5. **Tests**
   - Add webhook tests for multi-container GPU count accumulation
   - Add scheduler tests for per-container GPU allocation
   - Verify JSON format and correct GPU distribution

**Behavior:**
- By default: all containers share same GPUs (existing PodLevelResources)
- With annotation: each container gets specific GPU IDs
- VRAM/compute-percent remain shared across all container GPUs

Fixes multi-container GPU scheduling and allocation.