### PR TITLE
fix: cascade GPU phase to Unknown when GPUNode enters Failed state

### DIFF
--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -353,6 +353,10 @@ func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
 		if err := r.Status().Update(ctx, gpunode); err != nil {
 			return fmt.Errorf("failed to update GPU node status to failed: %w", err)
 		}
+		if _, err := r.syncStatusToGPUDevices(ctx, gpunode, tfv1.TensorFusionGPUPhasePending); err != nil {
+			log.Error(err, "failed to cascade GPU phase to Pending when node failed", "node", gpunode.Name)
+		}
+
 		metrics.SetNodeMetrics(gpunode, pool, nil)
 	}
 


### PR DESCRIPTION
fix: cascade GPU phase to Unknown when GPUNode enters Failed state
- When a GPUNode enters `Failed` state (e.g., discovery job failure, GPU card drop), 
  cascade the phase change to all GPU CRs on that node by setting them to `Unknown`
- Previously, GPU CRs remained `Running` even when their parent GPUNode was `Failed`,
  causing the scheduler to treat unavailable GPUs as schedulable resources