### PR TITLE
fix(gpupool): simplify GPU usage function and enhance defrag logic

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -201,6 +201,9 @@ const (
 
 	// RFC3339 time when the drain label was applied.
 	DefragDrainingSinceAnnotation = Domain + "/defrag-draining-since"
+
+	// GPUPool that owns the current defrag drain operation.
+	DefragDrainingPoolAnnotation = Domain + "/defrag-draining-pool"
 )
 
 const (

--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -410,7 +410,7 @@ func (r *GPUPoolCompactionReconciler) processDefragCandidate(
 		"utilization", cand.utilizationScore, "workerCount", len(cand.workerPods))
 
 	// Label the source node before simulation so it cannot be chosen again.
-	if err := r.applyDefragDrainingLabel(ctx, cand.nodeName); err != nil {
+	if err := r.applyDefragDrainingLabel(ctx, cand.nodeName, pool.Name); err != nil {
 		l.Error(err, "patch draining label failed; skip candidate")
 		return
 	}
@@ -931,7 +931,6 @@ func (r *GPUPoolCompactionReconciler) defragDrainWatcherTick(ctx context.Context
 		return
 	}
 	nodeWorkerStore := r.Allocator.GetNodeWorkerStoreSnapshot()
-	poolKey := fmt.Sprintf(constants.GPUNodePoolIdentifierLabelFormat, pool.Name)
 
 	r.defragDrainingNodes.Range(func(k, v any) bool {
 		nodeName, _ := k.(string)
@@ -945,7 +944,13 @@ func (r *GPUPoolCompactionReconciler) defragDrainWatcherTick(ctx context.Context
 			log.FromContext(ctx).Error(err, "get draining node in watcher", "node", nodeName)
 			return true
 		}
-		if node.Labels[poolKey] != constants.TrueStringValue {
+		belongs, err := r.defragNodeBelongsToPool(ctx, pool.Name, node)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "check draining node pool ownership",
+				"node", nodeName, "pool", pool.Name)
+			return true
+		}
+		if !belongs {
 			return true
 		}
 
@@ -980,8 +985,7 @@ func (r *GPUPoolCompactionReconciler) defragStaleLabelCleanupTick(ctx context.Co
 
 	nodeList := &corev1.NodeList{}
 	if err := r.List(ctx, nodeList, client.MatchingLabels{
-		constants.DefragDrainingLabel:                                      constants.TrueStringValue,
-		fmt.Sprintf(constants.GPUNodePoolIdentifierLabelFormat, pool.Name): constants.TrueStringValue,
+		constants.DefragDrainingLabel: constants.TrueStringValue,
 	}); err != nil {
 		log.FromContext(ctx).Error(err, "list draining nodes for stale cleanup")
 		return
@@ -989,6 +993,16 @@ func (r *GPUPoolCompactionReconciler) defragStaleLabelCleanupTick(ctx context.Co
 	now := time.Now()
 	for i := range nodeList.Items {
 		n := &nodeList.Items[i]
+		belongs, err := r.defragNodeBelongsToPool(ctx, pool.Name, n)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "check stale draining node pool ownership",
+				"node", n.Name, "pool", pool.Name)
+			continue
+		}
+		if !belongs {
+			continue
+		}
+
 		raw := n.Annotations[constants.DefragDrainingSinceAnnotation]
 		if raw == "" {
 			_ = r.clearDefragDrainingLabel(ctx, n.Name)
@@ -1055,8 +1069,33 @@ func (r *GPUPoolCompactionReconciler) scheduleDefragDrainWatcherBootstrap(mgr ma
 
 // ----- node label / annotation helpers ---------------------------------
 
-// applyDefragDrainingLabel writes the drain label and since-annotation.
-func (r *GPUPoolCompactionReconciler) applyDefragDrainingLabel(ctx context.Context, nodeName string) error {
+func (r *GPUPoolCompactionReconciler) defragNodeBelongsToPool(ctx context.Context, poolName string, node *corev1.Node) (bool, error) {
+	if node == nil {
+		return false, nil
+	}
+	if node.Annotations != nil {
+		if owner := node.Annotations[constants.DefragDrainingPoolAnnotation]; owner != "" {
+			return owner == poolName, nil
+		}
+	}
+
+	poolKey := fmt.Sprintf(constants.GPUNodePoolIdentifierLabelFormat, poolName)
+	if node.Labels != nil && node.Labels[poolKey] == constants.TrueStringValue {
+		return true, nil
+	}
+
+	gpuNode := &tfv1.GPUNode{}
+	if err := r.Get(ctx, client.ObjectKey{Name: node.Name}, gpuNode); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return gpuNode.Labels[poolKey] == constants.TrueStringValue, nil
+}
+
+// applyDefragDrainingLabel writes the drain label and annotations.
+func (r *GPUPoolCompactionReconciler) applyDefragDrainingLabel(ctx context.Context, nodeName string, poolName string) error {
 	patch := map[string]any{
 		"metadata": map[string]any{
 			"labels": map[string]any{
@@ -1064,6 +1103,7 @@ func (r *GPUPoolCompactionReconciler) applyDefragDrainingLabel(ctx context.Conte
 			},
 			"annotations": map[string]any{
 				constants.DefragDrainingSinceAnnotation: time.Now().Format(time.RFC3339),
+				constants.DefragDrainingPoolAnnotation:  poolName,
 			},
 		},
 	}
@@ -1084,6 +1124,7 @@ func (r *GPUPoolCompactionReconciler) clearDefragDrainingLabel(ctx context.Conte
 			},
 			"annotations": map[string]any{
 				constants.DefragDrainingSinceAnnotation: nil,
+				constants.DefragDrainingPoolAnnotation:  nil,
 			},
 		},
 	}

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -435,6 +435,25 @@ func TestDefragStaleLabelCleanupTick_ScopedToPool(t *testing.T) {
 	}
 }
 
+func TestDefragStaleLabelCleanupTick_UsesGPUNodePoolWhenNodePoolLabelMissing(t *testing.T) {
+	pool := newDefragTestPool("pool-a", "30m")
+	staleSince := time.Now().Add(-2 * time.Hour)
+
+	node := newDefragDrainingNodeWithoutPoolLabel("node-a", staleSince)
+	gpuNode := newDefragGPUNode("node-a", "pool-a")
+
+	r, kubeClient := newDefragControllerTestReconciler(t, pool, node, gpuNode)
+	r.defragStaleLabelCleanupTick(context.Background(), pool)
+
+	updated := &corev1.Node{}
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: node.Name}, updated); err != nil {
+		t.Fatalf("get updated node: %v", err)
+	}
+	if _, exists := updated.Labels[constants.DefragDrainingLabel]; exists {
+		t.Fatalf("expected drain label to be cleared via GPUNode pool ownership, labels=%v", updated.Labels)
+	}
+}
+
 func TestDefragDrainWatcherTick_ScopedToPool(t *testing.T) {
 	pool := newDefragTestPool("pool-a", "30m")
 	nodeB := newDefragDrainingNode("node-b", "pool-b", time.Now().Add(-10*time.Minute))
@@ -450,6 +469,64 @@ func TestDefragDrainWatcherTick_ScopedToPool(t *testing.T) {
 	}
 	if updated.Labels[constants.DefragDrainingLabel] != constants.TrueStringValue {
 		t.Fatalf("expected foreign-pool drain label to remain, labels=%v", updated.Labels)
+	}
+}
+
+func TestDefragDrainWatcherTick_UsesGPUNodePoolWhenNodePoolLabelMissing(t *testing.T) {
+	pool := newDefragTestPool("pool-a", "30m")
+	node := newDefragDrainingNodeWithoutPoolLabel("node-a", time.Now().Add(-10*time.Minute))
+	gpuNode := newDefragGPUNode("node-a", "pool-a")
+
+	r, kubeClient := newDefragControllerTestReconciler(t, pool, node, gpuNode)
+	r.defragDrainingNodes.Store(node.Name, time.Now().Add(-time.Minute))
+
+	r.defragDrainWatcherTick(context.Background(), pool)
+
+	updated := &corev1.Node{}
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: node.Name}, updated); err != nil {
+		t.Fatalf("get updated node: %v", err)
+	}
+	if _, exists := updated.Labels[constants.DefragDrainingLabel]; exists {
+		t.Fatalf("expected drain label to be cleared via GPUNode pool ownership, labels=%v", updated.Labels)
+	}
+}
+
+func TestDefragDrainingLabelPatch_IncludesAndClearsPoolOwner(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+	r, kubeClient := newDefragControllerTestReconciler(t, node)
+
+	if err := r.applyDefragDrainingLabel(context.Background(), node.Name, "pool-a"); err != nil {
+		t.Fatalf("apply drain label: %v", err)
+	}
+
+	updated := &corev1.Node{}
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: node.Name}, updated); err != nil {
+		t.Fatalf("get updated node: %v", err)
+	}
+	if updated.Labels[constants.DefragDrainingLabel] != constants.TrueStringValue {
+		t.Fatalf("expected drain label, labels=%v", updated.Labels)
+	}
+	if updated.Annotations[constants.DefragDrainingPoolAnnotation] != "pool-a" {
+		t.Fatalf("expected drain pool annotation, annotations=%v", updated.Annotations)
+	}
+	if updated.Annotations[constants.DefragDrainingSinceAnnotation] == "" {
+		t.Fatalf("expected drain since annotation, annotations=%v", updated.Annotations)
+	}
+
+	if err := r.clearDefragDrainingLabel(context.Background(), node.Name); err != nil {
+		t.Fatalf("clear drain label: %v", err)
+	}
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: node.Name}, updated); err != nil {
+		t.Fatalf("get cleared node: %v", err)
+	}
+	if _, exists := updated.Labels[constants.DefragDrainingLabel]; exists {
+		t.Fatalf("expected drain label cleared, labels=%v", updated.Labels)
+	}
+	if _, exists := updated.Annotations[constants.DefragDrainingPoolAnnotation]; exists {
+		t.Fatalf("expected drain pool annotation cleared, annotations=%v", updated.Annotations)
+	}
+	if _, exists := updated.Annotations[constants.DefragDrainingSinceAnnotation]; exists {
+		t.Fatalf("expected drain since annotation cleared, annotations=%v", updated.Annotations)
 	}
 }
 
@@ -559,6 +636,31 @@ func newDefragDrainingNode(name, poolName string, since time.Time) *corev1.Node 
 			},
 			Annotations: map[string]string{
 				constants.DefragDrainingSinceAnnotation: since.Format(time.RFC3339),
+			},
+		},
+	}
+}
+
+func newDefragDrainingNodeWithoutPoolLabel(name string, since time.Time) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.DefragDrainingLabel: constants.TrueStringValue,
+			},
+			Annotations: map[string]string{
+				constants.DefragDrainingSinceAnnotation: since.Format(time.RFC3339),
+			},
+		},
+	}
+}
+
+func newDefragGPUNode(name, poolName string) *tfv1.GPUNode {
+	return &tfv1.GPUNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				fmt.Sprintf(constants.GPUNodePoolIdentifierLabelFormat, poolName): constants.TrueStringValue,
 			},
 		},
 	}


### PR DESCRIPTION
- Updated gpuWithUsage function to remove unnecessary parameters and set default capacity values.
- Refactored tests to align with the new function signature.
- Improved defrag candidate processing by adding checks for scheduler label observation and fresh worker detection.
- Introduced new methods for better handling of node worker pods and allocation readiness.