### PR TITLE
fix: copy api/ before go mod download in node-discovery Dockerfile

### DIFF
--- a/dockerfile/node-discovery.Dockerfile
+++ b/dockerfile/node-discovery.Dockerfile
@@ -7,13 +7,13 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY api/ api/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
 COPY cmd/ cmd/
-COPY api/ api/
 COPY internal/ internal/
 
 # Install cross-compilers


### PR DESCRIPTION
  The go.mod has a local replace directive (./api), so the api/ directory
  must be present before go mod download can resolve dependencies.