### PR TITLE
fix(opearotr):progressive migration observability, taint reconcile and hypervisor crash recovery

### DIFF
--- a/internal/config/global_config.go
+++ b/internal/config/global_config.go
@@ -16,6 +16,12 @@ type GlobalConfig struct {
 
 	AutoScalingInterval  string `yaml:"autoScalingInterval"`
 	GPUOperatorNamespace string `yaml:"gpuOperatorNamespace"`
+
+	// HypervisorMaxCrashCount is the container RestartCount threshold that triggers
+	// a full hypervisor pod recreation. Once any container on the hypervisor pod
+	// exceeds this count, the pod is deleted so the next reconcile recreates it.
+	// Set to 0 to disable. If nil, falls back to DefaultHypervisorMaxCrashCount.
+	HypervisorMaxCrashCount *int32 `yaml:"hypervisorMaxCrashCount"`
 }
 
 type AutoMigrationConfig struct {
@@ -61,6 +67,10 @@ const (
 
 	// Default GPU operator namespace
 	DefaultGPUOperatorNamespace = "gpu-operator"
+
+	// DefaultHypervisorMaxCrashCount is the fallback threshold when
+	// HypervisorMaxCrashCount is not configured.
+	DefaultHypervisorMaxCrashCount int32 = 5
 )
 
 // GetGPUOperatorNamespace returns the configured GPU operator namespace or default value

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -471,6 +471,26 @@ func (r *GPUNodeReconciler) reconcileHypervisorPod(
 
 	// If pod exists and prerequisites are satisfied, verify its status
 	if podExists {
+		// Crash-loop recovery: if any container on the hypervisor pod has exceeded
+		// the restart threshold, delete the pod so the next reconcile recreates it
+		// fresh. This runs before the "already Running" fast-path because a pod in
+		// CrashLoopBackOff stays Running overall while its containers keep restarting.
+		if crashedContainer, restartCount, threshold, ok := hypervisorPodCrashExceeded(currentPod); ok {
+			log.Info("hypervisor pod crash count exceeded threshold, deleting for recreation",
+				"node", node.Name,
+				"pod", currentPod.Name,
+				"container", crashedContainer,
+				"restartCount", restartCount,
+				"threshold", threshold)
+			r.Recorder.Eventf(node, corev1.EventTypeWarning, "HypervisorCrashLoopRecreate",
+				"Hypervisor pod %s deleted for recreation: container %s restarted %d times (threshold %d)",
+				currentPod.Name, crashedContainer, restartCount, threshold)
+			if err := r.Delete(ctx, currentPod); err != nil {
+				return "", fmt.Errorf("failed to delete crash-looping hypervisor pod: %w", err)
+			}
+			return "", nil
+		}
+
 		// If node is already running, no need to recreate
 		if node.Status.Phase == tfv1.TensorFusionGPUNodePhaseRunning {
 			return key.Name, nil
@@ -904,4 +924,34 @@ func (r *GPUNodeReconciler) mapDevicePluginPodToGPUNode(ctx context.Context, obj
 		"nodeName", pod.Spec.NodeName)
 
 	return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: pod.Spec.NodeName}}}
+}
+
+// hypervisorPodCrashExceeded reports whether any container (init or main) on the
+// hypervisor pod has restarted more than the configured threshold. Threshold is
+// read from GlobalConfig.HypervisorMaxCrashCount (operator configmap); missing or
+// nil falls back to DefaultHypervisorMaxCrashCount. A threshold of 0 or less
+// disables the check.
+func hypervisorPodCrashExceeded(pod *corev1.Pod) (container string, restartCount int32, threshold int32, exceeded bool) {
+	threshold = config.DefaultHypervisorMaxCrashCount
+	if cfg := config.GetGlobalConfig(); cfg != nil && cfg.HypervisorMaxCrashCount != nil {
+		threshold = *cfg.HypervisorMaxCrashCount
+	}
+	if threshold <= 0 {
+		return "", 0, 0, false
+	}
+	check := func(statuses []corev1.ContainerStatus) (string, int32, bool) {
+		for _, cs := range statuses {
+			if cs.RestartCount > threshold {
+				return cs.Name, cs.RestartCount, true
+			}
+		}
+		return "", 0, false
+	}
+	if name, count, hit := check(pod.Status.InitContainerStatuses); hit {
+		return name, count, threshold, true
+	}
+	if name, count, hit := check(pod.Status.ContainerStatuses); hit {
+		return name, count, threshold, true
+	}
+	return "", 0, threshold, false
 }

--- a/internal/gpuallocator/node_capacity.go
+++ b/internal/gpuallocator/node_capacity.go
@@ -26,7 +26,12 @@ func RefreshGPUNodeCapacity(
 		return nil, fmt.Errorf("failed to list GPUs: %w", err)
 	}
 	if len(gpuList.Items) == 0 {
-		// node discovery job not completed, wait next reconcile loop to check again
+		// node discovery job not completed, or GPU CRs have been removed externally.
+		// In the latter case TF owns nothing on this node, so reconcile the taint as idle
+		// to avoid a stale `tensor-fusion.ai/used-by` taint blocking native scheduling.
+		if err := reconcileProgressiveTaint(ctx, k8sClient, coreNode, true); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
@@ -107,37 +112,69 @@ func RefreshGPUNodeCapacity(
 	node.Status.Phase = tfv1.TensorFusionGPUNodePhaseRunning
 
 	if !equality.Semantic.DeepEqual(node.Status, statusCopy) {
-		err := k8sClient.Status().Update(ctx, node)
-		if err != nil {
+		if err := k8sClient.Status().Update(ctx, node); err != nil {
 			return nil, fmt.Errorf("failed to update GPU node status: %w", err)
 		}
+	}
 
-		// check if need to update K8S node label
-		if utils.IsProgressiveMigration() && coreNode != nil {
-			taint := &corev1.Taint{
-				Key:    constants.NodeUsedByTaintKey,
-				Effect: corev1.TaintEffectPreferNoSchedule,
-				Value:  constants.TensorFusionSystemName,
-			}
-			needUpdateNode := false
-			if node.Status.AvailableVRAM.Equal(node.Status.TotalVRAM) && node.Status.AvailableTFlops.Equal(node.Status.TotalTFlops) {
-				// check if need to remove the taint
-				coreNode, needUpdateNode, _ = taints.RemoveTaint(coreNode, taint)
-			} else if !taints.TaintExists(coreNode.Spec.Taints, taint) {
-				// check if need to add the taint
-				coreNode, needUpdateNode, _ = taints.AddOrUpdateTaint(coreNode, taint)
-			}
-			if needUpdateNode {
-				log.FromContext(ctx).Info("Updating K8S node taints for isolation of tensor-fusion and non-tensor-fusion used nodes",
-					"node", coreNode.Name, "taint", taint.Key)
-				err := k8sClient.Update(ctx, coreNode)
-				if err != nil {
-					return nil, fmt.Errorf("failed to update K8S node: %w", err)
-				}
-			}
-		}
+	// Guard against a transient state where all GPU CRs on this node are missing
+	// Status.Capacity / Status.Available (e.g. fresh discovery, hypervisor restart,
+	// external status reset). The aggregation loop above skips such GPUs, so
+	// Total/Available both end up 0 and "Available.Equal(Total)" yields a
+	// meaningless isIdle=true — without this guard we'd wrongly remove the taint
+	// from a node that may still be serving TF workers. The next reconcile round
+	// will converge once GPU status is populated.
+	if node.Status.TotalVRAM.IsZero() && node.Status.TotalTFlops.IsZero() {
+		return gpuModels, nil
+	}
+
+	// Reconcile the isolation taint every round, independent of status diff.
+	// A transient Node update failure otherwise leaves the taint stuck because the next
+	// round's DeepEqual would be true and the block would be skipped.
+	isIdle := node.Status.AvailableVRAM.Equal(node.Status.TotalVRAM) &&
+		node.Status.AvailableTFlops.Equal(node.Status.TotalTFlops)
+	if err := reconcileProgressiveTaint(ctx, k8sClient, coreNode, isIdle); err != nil {
+		return nil, err
 	}
 	return gpuModels, nil
+}
+
+// reconcileProgressiveTaint converges the `tensor-fusion.ai/used-by` PreferNoSchedule
+// taint on the core k8s Node to the desired state derived from isIdle:
+//   - isIdle=true  + has taint  -> remove
+//   - isIdle=false + no taint   -> add
+//
+// No-op in all other combinations. Only runs when progressive migration is enabled
+// and coreNode is available.
+func reconcileProgressiveTaint(ctx context.Context, k8sClient client.Client, coreNode *corev1.Node, isIdle bool) error {
+	if !utils.IsProgressiveMigration() || coreNode == nil {
+		return nil
+	}
+	taint := &corev1.Taint{
+		Key:    constants.NodeUsedByTaintKey,
+		Effect: corev1.TaintEffectPreferNoSchedule,
+		Value:  constants.TensorFusionSystemName,
+	}
+	hasTaint := taints.TaintExists(coreNode.Spec.Taints, taint)
+	var (
+		updated *corev1.Node
+		changed bool
+	)
+	switch {
+	case isIdle && hasTaint:
+		updated, changed, _ = taints.RemoveTaint(coreNode, taint)
+	case !isIdle && !hasTaint:
+		updated, changed, _ = taints.AddOrUpdateTaint(coreNode, taint)
+	}
+	if !changed {
+		return nil
+	}
+	log.FromContext(ctx).Info("Reconciling TensorFusion isolation taint on node",
+		"node", updated.Name, "taint", taint.Key, "idle", isIdle)
+	if err := k8sClient.Update(ctx, updated); err != nil {
+		return fmt.Errorf("failed to update K8S node: %w", err)
+	}
+	return nil
 }
 
 func calculateVirtualCapacity(node *tfv1.GPUNode, pool *tfv1.GPUPool) (resource.Quantity, resource.Quantity) {

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -35,6 +35,22 @@ const CycleStateAllocateRequest = "allocateRequest"
 const CycleStateGPUSchedulingResult = "gpuSchedulingResult"
 const SchedulerSimulationKey = "schedulerSimulation"
 
+// CycleStateProgressiveNodeNames stores the candidate node set returned by the
+// progressive migration branch of PreFilter. Exposed for simulate-schedule /
+// debug endpoints so operators can see exactly which nodes TF advertised as
+// "TF-free" for a native pod, without having to infer it from FitError output.
+const CycleStateProgressiveNodeNames = "progressiveNodeNames"
+
+// ProgressiveNodeNamesState captures the node set decided by ListNonUsingNodes
+// at PreFilter time.
+type ProgressiveNodeNamesState struct {
+	NodeNames sets.Set[string]
+}
+
+// Clone satisfies fwk.StateData. The set is read-only after PreFilter, so
+// returning the same pointer is safe.
+func (p *ProgressiveNodeNamesState) Clone() fwk.StateData { return p }
+
 var _ framework.PreFilterPlugin = &GPUFit{}
 var _ framework.FilterPlugin = &GPUFit{}
 var _ framework.ScorePlugin = &GPUFit{}
@@ -120,6 +136,8 @@ func (s *GPUFit) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Po
 	// Handle progressive migration case
 	if utils.IsProgressiveMigration() && utils.HasGPUResourceRequest(pod) {
 		nodeNames := s.allocator.ListNonUsingNodes()
+		// Record the candidate set for simulate-schedule / debug endpoints.
+		state.Write(CycleStateProgressiveNodeNames, &ProgressiveNodeNamesState{NodeNames: nodeNames})
 		s.fh.EventRecorder().Eventf(pod, pod, v1.EventTypeNormal, "ScheduleWithNativeGPU",
 			"Scheduling non-TF workload for progressive migration",
 			"use native GPU resources, available native GPU nodes: "+strconv.Itoa(len(nodeNames)))

--- a/internal/server/router/allocator_info.go
+++ b/internal/server/router/allocator_info.go
@@ -2,8 +2,11 @@ package router
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"sort"
 
 	"time"
 
@@ -119,27 +122,96 @@ func (r *AllocatorInfoRouter) SimulateScheduleOnePod(ctx *gin.Context) {
 	scheduleResult, err := r.scheduler.SchedulePod(ctx, fwkInstance, state, pod)
 	gpuCycleState, _ := state.Read(gpuresources.CycleStateGPUSchedulingResult)
 	simulateSchedulingFilterDetail, _ := state.Read(fwk.StateKey(constants.SchedulerSimulationKey))
+	progressiveNodes := readProgressiveNodeNames(state)
+
+	// errorPayload collects every piece of diagnostic info from the scheduler error.
+	// The old code used `"error": err` which serialises Go's error interface to {} —
+	// callers were seeing empty JSON and no way to learn why scheduling failed.
+	var errorPayload gin.H
 	if err != nil {
-		if fitError, ok := err.(*framework.FitError); ok {
-			ctx.JSON(http.StatusOK, gin.H{
-				"scheduleResult": scheduleResult,
-				"filterDetail":   simulateSchedulingFilterDetail,
-				"error": gin.H{
-					"numAllNodes": fitError.NumAllNodes,
-					"diagnosis":   fitError.Diagnosis,
-				},
-				"cycleState":        state,
-				"gpuSchedulerState": gpuCycleState,
-			})
-			return
+		log.FromContext(ctx).Error(err, "Simulate schedule pod failed",
+			"pod", pod.Name, "namespace", pod.Namespace,
+			"errorType", fmt.Sprintf("%T", err))
+
+		errorPayload = gin.H{
+			"type":    fmt.Sprintf("%T", err),
+			"message": err.Error(),
+		}
+		// Use errors.As so wrapped FitError (from fmt.Errorf("...: %w", fe)) still unwraps.
+		var fitError *framework.FitError
+		if errors.As(err, &fitError) {
+			errorPayload["numAllNodes"] = fitError.NumAllNodes
+			errorPayload["diagnosis"] = renderDiagnosis(&fitError.Diagnosis)
 		}
 	}
+
 	ctx.JSON(http.StatusOK, gin.H{
-		"scheduleResult":    scheduleResult,
-		"filterDetail":      simulateSchedulingFilterDetail,
-		"error":             err,
-		"cycleState":        state,
-		"gpuSchedulerState": gpuCycleState,
+		"scheduleResult":       scheduleResult,
+		"filterDetail":         simulateSchedulingFilterDetail,
+		"error":                errorPayload,
+		"cycleState":           state,
+		"gpuSchedulerState":    gpuCycleState,
+		"progressiveNodeNames": progressiveNodes,
 	})
-	log.FromContext(ctx).Info("Simulate schedule pod completed", "pod", pod.Name, "namespace", pod.Namespace, "duration", time.Since(start))
+	log.FromContext(ctx).Info("Simulate schedule pod completed",
+		"pod", pod.Name, "namespace", pod.Namespace,
+		"duration", time.Since(start), "scheduleError", err != nil)
+}
+
+// renderDiagnosis flattens framework.Diagnosis into JSON-serialisable form.
+// Diagnosis.NodeToStatus has unexported map fields and sets.Set[string] serialises
+// to `{"pluginName": {}}` — both lose their information through encoding/json.
+func renderDiagnosis(d *framework.Diagnosis) gin.H {
+	if d == nil {
+		return nil
+	}
+	out := gin.H{
+		"preFilterMsg":         d.PreFilterMsg,
+		"postFilterMsg":        d.PostFilterMsg,
+		"unschedulablePlugins": d.UnschedulablePlugins.UnsortedList(),
+		"pendingPlugins":       d.PendingPlugins.UnsortedList(),
+	}
+	if d.NodeToStatus != nil {
+		nodeStatuses := gin.H{}
+		d.NodeToStatus.ForEachExplicitNode(func(name string, s *fwk.Status) {
+			nodeStatuses[name] = renderStatus(s)
+		})
+		out["nodeToStatus"] = gin.H{
+			"nodes":             nodeStatuses,
+			"absentNodesStatus": renderStatus(d.NodeToStatus.AbsentNodesStatus()),
+		}
+	}
+	return out
+}
+
+func renderStatus(s *fwk.Status) gin.H {
+	if s == nil {
+		return gin.H{"code": "Success"}
+	}
+	return gin.H{
+		"code":    s.Code().String(),
+		"plugin":  s.Plugin(),
+		"reasons": s.Reasons(),
+		"message": s.Message(),
+	}
+}
+
+// readProgressiveNodeNames extracts the candidate node set written by the
+// progressive migration PreFilter branch. Returns nil when the branch was not
+// taken (e.g. TF worker pod path, or progressive migration disabled).
+func readProgressiveNodeNames(state *framework.CycleState) gin.H {
+	raw, err := state.Read(gpuresources.CycleStateProgressiveNodeNames)
+	if err != nil || raw == nil {
+		return nil
+	}
+	s, ok := raw.(*gpuresources.ProgressiveNodeNamesState)
+	if !ok || s.NodeNames == nil {
+		return nil
+	}
+	names := s.NodeNames.UnsortedList()
+	sort.Strings(names)
+	return gin.H{
+		"count": len(names),
+		"nodes": names,
+	}
 }


### PR DESCRIPTION

* simulate-schedule endpoint now surfaces full FitError diagnosis (per-node status + absentNodesStatus) and the PreFilter candidate set (progressiveNodeNames) so operators can diagnose "pod stuck Pending" cases directly instead of inferring from FitError text.

* Extract reconcileProgressiveTaint helper so the `tensor-fusion.ai/used-by` isolation taint is reconciled idempotently every round, independent of GPUNode status diff. A transient Node update failure no longer leaves the taint stuck on the next reconcile. Empty gpuList now also reconciles the taint as idle (covers external GPU CR deletion). Guard against all- GPU-status-missing where Total ends up zero and wrongly trips isIdle.

* Hypervisor pod crash-loop recovery via operator configmap (HypervisorMaxCrashCount, default 5, 0 disables). When any container on the hypervisor pod exceeds the restart threshold the pod is deleted so the next reconcile recreates it. Handles CrashLoopBackOff where the pod stays Running overall and IsPodStopped does not trigger.