### PR TITLE
fix：cherry pick the issues fixed in version v1 to main

### DIFF
--- a/internal/component/client.go
+++ b/internal/component/client.go
@@ -28,8 +28,8 @@ func (c *Client) GetName() string {
 
 func (c *Client) DetectConfigChange(pool *tfv1.GPUPool, status *tfv1.PoolComponentStatus) (bool, string, string) {
 	oldHash := status.ClientVersion
-	changed, newHash := utils.CompareAndGetObjectHash(oldHash, pool.Spec.ComponentConfig.Client)
-	return changed, newHash, oldHash
+	newHash := utils.ClientTemplateHash(pool)
+	return oldHash != newHash, newHash, oldHash
 }
 
 func (c *Client) SetConfigHash(status *tfv1.PoolComponentStatus, hash string) {

--- a/internal/component/hypervisor.go
+++ b/internal/component/hypervisor.go
@@ -29,8 +29,8 @@ func (h *Hypervisor) GetName() string {
 
 func (h *Hypervisor) DetectConfigChange(pool *tfv1.GPUPool, status *tfv1.PoolComponentStatus) (bool, string, string) {
 	oldHash := status.HypervisorVersion
-	changed, newHash := utils.CompareAndGetObjectHash(oldHash, pool.Spec.ComponentConfig.Hypervisor)
-	return changed, newHash, oldHash
+	newHash := utils.HypervisorTemplateHash(pool)
+	return oldHash != newHash, newHash, oldHash
 }
 
 func (h *Hypervisor) SetConfigHash(status *tfv1.PoolComponentStatus, hash string) {

--- a/internal/component/worker.go
+++ b/internal/component/worker.go
@@ -30,8 +30,8 @@ func (w *Worker) GetName() string {
 
 func (w *Worker) DetectConfigChange(pool *tfv1.GPUPool, status *tfv1.PoolComponentStatus) (bool, string, string) {
 	oldHash := status.WorkerVersion
-	changed, newHash := utils.CompareAndGetObjectHash(oldHash, pool.Spec.ComponentConfig.Worker)
-	return changed, newHash, oldHash
+	newHash := utils.WorkerTemplateHash(pool.Spec.ComponentConfig.Worker, pool.Spec.ComponentConfig.Hypervisor)
+	return oldHash != newHash, newHash, oldHash
 }
 
 func (w *Worker) SetConfigHash(status *tfv1.PoolComponentStatus, hash string) {

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -155,6 +155,21 @@ func (r *GPUNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	hypervisorName, err := r.reconcileHypervisorPod(ctx, node, poolObj, coreNode)
 	if err != nil {
+		nodePhaseChanged, gpuList, pendingErr := r.syncNodeAndOwnedGPUPhases(
+			ctx,
+			node,
+			tfv1.TensorFusionGPUNodePhasePending,
+			tfv1.TensorFusionGPUPhasePending,
+		)
+		if pendingErr != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to mark GPUNode pending after hypervisor reconcile error %q: %w", err.Error(), pendingErr)
+		}
+		if nodePhaseChanged {
+			metrics.SetNodeMetrics(node, poolObj, nil)
+		}
+		if len(gpuList) > 0 {
+			metrics.SetGPUMetrics(gpuList, node.Name, poolObj.Name)
+		}
 		return ctrl.Result{}, err
 	}
 	// pod deleted or deleting, wait next reconcile
@@ -197,24 +212,21 @@ func (r *GPUNodeReconciler) checkStatusAndUpdateVirtualCapacity(
 	}
 
 	if hypervisorNotReady {
-		if node.Status.Phase != tfv1.TensorFusionGPUNodePhasePending {
-			node.Status.Phase = tfv1.TensorFusionGPUNodePhasePending
-			err := r.Status().Update(ctx, node)
-			if err != nil {
-				return fmt.Errorf("failed to update GPU node status to pending: %w", err)
-			}
-			metrics.SetNodeMetrics(node, poolObj, nil)
-		}
-
-		gpuList, err := r.syncStatusToGPUDevices(ctx, node, tfv1.TensorFusionGPUPhasePending)
+		nodePhaseChanged, gpuList, err := r.syncNodeAndOwnedGPUPhases(
+			ctx,
+			node,
+			tfv1.TensorFusionGPUNodePhasePending,
+			tfv1.TensorFusionGPUPhasePending,
+		)
 		if err != nil {
 			return err
 		}
-
+		if nodePhaseChanged {
+			metrics.SetNodeMetrics(node, poolObj, nil)
+		}
 		if len(gpuList) > 0 {
 			metrics.SetGPUMetrics(gpuList, node.Name, poolObj.Name)
 		}
-
 		return nil
 	} else {
 		gpuModels, err := gpuallocator.RefreshGPUNodeCapacity(ctx, r.Client, node, poolObj, r.Allocator, coreNode)
@@ -263,6 +275,28 @@ func (r *GPUNodeReconciler) checkStatusAndUpdateVirtualCapacity(
 		}
 		return nil
 	}
+}
+
+func (r *GPUNodeReconciler) syncNodeAndOwnedGPUPhases(
+	ctx context.Context,
+	node *tfv1.GPUNode,
+	nodePhase tfv1.TensorFusionGPUNodePhase,
+	gpuPhase tfv1.TensorFusionGPUPhase,
+) (bool, []tfv1.GPU, error) {
+	nodePhaseChanged := node.Status.Phase != nodePhase
+	if nodePhaseChanged {
+		node.Status.Phase = nodePhase
+		if err := r.Status().Update(ctx, node); err != nil {
+			return false, nil, fmt.Errorf("failed to update GPU node status to %s: %w", nodePhase, err)
+		}
+	}
+
+	gpuList, err := r.syncStatusToGPUDevices(ctx, node, gpuPhase)
+	if err != nil {
+		return nodePhaseChanged, nil, err
+	}
+
+	return nodePhaseChanged, gpuList, nil
 }
 
 func (r *GPUNodeReconciler) syncStatusToGPUDevices(ctx context.Context, node *tfv1.GPUNode, state tfv1.TensorFusionGPUPhase) ([]tfv1.GPU, error) {

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -377,7 +377,7 @@ func (r *GPUNodeReconciler) reconcileHypervisorPod(
 			return "", nil
 		}
 
-		newHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Hypervisor)
+		newHash := utils.HypervisorTemplateHash(pool)
 		if utils.IsPodStopped(currentPod) || oldHash != newHash {
 			if err := r.Delete(ctx, currentPod); err != nil {
 				return "", fmt.Errorf("failed to delete old hypervisor pod: %w", err)
@@ -520,7 +520,7 @@ func (r *GPUNodeReconciler) createHypervisorPod(
 	}
 
 	// compose the final pod and set tolerations and controller reference
-	newHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Hypervisor)
+	newHash := utils.HypervisorTemplateHash(pool)
 	newPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.Name,

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -824,7 +824,7 @@ func (n *nvidiaHandler) findDevicePluginPod(ctx context.Context, r *GPUNodeRecon
 }
 
 func getDriverProbeJobName(gpuNodeName string) string {
-	return fmt.Sprintf("driver-probe-%s", gpuNodeName)
+	return utils.BuildNodeScopedName("driver-probe", gpuNodeName, 63, 8)
 }
 
 type providerDeviceMountEnv struct {

--- a/internal/controller/gpupool_controller_test.go
+++ b/internal/controller/gpupool_controller_test.go
@@ -59,7 +59,7 @@ var _ = Describe("GPUPool Controller", func() {
 			tfEnv := NewTensorFusionEnvBuilder().AddPoolWithNodeCount(0).Build()
 			By("verifying hypervisor status should be initialized when the gpu pool is created")
 			pool := tfEnv.GetGPUPool(0)
-			oldHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Hypervisor)
+			oldHash := utils.HypervisorTemplateHash(pool)
 			Eventually(func(g Gomega) {
 				pool := tfEnv.GetGPUPool(0)
 				g.Expect(pool.Status.ComponentStatus.HypervisorVersion).To(Equal(oldHash))
@@ -71,7 +71,7 @@ var _ = Describe("GPUPool Controller", func() {
 			updateHypervisorConfig(tfEnv)
 			Eventually(func(g Gomega) {
 				pool := tfEnv.GetGPUPool(0)
-				newHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Hypervisor)
+				newHash := utils.HypervisorTemplateHash(pool)
 				g.Expect(newHash).ShouldNot(Equal(oldHash))
 				g.Expect(pool.Status.ComponentStatus.HypervisorVersion).To(Equal(newHash))
 				g.Expect(pool.Status.ComponentStatus.HyperVisorUpdateProgress).To(BeZero())
@@ -162,7 +162,7 @@ var _ = Describe("GPUPool Controller", func() {
 			tfEnv := NewTensorFusionEnvBuilder().AddPoolWithNodeCount(0).Build()
 			By("verifying worker status should be initialized when the gpu pool is created")
 			pool := tfEnv.GetGPUPool(0)
-			oldHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Worker)
+			oldHash := utils.WorkerTemplateHash(pool.Spec.ComponentConfig.Worker, pool.Spec.ComponentConfig.Hypervisor)
 			Eventually(func(g Gomega) {
 				pool := tfEnv.GetGPUPool(0)
 				g.Expect(pool.Status.ComponentStatus.WorkerVersion).To(Equal(oldHash))
@@ -174,7 +174,7 @@ var _ = Describe("GPUPool Controller", func() {
 			updateWorkerConfig(tfEnv)
 			Eventually(func(g Gomega) {
 				pool := tfEnv.GetGPUPool(0)
-				newHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Worker)
+				newHash := utils.WorkerTemplateHash(pool.Spec.ComponentConfig.Worker, pool.Spec.ComponentConfig.Hypervisor)
 				g.Expect(newHash).ShouldNot(Equal(oldHash))
 				g.Expect(pool.Status.ComponentStatus.WorkerVersion).To(Equal(newHash))
 				g.Expect(pool.Status.ComponentStatus.WorkerUpdateProgress).To(BeZero())
@@ -238,7 +238,7 @@ var _ = Describe("GPUPool Controller", func() {
 			tfEnv := NewTensorFusionEnvBuilder().AddPoolWithNodeCount(0).Build()
 			By("verifying client status should be initialized when the gpu pool is created")
 			pool := tfEnv.GetGPUPool(0)
-			oldHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Client)
+			oldHash := utils.ClientTemplateHash(pool)
 			Eventually(func(g Gomega) {
 				pool := tfEnv.GetGPUPool(0)
 				g.Expect(pool.Status.ComponentStatus.ClientVersion).To(Equal(oldHash))
@@ -250,7 +250,7 @@ var _ = Describe("GPUPool Controller", func() {
 			updateClientConfig(tfEnv)
 			Eventually(func(g Gomega) {
 				pool := tfEnv.GetGPUPool(0)
-				newHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Client)
+				newHash := utils.ClientTemplateHash(pool)
 				g.Expect(newHash).ShouldNot(Equal(oldHash))
 				g.Expect(pool.Status.ComponentStatus.ClientVersion).To(Equal(newHash))
 				g.Expect(pool.Status.ComponentStatus.ClientUpdateProgress).To(BeZero())
@@ -517,7 +517,7 @@ func verifyGpuPoolClientHash(tfEnv *TensorFusionEnv, oldHash string) string {
 	pool := &tfv1.GPUPool{}
 	Eventually(func(g Gomega) {
 		pool = tfEnv.GetGPUPool(0)
-		newHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Client)
+		newHash := utils.ClientTemplateHash(pool)
 		g.Expect(newHash).ShouldNot(Equal(oldHash))
 		g.Expect(pool.Status.ComponentStatus.ClientVersion).To(Equal(newHash))
 	}).Should(Succeed())
@@ -530,7 +530,7 @@ func verifyGpuPoolHypervisorHash(tfEnv *TensorFusionEnv, oldHash string) string 
 	pool := &tfv1.GPUPool{}
 	Eventually(func(g Gomega) {
 		pool = tfEnv.GetGPUPool(0)
-		newHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Hypervisor)
+		newHash := utils.HypervisorTemplateHash(pool)
 		g.Expect(newHash).ShouldNot(Equal(oldHash))
 		g.Expect(pool.Status.ComponentStatus.HypervisorVersion).To(Equal(newHash))
 	}).Should(Succeed())
@@ -543,7 +543,7 @@ func verifyGpuPoolWorkerHash(tfEnv *TensorFusionEnv, oldHash string) string {
 	pool := &tfv1.GPUPool{}
 	Eventually(func(g Gomega) {
 		pool = tfEnv.GetGPUPool(0)
-		newHash := utils.GetObjectHash(pool.Spec.ComponentConfig.Worker)
+		newHash := utils.WorkerTemplateHash(pool.Spec.ComponentConfig.Worker, pool.Spec.ComponentConfig.Hypervisor)
 		g.Expect(newHash).ShouldNot(Equal(oldHash))
 		g.Expect(pool.Status.ComponentStatus.WorkerVersion).To(Equal(newHash))
 	}).Should(Succeed())
@@ -782,7 +782,7 @@ func createClientPodByIndex(tfEnv *TensorFusionEnv, index int) {
 			Labels: map[string]string{
 				constants.TensorFusionEnabledLabelKey: constants.TrueStringValue,
 				constants.GpuPoolKey:                  pool.Name,
-				constants.LabelKeyPodTemplateHash:     utils.GetObjectHash(pool.Spec.ComponentConfig.Client),
+				constants.LabelKeyPodTemplateHash:     utils.ClientTemplateHash(pool),
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -814,7 +814,7 @@ func createClientPods(tfEnv *TensorFusionEnv, count int) {
 				Labels: map[string]string{
 					constants.TensorFusionEnabledLabelKey: constants.TrueStringValue,
 					constants.GpuPoolKey:                  pool.Name,
-					constants.LabelKeyPodTemplateHash:     utils.GetObjectHash(pool.Spec.ComponentConfig.Client),
+					constants.LabelKeyPodTemplateHash:     utils.ClientTemplateHash(pool),
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -353,6 +353,19 @@ func (s *GPUFit) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, 
 		return fwk.NewStatus(fwk.Success, "skip for non tensor-fusion mode")
 	}
 
+	// Fast-path rejection: the 16 tensor-fusion.ai/index_<hex> extended resources are
+	// registered by the hypervisor container's device plugins and share its lifetime.
+	// When the hypervisor dies, kubelet zeros these allocatables well before the
+	// GPUNode -> GPU phase cascade reaches PhaseFilter. Check index_0 as a proxy
+	// (all 16 die together since they're in the same container). Only reject when
+	// the key is present AND <= 0 — absence means a non-TF node or one still
+	// bootstrapping, which other filters will handle correctly.
+	idx0Key := v1.ResourceName(constants.PodIndexAnnotation + constants.PodIndexDelimiter + "0")
+	if v, ok := nodeInfo.GetAllocatable().GetScalarResources()[idx0Key]; ok && v <= 0 {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
+			"node tensor-fusion.ai/index_0 allocatable is <= 0, hypervisor likely unhealthy")
+	}
+
 	filterResult, err := state.Read(CycleStateGPUSchedulingResult)
 	if err != nil {
 		return fwk.NewStatus(fwk.Error, err.Error())
@@ -1022,6 +1035,10 @@ func (s *GPUFit) queueingHint(logger klog.Logger, pod *v1.Pod, oldObj, newObj an
 		}
 	}
 
+	if hint, handled := s.phaseRunningWakeupHint(logger, pod, oldGPU, newGPU); handled {
+		return hint, nil
+	}
+
 	// Calculate resource increase
 	var increaseTflops, increaseVram resource.Quantity
 	if oldGPU == nil && newGPU != nil {
@@ -1084,6 +1101,58 @@ func (s *GPUFit) queueingHint(logger klog.Logger, pod *v1.Pod, oldObj, newObj an
 	}
 
 	return fwk.QueueSkip, nil
+}
+
+// phaseRunningWakeupHint handles the rare, strong wake-up signal of a GPU CR
+// transitioning into the Running phase (e.g. after hypervisor recovery).
+// Available resources may be unchanged across this transition, so the
+// available-increase path in queueingHint would otherwise miss it and leave
+// the pod stuck until the 5-minute unschedulable queue flush. We accept the
+// false-positive cost of one wasted scheduling cycle in exchange for a
+// guaranteed wake-up.
+//
+// Race-free pre-check: only wake pods in the same pool as the GPU. An empty
+// podPool would fail in ComposeAllocationRequest anyway; an empty gpuPool
+// means the GPU has not been claimed by any pool. Both sides must be set and
+// equal. This check never touches the allocator, so it cannot reintroduce an
+// informer race.
+//
+// Returns (hint, handled). When handled is false the caller should continue
+// with the resource-increase path.
+func (s *GPUFit) phaseRunningWakeupHint(
+	logger klog.Logger,
+	pod *v1.Pod,
+	oldGPU, newGPU *tfv1.GPU,
+) (fwk.QueueingHint, bool) {
+	if newGPU == nil || newGPU.Status.Phase != tfv1.TensorFusionGPUPhaseRunning {
+		return fwk.QueueSkip, false
+	}
+	if oldGPU != nil && oldGPU.Status.Phase == tfv1.TensorFusionGPUPhaseRunning {
+		return fwk.QueueSkip, false
+	}
+
+	podPool := ""
+	if pod.Annotations != nil {
+		podPool = pod.Annotations[constants.GpuPoolKey]
+	}
+	gpuPool := ""
+	if newGPU.Labels != nil {
+		gpuPool = newGPU.Labels[constants.GpuPoolKey]
+	}
+	if podPool == "" || gpuPool == "" || podPool != gpuPool {
+		logger.V(4).Info("GPU phase->Running but pool does not match, skip",
+			"pod", klog.KObj(pod), "gpu", newGPU.Name,
+			"podPool", podPool, "gpuPool", gpuPool)
+		return fwk.QueueSkip, true
+	}
+	oldPhase := tfv1.TensorFusionGPUPhase("")
+	if oldGPU != nil {
+		oldPhase = oldGPU.Status.Phase
+	}
+	logger.Info("GPU transitioned into Running phase, requeue unscheduled pod",
+		"pod", klog.KObj(pod), "gpu", newGPU.Name, "oldPhase", oldPhase,
+		"pool", gpuPool)
+	return fwk.Queue, true
 }
 
 // allocateGPUsToContainers allocates GPUs to containers based on their requirements

--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -52,8 +52,6 @@ var workerDefaultRequests v1.ResourceList = v1.ResourceList{
 	v1.ResourceMemory: resource.MustParse("128Mi"),
 }
 
-var sharedMemMaxSize = resource.MustParse("512Mi")
-
 var workerPodIndexCounter uint32
 var featureShortcutMap = map[string]struct {
 	EnvName  string
@@ -473,8 +471,7 @@ func AddTFDefaultClientConfBeforePatch(
 				Name: constants.TransportShmVolumeName,
 				VolumeSource: v1.VolumeSource{
 					EmptyDir: &v1.EmptyDirVolumeSource{
-						SizeLimit: &sharedMemMaxSize,
-						Medium:    v1.StorageMediumMemory,
+						Medium: v1.StorageMediumMemory,
 					},
 				},
 			})

--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	context "context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -1277,6 +1278,57 @@ func SetWorkerContainerSpec(
 	if len(container.Resources.Requests) == 0 {
 		container.Resources.Requests = workerDefaultRequests
 	}
+}
+
+// HypervisorTemplateHash computes hash of the full hypervisor pod template
+// including code-level defaults from AddTFHypervisorConfAfterTemplate.
+// Vendor-agnostic: uses empty vendor and compatibleWithNvidiaContainerToolkit=false
+// so the hash stays stable across nodes — vendor-specific extras are applied
+// per-node at pod creation time.
+func HypervisorTemplateHash(pool *tfv1.GPUPool) string {
+	podTmpl := &v1.PodTemplate{}
+	if pool.Spec.ComponentConfig.Hypervisor != nil && pool.Spec.ComponentConfig.Hypervisor.PodTemplate != nil {
+		json.Unmarshal(pool.Spec.ComponentConfig.Hypervisor.PodTemplate.Raw, podTmpl) //nolint:errcheck
+	}
+	spec := podTmpl.Template.Spec
+	AddTFHypervisorConfAfterTemplate(context.Background(), &spec, pool, "", false)
+	return GetObjectHash(spec)
+}
+
+// WorkerTemplateHash computes hash of the base worker pod template
+// including code-level defaults from SetWorkerContainerSpec.
+// Only the hypervisor port number is included — other hypervisor config
+// changes should not cascade to worker pod recreation.
+func WorkerTemplateHash(workerConfig *tfv1.WorkerConfig, hypervisorConfig *tfv1.HypervisorConfig) string {
+	podTmpl := &v1.PodTemplate{}
+	if workerConfig != nil && workerConfig.PodTemplate != nil {
+		json.Unmarshal(workerConfig.PodTemplate.Raw, podTmpl) //nolint:errcheck
+	}
+	spec := podTmpl.Template.Spec
+	if len(spec.Containers) == 0 {
+		spec.Containers = []v1.Container{{}}
+	}
+	// Use a minimal HypervisorConfig containing only the port number,
+	// so that unrelated hypervisor changes don't affect the worker hash.
+	portOnly := &tfv1.HypervisorConfig{}
+	if hypervisorConfig != nil && hypervisorConfig.PortNumber != nil {
+		portOnly.PortNumber = hypervisorConfig.PortNumber
+	}
+	SetWorkerContainerSpec(&spec.Containers[0], &tfv1.WorkloadProfileSpec{}, workerConfig, portOnly, "", false)
+	spec.TerminationGracePeriodSeconds = constants.GracefulPeriodSeconds
+	return GetObjectHash(spec)
+}
+
+// ClientTemplateHash computes hash of the base client injection template
+// including code-level defaults from AddTFDefaultClientConfBeforePatch,
+// plus webhook-stage fields (OperatorEndpoint, PatchToContainer, etc.)
+// that also affect the final injected pod spec.
+func ClientTemplateHash(pool *tfv1.GPUPool) string {
+	pod := &v1.Pod{Spec: v1.PodSpec{Containers: []v1.Container{{Name: "baseline"}}}}
+	tfInfo := TensorFusionInfo{Profile: &tfv1.WorkloadProfileSpec{}}
+	AddTFDefaultClientConfBeforePatch(context.Background(), pod, pool, tfInfo, []int{0})
+	clientConfig := pool.Spec.ComponentConfig.Client
+	return GetObjectHash(pod.Spec, clientConfig.OperatorEndpoint, clientConfig.PatchToPod, clientConfig.PatchToContainer)
 }
 
 func AddWorkerConfAfterTemplate(

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -518,7 +518,7 @@ var _ = Describe("Compose Utils", func() {
 					Expect(container.Command[2]).To(ContainSubstring("exec ./tensor-fusion-worker"), "should exec worker")
 					Expect(container.Command[2]).To(ContainSubstring("-n shmem"), "should use shmem mode")
 					Expect(container.Command[2]).To(ContainSubstring("-m tf_shm"), "should specify shared memory name")
-					Expect(container.Command[2]).To(ContainSubstring("-M 256"), "should specify shared memory size")
+					Expect(container.Command[2]).To(ContainSubstring("-M 1024"), "should specify shared memory size")
 				}
 			},
 			Entry("hard worker: no LD_PRELOAD, no NVIDIA_VISIBLE_DEVICES=all (device plugin allocates UUID)", "NVIDIA", "worker:latest", "", false, tfv1.IsolationModeType(tfv1.IsolationModeHard), []string{
@@ -534,7 +534,7 @@ var _ = Describe("Compose Utils", func() {
 			Entry("worker with shared memory mode (hard)", "NVIDIA", "worker:latest", "", true, tfv1.IsolationModeType(tfv1.IsolationModeHard), []string{
 				"/bin/bash",
 				"-c",
-				"touch /dev/shm/tf_shm && chmod 666 /dev/shm/tf_shm && exec ./tensor-fusion-worker -n shmem -m tf_shm -M 256",
+				"touch /dev/shm/tf_shm && chmod 666 /dev/shm/tf_shm && exec ./tensor-fusion-worker -n shmem -m tf_shm -M 1024",
 			}, false, false),
 			Entry("worker with disabled start-worker feature (hard)", "NVIDIA", "worker:latest", "start-worker", false, tfv1.IsolationModeType(tfv1.IsolationModeHard), []string{
 				"sleep",

--- a/internal/utils/reconcile.go
+++ b/internal/utils/reconcile.go
@@ -149,11 +149,6 @@ func GetObjectHash(objs ...any) string {
 	return fmt.Sprintf("%x", hasher.Sum(nil))
 }
 
-func CompareAndGetObjectHash(hash string, obj ...any) (bool, string) {
-	newHash := GetObjectHash(obj...)
-	return hash != newHash, newHash
-}
-
 func IsPodConditionTrue(conditions []corev1.PodCondition, conditionType corev1.PodConditionType) bool {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -387,7 +387,7 @@ func (m *TensorFusionPodMutator) patchTFClient(
 	if pod.Labels == nil {
 		pod.Labels = map[string]string{}
 	}
-	pod.Labels[constants.LabelKeyPodTemplateHash] = utils.GetObjectHash(clientConfig)
+	pod.Labels[constants.LabelKeyPodTemplateHash] = utils.ClientTemplateHash(pool)
 
 	assignPodLabelsAndAnnotations(isLocalGPU, sidecarWorker, pod, pool)
 

--- a/internal/webhook/v1/tf_parser.go
+++ b/internal/webhook/v1/tf_parser.go
@@ -158,13 +158,18 @@ func ParseTensorFusionInfo(
 	applyVerticalScalingRules(ctx, k8sClient, pod, pool, workloadProfile)
 
 	injectContainer, ok := pod.Annotations[constants.InjectContainerAnnotation]
-	containerNames := strings.Split(injectContainer, ",")
+	containerNames := []string{}
+	if ok && injectContainer != "" {
+		containerNames = strings.Split(injectContainer, ",")
+		for i := range containerNames {
+			containerNames[i] = strings.TrimSpace(containerNames[i])
+		}
+	}
 	if len(pod.Spec.Containers) > 1 {
-		if !ok || len(containerNames) == 0 {
+		if len(containerNames) == 0 {
 			return info, fmt.Errorf("inject container has to be specified when Pod containers > 1")
 		}
-	} else {
-		// assign default container name when annotation not specified
+	} else if len(containerNames) == 0 {
 		containerNames = []string{pod.Spec.Containers[0].Name}
 	}
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -25,10 +25,8 @@ type WorkerGenerator struct {
 var ErrNoAvailableWorker = errors.New("no available worker")
 
 func (wg *WorkerGenerator) PodTemplateHash(workloadSpec any) (string, error) {
-	return utils.GetObjectHash(
-		wg.WorkerConfig,
-		workloadSpec,
-	), nil
+	baseHash := utils.WorkerTemplateHash(wg.WorkerConfig, wg.HypervisorConfig)
+	return utils.GetObjectHash(baseHash, workloadSpec), nil
 }
 
 func (wg *WorkerGenerator) GenerateWorkerPod(

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -72,7 +72,7 @@ const (
 	ConnectionNameEnv       = "TENSOR_FUSION_CONNECTION_NAME"
 	ConnectionNamespaceEnv  = "TENSOR_FUSION_CONNECTION_NAMESPACE"
 	DisableVMSharedMemEnv   = "TF_USE_IVSHMEM"
-	ConnectionSharedMemSize = "256"
+	ConnectionSharedMemSize = "1024"
 	ConnectionSharedMemName = "tf_shm"
 
 	RealNvmlLibPathValue = "/lib/x86_64-linux-gnu/libnvidia-ml.so.1"


### PR DESCRIPTION
cherry pick the following pr
2622d14  fix(scheduler): close pod-storm window and speed up GPU recovery requeue (port #656)
8b09e6d  fix(gpunode): reset node and gpu phases when hypervisor reconcile fails (port #654)
bc8dfc8  fix: compute component template hash from rendered PodSpec (port #601)
5de7f07  fix: cap driver-probe job name at 63 chars (port #626)
87af751  fix: raise worker SHM size to 1024MiB (port #642)
3fe443d  fix: webhook container name parsing (port #514)