### PR TITLE
fix: rename VGPU functions to Accel for consistency across platforms

### DIFF
--- a/pkg/hypervisor/device/accelerator.go
+++ b/pkg/hypervisor/device/accelerator.go
@@ -225,8 +225,8 @@ type SnapshotContext struct {
 var (
 	libHandle uintptr
 	// DeviceInfo APIs
-	vgpuInit              func() Result
-	vgpuShutdown          func() Result
+	accelInit              func() Result
+	accelShutdown          func() Result
 	getDeviceCount        func(*uintptr) Result
 	getAllDevices         func(*ExtendedDeviceInfo, uintptr, *uintptr) Result
 	getAllDevicesTopology func(*ExtendedDeviceTopology) Result
@@ -286,7 +286,7 @@ func (a *AcceleratorInterface) Close() error {
 					_ = r // ignore recovery value
 				}
 			}()
-			vgpuShutdown()
+			accelShutdown()
 			if registerLogCallback != nil {
 				registerLogCallback(0)
 			}

--- a/pkg/hypervisor/device/accelerator_unix.go
+++ b/pkg/hypervisor/device/accelerator_unix.go
@@ -40,34 +40,34 @@ func (a *AcceleratorInterface) Load() error {
 	libHandle = handle
 
 	// Register all required functions - names must match C header exactly
-	purego.RegisterLibFunc(&vgpuInit, handle, "VGPUInit")
-	purego.RegisterLibFunc(&vgpuShutdown, handle, "VGPUShutdown")
-	purego.RegisterLibFunc(&getDeviceCount, handle, "GetDeviceCount")
-	purego.RegisterLibFunc(&getAllDevices, handle, "GetAllDevices")
-	purego.RegisterLibFunc(&getAllDevicesTopology, handle, "GetAllDevicesTopology")
-	purego.RegisterLibFunc(&assignPartition, handle, "AssignPartition")
-	purego.RegisterLibFunc(&removePartition, handle, "RemovePartition")
-	purego.RegisterLibFunc(&setMemHardLimit, handle, "SetMemHardLimit")
-	purego.RegisterLibFunc(&setComputeUnitHardLimit, handle, "SetComputeUnitHardLimit")
-	purego.RegisterLibFunc(&snapshot, handle, "Snapshot")
-	purego.RegisterLibFunc(&resume, handle, "Resume")
-	purego.RegisterLibFunc(&getProcessInformation, handle, "GetProcessInformation")
-	purego.RegisterLibFunc(&getDeviceMetrics, handle, "GetDeviceMetrics")
-	purego.RegisterLibFunc(&getVendorMountLibs, handle, "GetVendorMountLibs")
+	purego.RegisterLibFunc(&accelInit, handle, "AccelInit")
+	purego.RegisterLibFunc(&accelShutdown, handle, "AccelShutdown")
+	purego.RegisterLibFunc(&getDeviceCount, handle, "AccelGetDeviceCount")
+	purego.RegisterLibFunc(&getAllDevices, handle, "AccelGetAllDevices")
+	purego.RegisterLibFunc(&getAllDevicesTopology, handle, "AccelGetAllDevicesTopology")
+	purego.RegisterLibFunc(&assignPartition, handle, "AccelAssignPartition")
+	purego.RegisterLibFunc(&removePartition, handle, "AccelRemovePartition")
+	purego.RegisterLibFunc(&setMemHardLimit, handle, "AccelSetMemHardLimit")
+	purego.RegisterLibFunc(&setComputeUnitHardLimit, handle, "AccelSetComputeUnitHardLimit")
+	purego.RegisterLibFunc(&snapshot, handle, "AccelSnapshot")
+	purego.RegisterLibFunc(&resume, handle, "AccelResume")
+	purego.RegisterLibFunc(&getProcessInformation, handle, "AccelGetProcessInformation")
+	purego.RegisterLibFunc(&getDeviceMetrics, handle, "AccelGetDeviceMetrics")
+	purego.RegisterLibFunc(&getVendorMountLibs, handle, "AccelGetVendorMountLibs")
 
 	// Register log callback only on non-macOS platforms
 	// purego callback has issues on macOS ARM64, causing bus errors when C code calls back into Go
 	if runtime.GOOS != "darwin" {
-		purego.RegisterLibFunc(&registerLogCallback, handle, "RegisterLogCallback")
+		purego.RegisterLibFunc(&registerLogCallback, handle, "AccelRegisterLogCallback")
 		callback := purego.NewCallback(goLogCallback)
 		if result := registerLogCallback(callback); result != ResultSuccess {
 			klog.Warningf("Failed to register log callback: %d", result)
 		}
 	}
 
-	result := vgpuInit()
+	result := accelInit()
 	if result != ResultSuccess {
-		return fmt.Errorf("failed to initialize VGPU: %d", result)
+		return fmt.Errorf("failed to initialize accelerator: %d", result)
 	}
 
 	a.loaded = true

--- a/pkg/hypervisor/device/accelerator_windows.go
+++ b/pkg/hypervisor/device/accelerator_windows.go
@@ -39,27 +39,27 @@ func (a *AcceleratorInterface) Load() error {
 	libHandle = uintptr(dll.Handle)
 
 	// purego.RegisterLibFunc works with Windows DLL handles - names must match C header exactly
-	purego.RegisterLibFunc(&vgpuInit, libHandle, "VGPUInit")
-	purego.RegisterLibFunc(&vgpuShutdown, libHandle, "VGPUShutdown")
-	purego.RegisterLibFunc(&getDeviceCount, libHandle, "GetDeviceCount")
-	purego.RegisterLibFunc(&getAllDevices, libHandle, "GetAllDevices")
-	purego.RegisterLibFunc(&getAllDevicesTopology, libHandle, "GetAllDevicesTopology")
-	purego.RegisterLibFunc(&assignPartition, libHandle, "AssignPartition")
-	purego.RegisterLibFunc(&removePartition, libHandle, "RemovePartition")
-	purego.RegisterLibFunc(&setMemHardLimit, libHandle, "SetMemHardLimit")
-	purego.RegisterLibFunc(&setComputeUnitHardLimit, libHandle, "SetComputeUnitHardLimit")
-	purego.RegisterLibFunc(&snapshot, libHandle, "Snapshot")
-	purego.RegisterLibFunc(&resume, libHandle, "Resume")
-	purego.RegisterLibFunc(&getProcessInformation, libHandle, "GetProcessInformation")
-	purego.RegisterLibFunc(&getDeviceMetrics, libHandle, "GetDeviceMetrics")
-	purego.RegisterLibFunc(&getVendorMountLibs, libHandle, "GetVendorMountLibs")
+	purego.RegisterLibFunc(&accelInit, libHandle, "AccelInit")
+	purego.RegisterLibFunc(&accelShutdown, libHandle, "AccelShutdown")
+	purego.RegisterLibFunc(&getDeviceCount, libHandle, "AccelGetDeviceCount")
+	purego.RegisterLibFunc(&getAllDevices, libHandle, "AccelGetAllDevices")
+	purego.RegisterLibFunc(&getAllDevicesTopology, libHandle, "AccelGetAllDevicesTopology")
+	purego.RegisterLibFunc(&assignPartition, libHandle, "AccelAssignPartition")
+	purego.RegisterLibFunc(&removePartition, libHandle, "AccelRemovePartition")
+	purego.RegisterLibFunc(&setMemHardLimit, libHandle, "AccelSetMemHardLimit")
+	purego.RegisterLibFunc(&setComputeUnitHardLimit, libHandle, "AccelSetComputeUnitHardLimit")
+	purego.RegisterLibFunc(&snapshot, libHandle, "AccelSnapshot")
+	purego.RegisterLibFunc(&resume, libHandle, "AccelResume")
+	purego.RegisterLibFunc(&getProcessInformation, libHandle, "AccelGetProcessInformation")
+	purego.RegisterLibFunc(&getDeviceMetrics, libHandle, "AccelGetDeviceMetrics")
+	purego.RegisterLibFunc(&getVendorMountLibs, libHandle, "AccelGetVendorMountLibs")
 
 	// Note: Log callback is not registered on Windows due to calling convention differences
 	// Windows uses stdcall/cdecl while Unix uses System V ABI
 
-	result := vgpuInit()
+	result := accelInit()
 	if result != ResultSuccess {
-		return fmt.Errorf("failed to initialize VGPU: %d", result)
+		return fmt.Errorf("failed to initialize accelerator: %d", result)
 	}
 
 	a.loaded = true

--- a/provider/example/accelerator.c
+++ b/provider/example/accelerator.c
@@ -81,7 +81,7 @@ static void* limiterThreadFunc(void* arg __attribute__((unused))) {
     size_t deviceCount = 0;
     char deviceUUID[64] = {0};
     
-    if (GetAllDevices(devices, 4, &deviceCount) != ACCEL_SUCCESS || deviceCount == 0) {
+    if (AccelGetAllDevices(devices, 4, &deviceCount) != ACCEL_SUCCESS || deviceCount == 0) {
         free(devices);
         return NULL;
     }
@@ -218,17 +218,17 @@ Result AutoResume(const char* workerId, const char* deviceUUID, const char* reso
 // Example Implementation - DeviceInfo APIs
 // ============================================================================
 
-AccelResult VGPUInit(void) {
-    logMessage("INFO", "VGPUInit called from provider example");
+AccelResult AccelInit(void) {
+    logMessage("INFO", "AccelInit called from provider example");
     return ACCEL_SUCCESS;
 }
 
-AccelResult VGPUShutdown(void) {
-    logMessage("INFO", "VGPUShutdown called from provider example");
+AccelResult AccelShutdown(void) {
+    logMessage("INFO", "AccelShutdown called from provider example");
     return ACCEL_SUCCESS;
 }
 
-AccelResult GetDeviceCount(size_t* deviceCount) {
+AccelResult AccelGetDeviceCount(size_t* deviceCount) {
     if (!deviceCount) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
@@ -324,7 +324,7 @@ static void initDeviceInfo(ExtendedDeviceInfo* info, int32_t deviceIndex) {
     info->virtualizationCapabilities.maxWorkersPerDevice = 16;
 }
 
-AccelResult GetAllDevices(ExtendedDeviceInfo* devices, size_t maxCount, size_t* deviceCount) {
+AccelResult AccelGetAllDevices(ExtendedDeviceInfo* devices, size_t maxCount, size_t* deviceCount) {
     if (!devices || !deviceCount || maxCount == 0) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
@@ -340,18 +340,18 @@ AccelResult GetAllDevices(ExtendedDeviceInfo* devices, size_t maxCount, size_t* 
     for (size_t i = 0; i < actualCount; i++) {
         initDeviceInfo(&devices[i], (int32_t)i);
     }
-    logMessage("INFO", "GetAllDevices called from provider example");
+    logMessage("INFO", "AccelGetAllDevices called from provider example");
     return ACCEL_SUCCESS;
 }
 
-AccelResult GetAllDevicesTopology(ExtendedDeviceTopology* topology) {
+AccelResult AccelGetAllDevicesTopology(ExtendedDeviceTopology* topology) {
     if (!topology) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
 
     // Get device count first
     size_t deviceCount = 0;
-    if (GetDeviceCount(&deviceCount) != ACCEL_SUCCESS || deviceCount == 0) {
+    if (AccelGetDeviceCount(&deviceCount) != ACCEL_SUCCESS || deviceCount == 0) {
         topology->deviceCount = 0;
         return ACCEL_ERROR_INTERNAL;
     }
@@ -364,7 +364,7 @@ AccelResult GetAllDevicesTopology(ExtendedDeviceTopology* topology) {
     // Get all devices to populate topology
     ExtendedDeviceInfo devices[MAX_TOPOLOGY_DEVICES];
     size_t actualDeviceCount = 0;
-    if (GetAllDevices(devices, deviceCount, &actualDeviceCount) != ACCEL_SUCCESS) {
+    if (AccelGetAllDevices(devices, deviceCount, &actualDeviceCount) != ACCEL_SUCCESS) {
         topology->deviceCount = 0;
         return ACCEL_ERROR_INTERNAL;
     }
@@ -396,7 +396,7 @@ AccelResult GetAllDevicesTopology(ExtendedDeviceTopology* topology) {
         }
     }
 
-    logMessage("INFO", "GetAllDevicesTopology called from provider example");
+    logMessage("INFO", "AccelGetAllDevicesTopology called from provider example");
     return ACCEL_SUCCESS;
 }
 
@@ -407,7 +407,7 @@ AccelResult GetAllDevicesTopology(ExtendedDeviceTopology* topology) {
 // Counter for generating unique partition IDs
 static int partitionCounter = 0;
 
-AccelResult AssignPartition(const char* templateId, const char* deviceUUID, PartitionResult* partitionResult) {
+AccelResult AccelAssignPartition(const char* templateId, const char* deviceUUID, PartitionResult* partitionResult) {
     if (!templateId || !deviceUUID || !partitionResult) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
@@ -427,17 +427,17 @@ AccelResult AssignPartition(const char* templateId, const char* deviceUUID, Part
     snprintf(partitionResult->envVars[1], sizeof(partitionResult->envVars[1]), "GPU_UUID=%s", deviceUUID);
     snprintf(partitionResult->envVars[2], sizeof(partitionResult->envVars[2]), "PARTITION_TEMPLATE=%s", templateId);
 
-    logMessage("INFO", "AssignPartition called from provider example");
+    logMessage("INFO", "AccelAssignPartition called from provider example");
     return ACCEL_SUCCESS;
 }
 
-AccelResult RemovePartition(const char* templateId, const char* deviceUUID) {
+AccelResult AccelRemovePartition(const char* templateId, const char* deviceUUID) {
     if (!templateId || !deviceUUID) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
 
     // Example: always succeed
-    logMessage("INFO", "RemovePartition called from provider example");
+    logMessage("INFO", "AccelRemovePartition called from provider example");
     return ACCEL_SUCCESS;
 }
 
@@ -445,23 +445,23 @@ AccelResult RemovePartition(const char* templateId, const char* deviceUUID) {
 // Example Implementation - Virtualization APIs - Hard Isolation
 // ============================================================================
 
-AccelResult SetMemHardLimit(const char* deviceUUID, uint64_t memoryLimitBytes) {
+AccelResult AccelSetMemHardLimit(const char* deviceUUID, uint64_t memoryLimitBytes) {
     if (!deviceUUID || memoryLimitBytes == 0) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
 
     // Example: always succeed
-    logMessage("INFO", "SetMemHardLimit called from provider example");
+    logMessage("INFO", "AccelSetMemHardLimit called from provider example");
     return ACCEL_SUCCESS;
 }
 
-AccelResult SetComputeUnitHardLimit(const char* deviceUUID, uint32_t computeUnitLimit) {
+AccelResult AccelSetComputeUnitHardLimit(const char* deviceUUID, uint32_t computeUnitLimit) {
     if (!deviceUUID || computeUnitLimit == 0 || computeUnitLimit > 100) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
 
     // Example: always succeed
-    logMessage("INFO", "SetComputeUnitHardLimit called from provider example");
+    logMessage("INFO", "AccelSetComputeUnitHardLimit called from provider example");
     return ACCEL_SUCCESS;
 }
 
@@ -469,7 +469,7 @@ AccelResult SetComputeUnitHardLimit(const char* deviceUUID, uint32_t computeUnit
 // Example Implementation - Virtualization APIs - Device Snapshot/Migration
 // ============================================================================
 
-AccelResult Snapshot(SnapshotContext* context) {
+AccelResult AccelSnapshot(SnapshotContext* context) {
     if (!context) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
@@ -488,10 +488,10 @@ AccelResult Snapshot(SnapshotContext* context) {
                 return ACCEL_ERROR_NOT_FOUND;
             }
         }
-        logMessage("INFO", "Snapshot (process-level) called from provider example");
+        logMessage("INFO", "AccelSnapshot (process-level) called from provider example");
     } else if (context->deviceUUID != NULL) {
         // Device-level snapshot
-        logMessage("INFO", "Snapshot (device-level) called from provider example");
+        logMessage("INFO", "AccelSnapshot (device-level) called from provider example");
     } else {
         return ACCEL_ERROR_INVALID_PARAM;
     }
@@ -500,7 +500,7 @@ AccelResult Snapshot(SnapshotContext* context) {
     return ACCEL_SUCCESS;
 }
 
-AccelResult Resume(SnapshotContext* context) {
+AccelResult AccelResume(SnapshotContext* context) {
     if (!context) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
@@ -511,10 +511,10 @@ AccelResult Resume(SnapshotContext* context) {
         if (context->processCount > MAX_PROCESSES) {
             return ACCEL_ERROR_INVALID_PARAM;
         }
-        logMessage("INFO", "Resume (process-level) called from provider example");
+        logMessage("INFO", "AccelResume (process-level) called from provider example");
     } else if (context->deviceUUID != NULL) {
         // Device-level resume
-        logMessage("INFO", "Resume (device-level) called from provider example");
+        logMessage("INFO", "AccelResume (device-level) called from provider example");
     } else {
         return ACCEL_ERROR_INVALID_PARAM;
     }
@@ -527,7 +527,7 @@ AccelResult Resume(SnapshotContext* context) {
 // Example Implementation - Metrics APIs
 // ============================================================================
 
-AccelResult GetProcessInformation(
+AccelResult AccelGetProcessInformation(
     ProcessInformation* processInfos,
     size_t maxCount,
     size_t* processInfoCount
@@ -559,7 +559,7 @@ AccelResult GetProcessInformation(
     uint64_t totalMemoryBytes = 16ULL * 1024 * 1024 * 1024; // Default 16GB
     uint64_t totalCUs = 108; // Default 108 CUs
     
-    if (GetAllDevices(devices, 256, &deviceCount) == ACCEL_SUCCESS && deviceCount > 0) {
+    if (AccelGetAllDevices(devices, 256, &deviceCount) == ACCEL_SUCCESS && deviceCount > 0) {
         totalMemoryBytes = devices[0].basic.totalMemoryBytes;
         totalCUs = devices[0].basic.totalComputeUnits;
     }
@@ -599,11 +599,11 @@ AccelResult GetProcessInformation(
     }
 
     *processInfoCount = actualCount;
-    logMessage("INFO", "GetProcessInformation called from provider example (AMD SMI style)");
+    logMessage("INFO", "AccelGetProcessInformation called from provider example (AMD SMI style)");
     return ACCEL_SUCCESS;
 }
 
-AccelResult GetDeviceMetrics(
+AccelResult AccelGetDeviceMetrics(
     const char** deviceUUIDs,
     size_t deviceCount,
     DeviceMetrics* metrics
@@ -692,20 +692,20 @@ AccelResult GetDeviceMetrics(
         dm->extraMetricsCount = extraCount;
     }
 
-    logMessage("INFO", "GetDeviceMetrics called from provider example");
+    logMessage("INFO", "AccelGetDeviceMetrics called from provider example");
     return ACCEL_SUCCESS;
 }
 
-AccelResult GetVendorMountLibs(MountPath* mounts, size_t maxCount, size_t* mountCount) {
+AccelResult AccelGetVendorMountLibs(MountPath* mounts, size_t maxCount, size_t* mountCount) {
     if (!mounts || maxCount == 0 || !mountCount) {
         return ACCEL_ERROR_INVALID_PARAM;
     }
     *mountCount = 0;
-    logMessage("INFO", "GetVendorMountLibs called from provider example");
+    logMessage("INFO", "AccelGetVendorMountLibs called from provider example");
     return ACCEL_SUCCESS;
 }
 
-AccelResult RegisterLogCallback(LogCallbackFunc callback) {
+AccelResult AccelRegisterLogCallback(LogCallbackFunc callback) {
     Log = callback;
     return ACCEL_SUCCESS;
 }

--- a/provider/test/test_accelerator.c
+++ b/provider/test/test_accelerator.c
@@ -37,44 +37,44 @@ static int tests_failed = 0;
         } \
     } while (0)
 
-// Test VGPUInit
-void test_virtualGPUInit() {
-    printf("\n=== Testing VGPUInit ===\n");
-    
-    AccelResult result = VGPUInit();
-    TEST_ASSERT(result == ACCEL_SUCCESS, "VGPUInit returns success");
-    
-    result = VGPUShutdown();
-    TEST_ASSERT(result == ACCEL_SUCCESS, "VGPUShutdown returns success");
+// Test AccelInit
+void test_accelInit() {
+    printf("\n=== Testing AccelInit ===\n");
+
+    AccelResult result = AccelInit();
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelInit returns success");
+
+    result = AccelShutdown();
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelShutdown returns success");
 }
 
-// Test GetDeviceCount
+// Test AccelGetDeviceCount
 void test_getDeviceCount() {
-    printf("\n=== Testing GetDeviceCount ===\n");
-    
+    printf("\n=== Testing AccelGetDeviceCount ===\n");
+
     size_t deviceCount = 0;
-    AccelResult result = GetDeviceCount(&deviceCount);
-    
-    TEST_ASSERT(result == ACCEL_SUCCESS, "GetDeviceCount returns success");
+    AccelResult result = AccelGetDeviceCount(&deviceCount);
+
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelGetDeviceCount returns success");
     TEST_ASSERT(deviceCount > 0, "Device count > 0");
-    
+
     // Test NULL parameter
-    result = GetDeviceCount(NULL);
+    result = AccelGetDeviceCount(NULL);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL parameter returns error");
 }
 
-// Test GetAllDevices
+// Test AccelGetAllDevices
 void test_getAllDevices() {
-    printf("\n=== Testing GetAllDevices ===\n");
-    
+    printf("\n=== Testing AccelGetAllDevices ===\n");
+
     ExtendedDeviceInfo devices[256];
     size_t deviceCount = 0;
-    
-    AccelResult result = GetAllDevices(devices, 256, &deviceCount);
-    
-    TEST_ASSERT(result == ACCEL_SUCCESS, "GetAllDevices returns success");
+
+    AccelResult result = AccelGetAllDevices(devices, 256, &deviceCount);
+
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelGetAllDevices returns success");
     TEST_ASSERT(deviceCount > 0, "Device count > 0");
-    
+
     if (deviceCount > 0) {
         TEST_ASSERT(strlen(devices[0].basic.uuid) > 0, "Device UUID is not empty");
         TEST_ASSERT(strlen(devices[0].basic.vendor) > 0, "Vendor is not empty");
@@ -84,187 +84,187 @@ void test_getAllDevices() {
         TEST_ASSERT(devices[0].basic.maxTflops > 0, "Max TFLOPS > 0");
         TEST_ASSERT(devices[0].virtualizationCapabilities.maxPartitions > 0, "Max partitions > 0");
     }
-    
+
     // Test invalid parameters
-    result = GetAllDevices(NULL, 256, &deviceCount);
+    result = AccelGetAllDevices(NULL, 256, &deviceCount);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL devices returns error");
-    
-    result = GetAllDevices(devices, 0, &deviceCount);
+
+    result = AccelGetAllDevices(devices, 0, &deviceCount);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "Zero maxCount returns error");
 }
 
-// Test GetAllDevicesTopology
+// Test AccelGetAllDevicesTopology
 void test_getDeviceTopology() {
-    printf("\n=== Testing GetAllDevicesTopology ===\n");
-    
+    printf("\n=== Testing AccelGetAllDevicesTopology ===\n");
+
     ExtendedDeviceTopology topology;
-    
-    AccelResult result = GetAllDevicesTopology(&topology);
-    
-    TEST_ASSERT(result == ACCEL_SUCCESS, "GetAllDevicesTopology returns success");
+
+    AccelResult result = AccelGetAllDevicesTopology(&topology);
+
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelGetAllDevicesTopology returns success");
     TEST_ASSERT(topology.deviceCount > 0, "Device count > 0");
-    
+
     if (topology.deviceCount > 0) {
         TEST_ASSERT(strlen(topology.devices[0].deviceUUID) > 0, "First device has UUID");
     }
-    
+
     // Test invalid parameters
-    result = GetAllDevicesTopology(NULL);
+    result = AccelGetAllDevicesTopology(NULL);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL topology returns error");
 }
 
-// Test AssignPartition
+// Test AccelAssignPartition
 void test_assignPartition() {
-    printf("\n=== Testing AssignPartition ===\n");
-    
+    printf("\n=== Testing AccelAssignPartition ===\n");
+
     PartitionResult partitionResult;
     memset(&partitionResult, 0, sizeof(partitionResult));
-    
-    AccelResult result = AssignPartition("mig-1g.7gb", "stub-device-0", &partitionResult);
-    
-    TEST_ASSERT(result == ACCEL_SUCCESS, "AssignPartition returns success");
+
+    AccelResult result = AccelAssignPartition("mig-1g.7gb", "stub-device-0", &partitionResult);
+
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelAssignPartition returns success");
     TEST_ASSERT(strlen(partitionResult.deviceUUID) > 0, "Device UUID is set");
-    TEST_ASSERT(partitionResult.type == PARTITION_TYPE_ENVIRONMENT_VARIABLE || 
+    TEST_ASSERT(partitionResult.type == PARTITION_TYPE_ENVIRONMENT_VARIABLE ||
                 partitionResult.type == PARTITION_TYPE_DEVICE_NODE, "Partition type is valid");
-    
+
     // Test invalid input
-    result = AssignPartition(NULL, "stub-device-0", &partitionResult);
+    result = AccelAssignPartition(NULL, "stub-device-0", &partitionResult);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL templateId returns error");
-    
-    result = AssignPartition("mig-1g.7gb", NULL, &partitionResult);
+
+    result = AccelAssignPartition("mig-1g.7gb", NULL, &partitionResult);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL deviceUUID returns error");
-    
-    result = AssignPartition("mig-1g.7gb", "stub-device-0", NULL);
+
+    result = AccelAssignPartition("mig-1g.7gb", "stub-device-0", NULL);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL partitionResult returns error");
 }
 
-// Test RemovePartition
+// Test AccelRemovePartition
 void test_removePartition() {
-    printf("\n=== Testing RemovePartition ===\n");
-    
-    AccelResult result = RemovePartition("mig-1g.7gb", "stub-device-0");
-    TEST_ASSERT(result == ACCEL_SUCCESS, "RemovePartition returns success");
-    
-    result = RemovePartition(NULL, "stub-device-0");
+    printf("\n=== Testing AccelRemovePartition ===\n");
+
+    AccelResult result = AccelRemovePartition("mig-1g.7gb", "stub-device-0");
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelRemovePartition returns success");
+
+    result = AccelRemovePartition(NULL, "stub-device-0");
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL templateId returns error");
-    
-    result = RemovePartition("mig-1g.7gb", NULL);
+
+    result = AccelRemovePartition("mig-1g.7gb", NULL);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL deviceUUID returns error");
 }
 
-// Test SetMemHardLimit
+// Test AccelSetMemHardLimit
 void test_setMemHardLimit() {
-    printf("\n=== Testing SetMemHardLimit ===\n");
-    
-    AccelResult result = SetMemHardLimit("stub-device-0", 4ULL * 1024 * 1024 * 1024);
-    TEST_ASSERT(result == ACCEL_SUCCESS, "SetMemHardLimit returns success");
-    
-    result = SetMemHardLimit(NULL, 4ULL * 1024 * 1024 * 1024);
+    printf("\n=== Testing AccelSetMemHardLimit ===\n");
+
+    AccelResult result = AccelSetMemHardLimit("stub-device-0", 4ULL * 1024 * 1024 * 1024);
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelSetMemHardLimit returns success");
+
+    result = AccelSetMemHardLimit(NULL, 4ULL * 1024 * 1024 * 1024);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL deviceUUID returns error");
-    
-    result = SetMemHardLimit("stub-device-0", 0);
+
+    result = AccelSetMemHardLimit("stub-device-0", 0);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "Zero memory limit returns error");
 }
 
-// Test SetComputeUnitHardLimit
+// Test AccelSetComputeUnitHardLimit
 void test_setComputeUnitHardLimit() {
-    printf("\n=== Testing SetComputeUnitHardLimit ===\n");
-    
-    AccelResult result = SetComputeUnitHardLimit("stub-device-0", 50);
-    TEST_ASSERT(result == ACCEL_SUCCESS, "SetComputeUnitHardLimit returns success");
-    
-    result = SetComputeUnitHardLimit("stub-device-0", 150);
+    printf("\n=== Testing AccelSetComputeUnitHardLimit ===\n");
+
+    AccelResult result = AccelSetComputeUnitHardLimit("stub-device-0", 50);
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelSetComputeUnitHardLimit returns success");
+
+    result = AccelSetComputeUnitHardLimit("stub-device-0", 150);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "Invalid limit > 100 returns error");
-    
-    result = SetComputeUnitHardLimit(NULL, 50);
+
+    result = AccelSetComputeUnitHardLimit(NULL, 50);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL deviceUUID returns error");
-    
-    result = SetComputeUnitHardLimit("stub-device-0", 0);
+
+    result = AccelSetComputeUnitHardLimit("stub-device-0", 0);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "Zero limit returns error");
 }
 
-// Test GetProcessInformation (combines compute and memory utilization)
+// Test AccelGetProcessInformation (combines compute and memory utilization)
 void test_getProcessInformation() {
-    printf("\n=== Testing GetProcessInformation ===\n");
-    
+    printf("\n=== Testing AccelGetProcessInformation ===\n");
+
     ProcessInformation processInfos[256];
     size_t processInfoCount = 0;
-    
-    AccelResult result = GetProcessInformation(processInfos, 256, &processInfoCount);
-    
-    TEST_ASSERT(result == ACCEL_SUCCESS, "GetProcessInformation returns success");
-    
+
+    AccelResult result = AccelGetProcessInformation(processInfos, 256, &processInfoCount);
+
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelGetProcessInformation returns success");
+
     if (processInfoCount > 0) {
         // Test compute utilization fields
-        TEST_ASSERT(processInfos[0].computeUtilizationPercent >= 0 && 
-                   processInfos[0].computeUtilizationPercent <= 100, 
+        TEST_ASSERT(processInfos[0].computeUtilizationPercent >= 0 &&
+                   processInfos[0].computeUtilizationPercent <= 100,
                    "Compute utilization percent in valid range");
         TEST_ASSERT(processInfos[0].activeSMs <= processInfos[0].totalSMs,
                    "Active SMs <= Total SMs");
-        
+
         // Test memory utilization fields
-        TEST_ASSERT(processInfos[0].memoryUtilizationPercent >= 0 && 
+        TEST_ASSERT(processInfos[0].memoryUtilizationPercent >= 0 &&
                    processInfos[0].memoryUtilizationPercent <= 100,
                    "Memory utilization percent in valid range");
     }
-    
+
     // Test invalid parameters
-    result = GetProcessInformation(NULL, 256, &processInfoCount);
+    result = AccelGetProcessInformation(NULL, 256, &processInfoCount);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL processInfos returns error");
-    
-    result = GetProcessInformation(processInfos, 0, &processInfoCount);
+
+    result = AccelGetProcessInformation(processInfos, 0, &processInfoCount);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "Zero maxCount returns error");
 }
 
-// Test GetDeviceMetrics
+// Test AccelGetDeviceMetrics
 void test_getDeviceMetrics() {
-    printf("\n=== Testing GetDeviceMetrics ===\n");
-    
+    printf("\n=== Testing AccelGetDeviceMetrics ===\n");
+
     const char* deviceUUIDs[] = {"stub-device-0"};
     DeviceMetrics metrics[1];
-    
-    AccelResult result = GetDeviceMetrics(deviceUUIDs, 1, metrics);
-    
-    TEST_ASSERT(result == ACCEL_SUCCESS, "GetDeviceMetrics returns success");
+
+    AccelResult result = AccelGetDeviceMetrics(deviceUUIDs, 1, metrics);
+
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelGetDeviceMetrics returns success");
     TEST_ASSERT(strlen(metrics[0].deviceUUID) > 0, "Device UUID is not empty");
     TEST_ASSERT(metrics[0].powerUsageWatts >= 0, "Power usage >= 0");
     TEST_ASSERT(metrics[0].temperatureCelsius >= 0, "Temperature >= 0");
-    
+
     // Test invalid parameters
-    result = GetDeviceMetrics(NULL, 1, metrics);
+    result = AccelGetDeviceMetrics(NULL, 1, metrics);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL deviceUUIDs returns error");
-    
-    result = GetDeviceMetrics(deviceUUIDs, 0, metrics);
+
+    result = AccelGetDeviceMetrics(deviceUUIDs, 0, metrics);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "Zero deviceCount returns error");
 }
 
-// Test GetVendorMountLibs
+// Test AccelGetVendorMountLibs
 void test_getVendorMountLibs() {
-    printf("\n=== Testing GetVendorMountLibs ===\n");
-    
+    printf("\n=== Testing AccelGetVendorMountLibs ===\n");
+
     MountPath mounts[64];
     size_t mountCount = 0;
-    
-    AccelResult result = GetVendorMountLibs(mounts, 64, &mountCount);
-    
-    TEST_ASSERT(result == ACCEL_SUCCESS, "GetVendorMountLibs returns success");
+
+    AccelResult result = AccelGetVendorMountLibs(mounts, 64, &mountCount);
+
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelGetVendorMountLibs returns success");
     // mountCount can be 0 for example implementation
-    
+
     // Test invalid parameters
-    result = GetVendorMountLibs(NULL, 64, &mountCount);
+    result = AccelGetVendorMountLibs(NULL, 64, &mountCount);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "NULL mounts returns error");
-    
-    result = GetVendorMountLibs(mounts, 0, &mountCount);
+
+    result = AccelGetVendorMountLibs(mounts, 0, &mountCount);
     TEST_ASSERT(result == ACCEL_ERROR_INVALID_PARAM, "Zero maxCount returns error");
 }
 
-// Test RegisterLogCallback
+// Test AccelRegisterLogCallback
 void test_registerLogCallback() {
-    printf("\n=== Testing RegisterLogCallback ===\n");
-    
+    printf("\n=== Testing AccelRegisterLogCallback ===\n");
+
     // Test with NULL callback (unregister)
-    AccelResult result = RegisterLogCallback(NULL);
-    TEST_ASSERT(result == ACCEL_SUCCESS, "RegisterLogCallback with NULL returns success");
+    AccelResult result = AccelRegisterLogCallback(NULL);
+    TEST_ASSERT(result == ACCEL_SUCCESS, "AccelRegisterLogCallback with NULL returns success");
 }
 
 // Main test runner
@@ -273,7 +273,7 @@ int main() {
     printf("Accelerator Library Test Suite\n");
     printf("========================================\n");
     
-    test_virtualGPUInit();
+    test_accelInit();
     test_getDeviceCount();
     test_getAllDevices();
     test_getDeviceTopology();


### PR DESCRIPTION
- Updated function names from VGPUInit, VGPUShutdown, and related functions to AccelInit, AccelShutdown, and their variants in both Unix and Windows implementations.
- Adjusted error messages to reflect the new function names.
- Updated corresponding tests and example implementations to use the new function names for better clarity and consistency.