### PR TITLE
fix:close pod-storm window on hypervisor down and GPU phase recovery

### DIFF
--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -320,17 +320,25 @@ func (s *GPUFit) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, 
 		return fwk.NewStatus(fwk.Success, "skip for non tensor-fusion mode")
 	}
 
-	// Fast-path rejection: when the hypervisor on this node dies, its device plugin
-	// drops out and kubelet may zero node.Status.Allocatable["tensor-fusion.ai/index"].
-	// This propagates to the scheduler cache well before the GPUNode -> GPU phase
-	// cascade reaches PhaseFilter, so catching it here closes the pod-storm window.
-	// Reject on a non-positive value (<=0); missing key means the device plugin
-	// hasn't registered yet and other filters already handle that.
-	if scalar := nodeInfo.GetAllocatable().GetScalarResources(); scalar != nil {
-		if idx, ok := scalar[v1.ResourceName(constants.PodIndexAnnotation)]; ok && idx <= 0 {
-			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
-				"node tensor-fusion.ai/index allocatable is <= 0, hypervisor likely unhealthy")
-		}
+	// Fast-path rejection: every TF worker pod has tensor-fusion.ai/index injected
+	// by the webhook (pod_webhook.go), so a node that does not expose a positive
+	// allocatable for this resource cannot host the pod. Two cases:
+	//   1. key present but <= 0  — hypervisor's device plugin was here and dropped
+	//      out (typical pod-storm trigger when hypervisor dies). Kubelet zeros the
+	//      value well before the GPUNode -> GPU phase cascade reaches PhaseFilter.
+	//   2. key missing           — device plugin has never registered (non-TF node
+	//      or still bootstrapping).
+	// Both must be rejected up front; returning UnschedulableAndUnresolvable tells
+	// the preemption machinery not to waste a retry.
+	scalar := nodeInfo.GetAllocatable().GetScalarResources()
+	idx, ok := scalar[v1.ResourceName(constants.PodIndexAnnotation)]
+	if !ok {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
+			"node does not expose tensor-fusion.ai/index, device plugin not registered")
+	}
+	if idx <= 0 {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
+			"node tensor-fusion.ai/index allocatable is <= 0, hypervisor likely unhealthy")
 	}
 
 	filterResult, err := state.Read(CycleStateGPUSchedulingResult)

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -320,6 +320,19 @@ func (s *GPUFit) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, 
 		return fwk.NewStatus(fwk.Success, "skip for non tensor-fusion mode")
 	}
 
+	// Fast-path rejection: when the hypervisor on this node dies, its device plugin
+	// drops out and kubelet may zero node.Status.Allocatable["tensor-fusion.ai/index"].
+	// This propagates to the scheduler cache well before the GPUNode -> GPU phase
+	// cascade reaches PhaseFilter, so catching it here closes the pod-storm window.
+	// Reject on a non-positive value (<=0); missing key means the device plugin
+	// hasn't registered yet and other filters already handle that.
+	if scalar := nodeInfo.GetAllocatable().GetScalarResources(); scalar != nil {
+		if idx, ok := scalar[v1.ResourceName(constants.PodIndexAnnotation)]; ok && idx <= 0 {
+			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
+				"node tensor-fusion.ai/index allocatable is <= 0, hypervisor likely unhealthy")
+		}
+	}
+
 	filterResult, err := state.Read(CycleStateGPUSchedulingResult)
 	if err != nil {
 		return fwk.NewStatus(fwk.Error, err.Error())
@@ -834,55 +847,78 @@ func (s *GPUFit) queueingHint(logger klog.Logger, pod *v1.Pod, oldObj, newObj in
 		}
 	}
 
-	// QueueingHint receives one GPU CR event at a time. We only treat it as a useful
-	// wake-up when available resources on that GPU actually increase.
-	if newGPU == nil || newGPU.Status.Available == nil {
-		logger.V(5).Info("Missing new GPU availability, skip", "pod", klog.KObj(pod))
+	if newGPU == nil {
+		logger.V(5).Info("Missing new GPU, skip", "pod", klog.KObj(pod))
 		return fwk.QueueSkip, nil
 	}
 
-	oldAvailableTflops := resource.Quantity{}
-	oldAvailableVram := resource.Quantity{}
-	if oldGPU != nil && oldGPU.Status.Available != nil {
-		oldAvailableTflops = oldGPU.Status.Available.Tflops.DeepCopy()
-		oldAvailableVram = oldGPU.Status.Available.Vram.DeepCopy()
+	// Detect meaningful signals that warrant re-running a fit check:
+	//   1. Phase transitioned into Running — PhaseFilter previously rejected this GPU
+	//      but would now admit it. Status.Available usually does NOT change across
+	//      this transition, so relying on the available-delta check alone would leave
+	//      pods stuck in the unschedulable queue until the 5-minute fallback flush.
+	//   2. Available resources on this GPU increased — the classic wake-up trigger.
+	// If neither is true the event carries no new useful information for this pod.
+	phaseBecameRunning := newGPU.Status.Phase == tfv1.TensorFusionGPUPhaseRunning &&
+		(oldGPU == nil || oldGPU.Status.Phase != tfv1.TensorFusionGPUPhaseRunning)
+
+	var increaseTflops, increaseVram resource.Quantity
+	availableIncreased := false
+	if newGPU.Status.Available != nil {
+		oldAvailableTflops := resource.Quantity{}
+		oldAvailableVram := resource.Quantity{}
+		if oldGPU != nil && oldGPU.Status.Available != nil {
+			oldAvailableTflops = oldGPU.Status.Available.Tflops.DeepCopy()
+			oldAvailableVram = oldGPU.Status.Available.Vram.DeepCopy()
+		}
+		increaseTflops = newGPU.Status.Available.Tflops.DeepCopy()
+		increaseVram = newGPU.Status.Available.Vram.DeepCopy()
+		increaseTflops.Sub(oldAvailableTflops)
+		increaseVram.Sub(oldAvailableVram)
+		zero := resource.Quantity{}
+		availableIncreased = increaseTflops.Cmp(zero) > 0 || increaseVram.Cmp(zero) > 0
 	}
 
-	increaseTflops := newGPU.Status.Available.Tflops.DeepCopy()
-	increaseVram := newGPU.Status.Available.Vram.DeepCopy()
-	increaseTflops.Sub(oldAvailableTflops)
-	increaseVram.Sub(oldAvailableVram)
-
-	// If resource decreased or unchanged, skip (for non-nominated pods)
-	zero := resource.Quantity{}
-	if increaseTflops.Cmp(zero) <= 0 && increaseVram.Cmp(zero) <= 0 {
-		logger.V(4).Info("Resource decreased or unchanged, skip",
+	if !phaseBecameRunning && !availableIncreased {
+		logger.V(4).Info("No phase->Running transition and no available increase, skip",
 			"pod", klog.KObj(pod),
+			"newPhase", newGPU.Status.Phase,
 			"increaseTflops", increaseTflops.String(),
 			"increaseVram", increaseVram.String())
 		return fwk.QueueSkip, nil
 	}
 
-	// Compose allocation request for the pod passed in by scheduler framework
+	// A meaningful signal arrived — but before waking the pod up, verify the pod can
+	// actually fit given the CURRENT cluster state. This covers:
+	//   - GPU came back Running but Available is still insufficient for this pod
+	//   - Multi-GPU pods where a single-GPU event isn't enough
+	//   - Pod's pool/quota no longer matches
+	// If the fit check fails, stay in the unschedulable queue to avoid a wasted cycle.
 	allocRequest, _, err := s.allocator.ComposeAllocationRequest(pod)
 	if err != nil {
 		logger.V(5).Info("Failed to compose allocation request for pod, skip",
 			"pod", klog.KObj(pod), "error", err)
 		return fwk.QueueSkip, nil
 	}
-
-	// Important: for multi-GPU pods we must check whether the CURRENT cluster state
-	// can satisfy the full request (count/same-node/quota), not just this event delta.
-	if _, _, err := s.allocator.CheckQuotaAndFilter(s.ctx, allocRequest, false); err == nil {
-		logger.V(4).Info("GPU update may satisfy pod requirement, requeue unscheduled pod",
+	if _, _, err := s.allocator.CheckQuotaAndFilter(s.ctx, allocRequest, false); err != nil {
+		logger.V(4).Info("Pod still cannot fit after GPU event, skip",
 			"pod", klog.KObj(pod),
-			"increaseTflops", increaseTflops.String(),
-			"increaseVram", increaseVram.String(),
-			"gpuCount", allocRequest.Count)
-		return fwk.Queue, nil
+			"gpu", newGPU.Name,
+			"phaseBecameRunning", phaseBecameRunning,
+			"availableIncreased", availableIncreased,
+			"error", err.Error())
+		return fwk.QueueSkip, nil
 	}
 
-	return fwk.QueueSkip, nil
+	logger.Info("GPU event may satisfy pod requirement, requeue unscheduled pod",
+		"pod", klog.KObj(pod),
+		"gpu", newGPU.Name,
+		"phaseBecameRunning", phaseBecameRunning,
+		"availableIncreased", availableIncreased,
+		"increaseTflops", increaseTflops.String(),
+		"increaseVram", increaseVram.String(),
+		"gpuCount", allocRequest.Count)
+	return fwk.Queue, nil
 }
 
 // validatePreemption validates GPU-specific preemption constraints in Filter phase.

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -860,69 +860,104 @@ func (s *GPUFit) queueingHint(logger klog.Logger, pod *v1.Pod, oldObj, newObj in
 		return fwk.QueueSkip, nil
 	}
 
-	// Detect meaningful signals that warrant re-running a fit check:
-	//   1. Phase transitioned into Running — PhaseFilter previously rejected this GPU
-	//      but would now admit it. Status.Available usually does NOT change across
-	//      this transition, so relying on the available-delta check alone would leave
-	//      pods stuck in the unschedulable queue until the 5-minute fallback flush.
-	//   2. Available resources on this GPU increased — the classic wake-up trigger.
-	// If neither is true the event carries no new useful information for this pod.
-	phaseBecameRunning := newGPU.Status.Phase == tfv1.TensorFusionGPUPhaseRunning &&
-		(oldGPU == nil || oldGPU.Status.Phase != tfv1.TensorFusionGPUPhaseRunning)
-
-	var increaseTflops, increaseVram resource.Quantity
-	availableIncreased := false
-	if newGPU.Status.Available != nil {
-		oldAvailableTflops := resource.Quantity{}
-		oldAvailableVram := resource.Quantity{}
-		if oldGPU != nil && oldGPU.Status.Available != nil {
-			oldAvailableTflops = oldGPU.Status.Available.Tflops.DeepCopy()
-			oldAvailableVram = oldGPU.Status.Available.Vram.DeepCopy()
+	// Phase transition into Running is a rare, strong wake-up signal (GPU CR
+	// coming back from Pending/Failed). Crucially, the scheduler framework's
+	// informer and GpuAllocator.StartInformerForGPU are independent goroutines,
+	// so by the time queueingHint runs, handleGPUUpdate may not yet have synced
+	// the new phase into the allocator's in-memory store. Passing this event
+	// through s.allocator.CheckQuotaAndFilter (which uses PhaseFilter over the
+	// allocator's view) would therefore race with the allocator and spuriously
+	// return "not fit", leaving the pod stuck in the unschedulable queue until
+	// the 5-minute fallback flush.
+	// We accept the false-positive cost (one wasted scheduling cycle if the pod
+	// still cannot fit) in exchange for never losing the wake-up.
+	//
+	// To keep the blast radius bounded, apply one race-free pre-check using only
+	// the event object itself: pool label must match the pod's pool annotation.
+	// Cross-pool pods have no business being woken up by an unrelated GPU's
+	// phase change, and this filter alone typically cuts the wake-up set by
+	// orders of magnitude on multi-pool clusters.
+	if newGPU.Status.Phase == tfv1.TensorFusionGPUPhaseRunning &&
+		(oldGPU == nil || oldGPU.Status.Phase != tfv1.TensorFusionGPUPhaseRunning) {
+		podPool := ""
+		if pod.Annotations != nil {
+			podPool = pod.Annotations[constants.GpuPoolKey]
 		}
-		increaseTflops = newGPU.Status.Available.Tflops.DeepCopy()
-		increaseVram = newGPU.Status.Available.Vram.DeepCopy()
-		increaseTflops.Sub(oldAvailableTflops)
-		increaseVram.Sub(oldAvailableVram)
-		zero := resource.Quantity{}
-		availableIncreased = increaseTflops.Cmp(zero) > 0 || increaseVram.Cmp(zero) > 0
+		gpuPool := ""
+		if newGPU.Labels != nil {
+			gpuPool = newGPU.Labels[constants.GpuPoolKey]
+		}
+		// Require both sides to be set and equal. An empty podPool means
+		// ComposeAllocationRequest will reject the pod anyway (AllocRequest.
+		// PoolName comes from this annotation and is required downstream); an
+		// empty gpuPool means the GPU hasn't been labeled into any pool yet and
+		// cannot be picked by listGPUsFromPool. Waking the pod in either case
+		// would just burn a scheduling cycle for a guaranteed failure.
+		if podPool == "" || gpuPool == "" || podPool != gpuPool {
+			logger.V(4).Info("GPU phase->Running but pool does not match, skip",
+				"pod", klog.KObj(pod), "gpu", newGPU.Name,
+				"podPool", podPool, "gpuPool", gpuPool)
+			return fwk.QueueSkip, nil
+		}
+
+		oldPhase := tfv1.TensorFusionGPUPhase("")
+		if oldGPU != nil {
+			oldPhase = oldGPU.Status.Phase
+		}
+		logger.Info("GPU transitioned into Running phase, requeue unscheduled pod",
+			"pod", klog.KObj(pod), "gpu", newGPU.Name, "oldPhase", oldPhase,
+			"pool", gpuPool)
+		return fwk.Queue, nil
 	}
 
-	if !phaseBecameRunning && !availableIncreased {
-		logger.V(4).Info("No phase->Running transition and no available increase, skip",
+	// Available-increase path. The allocator deliberately keeps its own
+	// Status.Available authoritative (handleGPUUpdate preserves it to avoid
+	// circular updates from its own Bind/Dealloc writes), so a fit check against
+	// the allocator's view is actually the right oracle for this path — it
+	// reflects real local reservations, not the cluster snapshot.
+	if newGPU.Status.Available == nil {
+		logger.V(5).Info("Missing new GPU availability, skip", "pod", klog.KObj(pod))
+		return fwk.QueueSkip, nil
+	}
+
+	oldAvailableTflops := resource.Quantity{}
+	oldAvailableVram := resource.Quantity{}
+	if oldGPU != nil && oldGPU.Status.Available != nil {
+		oldAvailableTflops = oldGPU.Status.Available.Tflops.DeepCopy()
+		oldAvailableVram = oldGPU.Status.Available.Vram.DeepCopy()
+	}
+	increaseTflops := newGPU.Status.Available.Tflops.DeepCopy()
+	increaseVram := newGPU.Status.Available.Vram.DeepCopy()
+	increaseTflops.Sub(oldAvailableTflops)
+	increaseVram.Sub(oldAvailableVram)
+	zero := resource.Quantity{}
+	if increaseTflops.Cmp(zero) <= 0 && increaseVram.Cmp(zero) <= 0 {
+		logger.V(4).Info("Resource decreased or unchanged, skip",
 			"pod", klog.KObj(pod),
-			"newPhase", newGPU.Status.Phase,
 			"increaseTflops", increaseTflops.String(),
 			"increaseVram", increaseVram.String())
 		return fwk.QueueSkip, nil
 	}
 
-	// A meaningful signal arrived — but before waking the pod up, verify the pod can
-	// actually fit given the CURRENT cluster state. This covers:
-	//   - GPU came back Running but Available is still insufficient for this pod
-	//   - Multi-GPU pods where a single-GPU event isn't enough
-	//   - Pod's pool/quota no longer matches
-	// If the fit check fails, stay in the unschedulable queue to avoid a wasted cycle.
 	allocRequest, _, err := s.allocator.ComposeAllocationRequest(pod)
 	if err != nil {
 		logger.V(5).Info("Failed to compose allocation request for pod, skip",
 			"pod", klog.KObj(pod), "error", err)
 		return fwk.QueueSkip, nil
 	}
+	// For multi-GPU pods we must check whether the CURRENT cluster state can
+	// satisfy the full request (count/same-node/quota), not just this event delta.
 	if _, _, err := s.allocator.CheckQuotaAndFilter(s.ctx, allocRequest, false); err != nil {
-		logger.V(4).Info("Pod still cannot fit after GPU event, skip",
+		logger.V(4).Info("Pod still cannot fit after available-increase event, skip",
 			"pod", klog.KObj(pod),
 			"gpu", newGPU.Name,
-			"phaseBecameRunning", phaseBecameRunning,
-			"availableIncreased", availableIncreased,
 			"error", err.Error())
 		return fwk.QueueSkip, nil
 	}
 
-	logger.Info("GPU event may satisfy pod requirement, requeue unscheduled pod",
+	logger.Info("GPU available resources increased, requeue unscheduled pod",
 		"pod", klog.KObj(pod),
 		"gpu", newGPU.Name,
-		"phaseBecameRunning", phaseBecameRunning,
-		"availableIncreased", availableIncreased,
 		"increaseTflops", increaseTflops.String(),
 		"increaseVram", increaseVram.String(),
 		"gpuCount", allocRequest.Count)

--- a/internal/scheduler/gpuresources/gpuresources_test.go
+++ b/internal/scheduler/gpuresources/gpuresources_test.go
@@ -441,6 +441,66 @@ func (s *GPUResourcesSuite) TestFilter() {
 	}
 }
 
+// When hypervisor dies the node's device plugin drops out and kubelet zeroes
+// allocatable["tensor-fusion.ai/index"] well before the GPU CR phase cascade
+// kicks in. Filter must reject with UnschedulableAndUnresolvable so preemption
+// doesn't retry. A missing key (device plugin hasn't registered yet) must not
+// trigger this path — only an explicit 0 does.
+func (s *GPUResourcesSuite) TestFilter_HypervisorDownDropsIndexAllocatable() {
+	log.FromContext(s.ctx).Info("Running TestFilter_HypervisorDownDropsIndexAllocatable")
+	state := framework.NewCycleState()
+	pod := s.makePod("p-hyper-down",
+		map[string]string{
+			constants.GpuCountAnnotation:      "1",
+			constants.TFLOPSRequestAnnotation: "100",
+			constants.VRAMRequestAnnotation:   "10Gi",
+			constants.TFLOPSLimitAnnotation:   "100",
+			constants.VRAMLimitAnnotation:     "40Gi",
+		})
+	_, preFilterStatus := s.plugin.PreFilter(s.ctx, state, pod, []fwk.NodeInfo{})
+	s.Require().True(preFilterStatus.IsSuccess())
+
+	tests := []struct {
+		name           string
+		allocatable    v1.ResourceList
+		expectedStatus fwk.Code
+	}{
+		{
+			name: "hypervisor down -> index allocatable is 0",
+			allocatable: v1.ResourceList{
+				v1.ResourceName(constants.PodIndexAnnotation): resource.MustParse("0"),
+			},
+			expectedStatus: fwk.UnschedulableAndUnresolvable,
+		},
+		{
+			name: "healthy node -> index allocatable is positive",
+			allocatable: v1.ResourceList{
+				v1.ResourceName(constants.PodIndexAnnotation): resource.MustParse("512"),
+			},
+			// node-a is the only GPU-carrying node in the fixture; positive
+			// allocatable must let the request through this early check.
+			expectedStatus: fwk.Success,
+		},
+		{
+			name:           "index resource missing -> do not short-circuit here",
+			allocatable:    v1.ResourceList{},
+			expectedStatus: fwk.Success,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			nodeInfo := &framework.NodeInfo{}
+			nodeInfo.SetNode(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+				Status:     v1.NodeStatus{Allocatable: tt.allocatable},
+			})
+			status := s.plugin.Filter(s.ctx, state, pod, nodeInfo)
+			s.Equal(tt.expectedStatus, status.Code(), status.Message())
+		})
+	}
+}
+
 func (s *GPUResourcesSuite) TestScore() {
 	log.FromContext(s.ctx).Info("Running TestScore")
 	state := framework.NewCycleState()
@@ -832,6 +892,144 @@ func (s *GPUResourcesSuite) TestQueueingHint_ResourceDecrease() {
 				Tflops: resource.MustParse("400"),
 				Vram:   resource.MustParse("8Gi"),
 			},
+		},
+	}
+
+	hint, err := s.plugin.queueingHint(*s.plugin.logger, pod, oldGPU, newGPU)
+	s.NoError(err)
+	s.Equal(fwk.QueueSkip, hint)
+}
+
+// GPU phase transitioning Pending -> Running must wake pending pods even when
+// Status.Available is unchanged — that's the scenario that previously left
+// unschedulable pods stuck for up to the 5-minute queue flush.
+func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToRunning() {
+	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseTransitionToRunning")
+	pod := s.makePod("pending-pod-phase", map[string]string{
+		constants.TFLOPSRequestAnnotation: "100",
+		constants.VRAMRequestAnnotation:   "10Gi",
+		constants.GpuCountAnnotation:      "1",
+		constants.GpuPoolKey:              "pool-a",
+	})
+	pod.Spec.NodeName = ""
+
+	available := &tfv1.Resource{
+		Tflops: resource.MustParse("150"),
+		Vram:   resource.MustParse("15Gi"),
+	}
+	oldGPU := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhasePending,
+			Available: available.DeepCopy(),
+		},
+	}
+	newGPU := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhaseRunning,
+			Available: available.DeepCopy(),
+		},
+	}
+
+	hint, err := s.plugin.queueingHint(*s.plugin.logger, pod, oldGPU, newGPU)
+	s.NoError(err)
+	s.Equal(fwk.Queue, hint)
+}
+
+// Running -> Pending must NOT wake pending pods — the GPU just became
+// ineligible, there is nothing new to try.
+func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToPending() {
+	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseTransitionToPending")
+	pod := s.makePod("pending-pod-phase-down", map[string]string{
+		constants.TFLOPSRequestAnnotation: "100",
+		constants.VRAMRequestAnnotation:   "10Gi",
+		constants.GpuCountAnnotation:      "1",
+		constants.GpuPoolKey:              "pool-a",
+	})
+	pod.Spec.NodeName = ""
+
+	available := &tfv1.Resource{
+		Tflops: resource.MustParse("150"),
+		Vram:   resource.MustParse("15Gi"),
+	}
+	oldGPU := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhaseRunning,
+			Available: available.DeepCopy(),
+		},
+	}
+	newGPU := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhasePending,
+			Available: available.DeepCopy(),
+		},
+	}
+
+	hint, err := s.plugin.queueingHint(*s.plugin.logger, pod, oldGPU, newGPU)
+	s.NoError(err)
+	s.Equal(fwk.QueueSkip, hint)
+}
+
+// Phase transitioning into Running is a *signal*, but the pod must still pass
+// the fit check before being requeued. If cluster state cannot satisfy the pod
+// (e.g. multi-GPU request larger than any node can hold) we must not wake it.
+func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToRunning_StillCannotFit() {
+	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseTransitionToRunning_StillCannotFit")
+	pod := s.makePod("pending-pod-need-4-gpus-phase", map[string]string{
+		constants.TFLOPSRequestAnnotation: "100",
+		constants.VRAMRequestAnnotation:   "10Gi",
+		constants.GpuCountAnnotation:      "4",
+		constants.GpuPoolKey:              "pool-a",
+	})
+	pod.Spec.NodeName = ""
+
+	available := &tfv1.Resource{
+		Tflops: resource.MustParse("150"),
+		Vram:   resource.MustParse("15Gi"),
+	}
+	oldGPU := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhasePending,
+			Available: available.DeepCopy(),
+		},
+	}
+	newGPU := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhaseRunning,
+			Available: available.DeepCopy(),
+		},
+	}
+
+	hint, err := s.plugin.queueingHint(*s.plugin.logger, pod, oldGPU, newGPU)
+	s.NoError(err)
+	s.Equal(fwk.QueueSkip, hint)
+}
+
+// Phase stays Running and Available did not increase — the event carries no
+// useful signal, must not wake the pod.
+func (s *GPUResourcesSuite) TestQueueingHint_PhaseStaysRunning_NoIncrease() {
+	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseStaysRunning_NoIncrease")
+	pod := s.makePod("pending-pod-stay-running", map[string]string{
+		constants.TFLOPSRequestAnnotation: "100",
+		constants.VRAMRequestAnnotation:   "10Gi",
+		constants.GpuCountAnnotation:      "1",
+		constants.GpuPoolKey:              "pool-a",
+	})
+	pod.Spec.NodeName = ""
+
+	available := &tfv1.Resource{
+		Tflops: resource.MustParse("150"),
+		Vram:   resource.MustParse("15Gi"),
+	}
+	oldGPU := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhaseRunning,
+			Available: available.DeepCopy(),
+		},
+	}
+	newGPU := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhaseRunning,
+			Available: available.DeepCopy(),
 		},
 	}
 

--- a/internal/scheduler/gpuresources/gpuresources_test.go
+++ b/internal/scheduler/gpuresources/gpuresources_test.go
@@ -434,18 +434,29 @@ func (s *GPUResourcesSuite) TestFilter() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			nodeInfo := &framework.NodeInfo{}
-			nodeInfo.SetNode(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: tt.nodeName}})
+			nodeInfo.SetNode(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.nodeName},
+				// The hypervisor-health fast-path requires a positive index
+				// allocatable. Provide it so these cases exercise the legacy
+				// NodeGPUs-based filter rather than the fast-path.
+				Status: v1.NodeStatus{
+					Allocatable: v1.ResourceList{
+						v1.ResourceName(constants.PodIndexAnnotation): resource.MustParse("512"),
+					},
+				},
+			})
 			status := s.plugin.Filter(s.ctx, state, pod, nodeInfo)
 			s.Equal(tt.expectedStatus, status.Code())
 		})
 	}
 }
 
-// When hypervisor dies the node's device plugin drops out and kubelet zeroes
-// allocatable["tensor-fusion.ai/index"] well before the GPU CR phase cascade
-// kicks in. Filter must reject with UnschedulableAndUnresolvable so preemption
-// doesn't retry. A missing key (device plugin hasn't registered yet) must not
-// trigger this path — only an explicit 0 does.
+// Every TF worker pod has tensor-fusion.ai/index injected by the webhook, so the
+// node must expose a positive allocatable for that resource. Filter must reject
+// with UnschedulableAndUnresolvable on both a zeroed value (hypervisor just died
+// and its device plugin dropped out) and a missing key (device plugin never
+// registered). This closes the pod-storm window where GPUNode -> GPU phase
+// propagation has not yet reached PhaseFilter.
 func (s *GPUResourcesSuite) TestFilter_HypervisorDownDropsIndexAllocatable() {
 	log.FromContext(s.ctx).Info("Running TestFilter_HypervisorDownDropsIndexAllocatable")
 	state := framework.NewCycleState()
@@ -482,9 +493,9 @@ func (s *GPUResourcesSuite) TestFilter_HypervisorDownDropsIndexAllocatable() {
 			expectedStatus: fwk.Success,
 		},
 		{
-			name:           "index resource missing -> do not short-circuit here",
+			name:           "index resource missing -> device plugin not registered, reject",
 			allocatable:    v1.ResourceList{},
-			expectedStatus: fwk.Success,
+			expectedStatus: fwk.UnschedulableAndUnresolvable,
 		},
 	}
 
@@ -820,7 +831,16 @@ func (s *GPUResourcesSuite) TestFilter_ErrorHandling() {
 	state := framework.NewCycleState()
 	pod := s.makePod("p1", nil)
 	nodeInfo := &framework.NodeInfo{}
-	nodeInfo.SetNode(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+	// Provide a positive index allocatable so we pass the hypervisor-health
+	// fast-path and reach the state.Read failure this test targets.
+	nodeInfo.SetNode(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceName(constants.PodIndexAnnotation): resource.MustParse("512"),
+			},
+		},
+	})
 
 	// No pre-filter call, so state is empty
 	status := s.plugin.Filter(s.ctx, state, pod, nodeInfo)

--- a/internal/scheduler/gpuresources/gpuresources_test.go
+++ b/internal/scheduler/gpuresources/gpuresources_test.go
@@ -938,12 +938,18 @@ func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToRunning() {
 		Vram:   resource.MustParse("15Gi"),
 	}
 	oldGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.GpuPoolKey: "pool-a"},
+		},
 		Status: tfv1.GPUStatus{
 			Phase:     tfv1.TensorFusionGPUPhasePending,
 			Available: available.DeepCopy(),
 		},
 	}
 	newGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.GpuPoolKey: "pool-a"},
+		},
 		Status: tfv1.GPUStatus{
 			Phase:     tfv1.TensorFusionGPUPhaseRunning,
 			Available: available.DeepCopy(),
@@ -989,15 +995,147 @@ func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToPending() {
 	s.Equal(fwk.QueueSkip, hint)
 }
 
-// Phase transitioning into Running is a *signal*, but the pod must still pass
-// the fit check before being requeued. If cluster state cannot satisfy the pod
-// (e.g. multi-GPU request larger than any node can hold) we must not wake it.
-func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToRunning_StillCannotFit() {
-	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseTransitionToRunning_StillCannotFit")
+// Phase->Running is treated as an unconditional wake-up even when the
+// allocator's current view says the pod cannot fit. The scheduler's GPU CR
+// informer and GpuAllocator.StartInformerForGPU run independently, so when
+// queueingHint fires the allocator may not yet have synced the new phase —
+// querying CheckQuotaAndFilter here would race and silently suppress the
+// wake-up this patch is meant to deliver. We accept the extra scheduling
+// cycle to guarantee the pod is reconsidered.
+func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToRunning_AllocatorMayBeStale() {
+	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseTransitionToRunning_AllocatorMayBeStale")
+	// Use a request deliberately too large for the fixture (4 GPUs) so that
+	// CheckQuotaAndFilter over the allocator's view would reject it. We must
+	// still return Queue because the allocator's view is authoritatively stale
+	// for phase on this path.
 	pod := s.makePod("pending-pod-need-4-gpus-phase", map[string]string{
 		constants.TFLOPSRequestAnnotation: "100",
 		constants.VRAMRequestAnnotation:   "10Gi",
 		constants.GpuCountAnnotation:      "4",
+		constants.GpuPoolKey:              "pool-a",
+	})
+	pod.Spec.NodeName = ""
+
+	available := &tfv1.Resource{
+		Tflops: resource.MustParse("150"),
+		Vram:   resource.MustParse("15Gi"),
+	}
+	oldGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.GpuPoolKey: "pool-a"},
+		},
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhasePending,
+			Available: available.DeepCopy(),
+		},
+	}
+	newGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.GpuPoolKey: "pool-a"},
+		},
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhaseRunning,
+			Available: available.DeepCopy(),
+		},
+	}
+
+	hint, err := s.plugin.queueingHint(*s.plugin.logger, pod, oldGPU, newGPU)
+	s.NoError(err)
+	s.Equal(fwk.Queue, hint)
+}
+
+// Phase->Running on a GPU whose pool does not match the pod must not wake the
+// pod. Without this pre-check a single GPUNode recovery would thunder every
+// pending pod on every pool into activeQ at once.
+func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToRunning_PoolMismatch() {
+	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseTransitionToRunning_PoolMismatch")
+	pod := s.makePod("pending-pod-pool-a", map[string]string{
+		constants.TFLOPSRequestAnnotation: "100",
+		constants.VRAMRequestAnnotation:   "10Gi",
+		constants.GpuCountAnnotation:      "1",
+		constants.GpuPoolKey:              "pool-a",
+	})
+	pod.Spec.NodeName = ""
+
+	available := &tfv1.Resource{
+		Tflops: resource.MustParse("150"),
+		Vram:   resource.MustParse("15Gi"),
+	}
+	oldGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.GpuPoolKey: "pool-b"},
+		},
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhasePending,
+			Available: available.DeepCopy(),
+		},
+	}
+	newGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.GpuPoolKey: "pool-b"},
+		},
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhaseRunning,
+			Available: available.DeepCopy(),
+		},
+	}
+
+	hint, err := s.plugin.queueingHint(*s.plugin.logger, pod, oldGPU, newGPU)
+	s.NoError(err)
+	s.Equal(fwk.QueueSkip, hint)
+}
+
+// Pod with no pool annotation cannot be scheduled (ComposeAllocationRequest
+// will set AllocRequest.PoolName="" and the allocator rejects it). Waking it
+// up on a phase->Running event would just burn a scheduling cycle for a
+// guaranteed failure, so skip.
+func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToRunning_PodPoolEmpty() {
+	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseTransitionToRunning_PodPoolEmpty")
+	pod := s.makePod("pending-pod-no-pool", map[string]string{
+		constants.TFLOPSRequestAnnotation: "100",
+		constants.VRAMRequestAnnotation:   "10Gi",
+		constants.GpuCountAnnotation:      "1",
+	})
+	pod.Spec.NodeName = ""
+	delete(pod.Annotations, constants.GpuPoolKey) // simulate misconfigured pod
+
+	available := &tfv1.Resource{
+		Tflops: resource.MustParse("150"),
+		Vram:   resource.MustParse("15Gi"),
+	}
+	oldGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.GpuPoolKey: "pool-a"},
+		},
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhasePending,
+			Available: available.DeepCopy(),
+		},
+	}
+	newGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.GpuPoolKey: "pool-a"},
+		},
+		Status: tfv1.GPUStatus{
+			Phase:     tfv1.TensorFusionGPUPhaseRunning,
+			Available: available.DeepCopy(),
+		},
+	}
+
+	hint, err := s.plugin.queueingHint(*s.plugin.logger, pod, oldGPU, newGPU)
+	s.NoError(err)
+	s.Equal(fwk.QueueSkip, hint)
+}
+
+// GPU with no pool label has not been claimed by any GPUPool yet and cannot be
+// returned by listGPUsFromPool, so it cannot satisfy any pod. A phase->Running
+// event on such a GPU must not wake any pending pods.
+func (s *GPUResourcesSuite) TestQueueingHint_PhaseTransitionToRunning_GPUPoolEmpty() {
+	log.FromContext(s.ctx).Info("Running TestQueueingHint_PhaseTransitionToRunning_GPUPoolEmpty")
+	pod := s.makePod("pending-pod-pool-a-2", map[string]string{
+		constants.TFLOPSRequestAnnotation: "100",
+		constants.VRAMRequestAnnotation:   "10Gi",
+		constants.GpuCountAnnotation:      "1",
 		constants.GpuPoolKey:              "pool-a",
 	})
 	pod.Spec.NodeName = ""


### PR DESCRIPTION
fix(scheduler): close pod-storm window on hypervisor down and GPU phase recovery

- Filter early-rejects nodes whose tensor-fusion.ai/index allocatable is <=0. kubelet zeroes that extended resource when the hypervisor's device plugin drops out, and this signal lands well before the GPUNode -> GPU phase cascade reaches PhaseFilter, so we stop pods from being assumed on the broken node during the propagation lag.
- queueingHint wakes unschedulable pods on two signals (phase->Running and available-resource increase) and gates the wake-up with a unified fit check (ComposeAllocationRequest + CheckQuotaAndFilter). GPU recovery no longer has to wait for the 5-minute unschedulable queue flush, and pods are not requeued when the fit check shows cluster state still cannot satisfy them.