### PR TITLE
rbac: add resourceclaims/binding permission for DRA granular status authorization

### DIFF
--- a/charts/tensor-fusion/templates/rbac.yaml
+++ b/charts/tensor-fusion/templates/rbac.yaml
@@ -327,6 +327,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/binding
+  verbs:
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -238,6 +238,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/binding
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - storage.k8s.io
   resources:
   - csidrivers

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -74,6 +74,7 @@ type PodReconciler struct {
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=deviceclasses;devicetaintrules;resourceclaims;resourceslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims,verbs=patch;update
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims/status,verbs=get;list;patch;update;watch
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims/binding,verbs=update;patch
 
 // Add GPU connection for Pods using GPU
 // Have to create TensorFusion connection here because pod UID not available in MutatingWebhook


### PR DESCRIPTION
This adds the necessary granular status authorization permissions for ResourceClaims as required by the Kubernetes v1.36 migration guide.

Relates to [kubernetes/kubernetes#138149](https://github.com/kubernetes/kubernetes/issues/138149)

The tracking issue lists tensor-fusion under "DRA Drivers", but the permission added here is `resourceclaims/binding` (the scheduler-category permission) rather than `resourceclaims/driver`. This is because tensor-fusion seems to embed a full kube-scheduler (`k8s.io/kubernetes/cmd/kube-scheduler/app`), whose built-in `DynamicResources` plugin writes `status.allocation` and `status.reservedFor` on ResourceClaims during the scheduling cycle. tensor-fusion does not seem to write `status.devices` so `resourceclaims/driver` is not needed.

If I'm wrong please ask for changes and I will happily comply.

