### PR TITLE
fix(operator): stop pre-setting NVIDIA_VISIBLE_DEVICES on user pods

### DIFF
--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -598,14 +598,16 @@ func AddTFDefaultClientConfBeforePatch(
 				})
 			}
 
-			if useInjectLib && shouldInjectNvidiaVisibleDevices(tfInfo.Profile.GPUVendor) && !lo.ContainsBy(envList, func(env v1.EnvVar) bool {
-				return env.Name == constants.NvidiaVisibleAllDeviceEnv
-			}) {
-				envList = append(envList, v1.EnvVar{
-					Name:  constants.NvidiaVisibleAllDeviceEnv,
-					Value: constants.NvidiaVisibleAllDeviceValue,
-				})
-			}
+			// We deliberately do NOT pre-set NVIDIA_VISIBLE_DEVICES=all here. After
+			// the soft/partitioned/shared `continue`s above, the only case left in
+			// this loop is `hard local sidecar`. For that flow the sidecar worker
+			// holds the real GPU; the client container talks to it over /dev/shm
+			// and does not need direct device access. Pre-setting =all would
+			// override the device plugin's per-card UUID at kubelet merge time
+			// and let the client physically see (and bypass the limiter to use)
+			// every GPU on the node. Letting the device plugin Allocate response
+			// be the single source of truth for NVIDIA_VISIBLE_DEVICES keeps the
+			// per-card boundary intact.
 			if useInjectLib && shouldDisableCudaHooksForLocalSidecarClient(tfInfo.Profile) {
 				envList = appendEnvIfMissing(envList, v1.EnvVar{
 					Name:  constants.EnableCudaHooksEnv,
@@ -1200,8 +1202,12 @@ func SetWorkerContainerSpec(
 		workerConfig = &tfv1.WorkerConfig{}
 	}
 
-	// NOTE: need to set environment variable to make all GPUs visible to the worker,
-	// vgpu.rs limiter will limit to specific devices after Pod started
+	// NVIDIA_VISIBLE_DEVICES is intentionally not set here — the hypervisor's
+	// AllocateWorkerDevices in pkg/hypervisor/worker/allocation.go is the single
+	// source of truth (canonical GPU-<hex> for non-partitioned NVIDIA, MIG-<uuid>
+	// kept untouched for partitioned). Pre-setting any value at pod-spec level
+	// would win over device-plugin envs at kubelet merge time and silently
+	// clobber the per-card or per-MIG boundary.
 	container.Name = constants.TFContainerNameWorker
 	container.Image = GetWorkerImage(workloadProfile.GPUVendor, workerConfig.Image)
 	// Shared mode (whole-card dedicated) has no limiter and no per-pod
@@ -1249,17 +1255,14 @@ func SetWorkerContainerSpec(
 			},
 		},
 	})
-	if shouldInjectNvidiaVisibleDevices(workloadProfile.GPUVendor) {
-		// Soft / hard isolation: let device plugin set NVIDIA_VISIBLE_DEVICES to the allocated GPU UUID.
-		// Partitioned / shared: expose all GPUs (no per-device restriction at this layer).
-		if workloadProfile.Isolation != tfv1.IsolationModeSoft &&
-			workloadProfile.Isolation != tfv1.IsolationModeHard {
-			container.Env = append(container.Env, v1.EnvVar{
-				Name:  constants.NvidiaVisibleAllDeviceEnv,
-				Value: constants.NvidiaVisibleAllDeviceValue,
-			})
-		}
-	}
+	// Intentionally do NOT pre-set NVIDIA_VISIBLE_DEVICES on the worker container.
+	// The hypervisor's AllocateWorkerDevices (pkg/hypervisor/worker/allocation.go)
+	// is the single source of truth: it writes the canonical GPU-<hex> UUID list
+	// for soft / hard / shared isolation, and intentionally lets the provider's
+	// MIG-<uuid> from PartitionResult.envVars stick for partitioned mode. Pod-spec
+	// env wins over device-plugin envs at kubelet merge time, so any pre-set
+	// value here would silently clobber the per-card / per-MIG boundary —
+	// including breaking MIG isolation by exposing the parent card.
 
 	// Only soft isolation preloads the open-source vgpu.rs cuda_limiter (reads limits from shm).
 	// Hard mode relies on the closed-source hard limiter that reads TF_CUDA_SM_PERCENT_LIMIT /

--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -392,9 +392,12 @@ func AddTFDefaultClientConfBeforePatch(
 
 	if tfInfo.Profile.IsLocalGPU {
 		// Local mode mounts shared data path for worker-hypervisor communication.
-		// Partitioned (MIG) doesn't need it — hardware isolation, no limiter/worker
-		// reads from this hostPath. Skip the volume so the pod spec stays clean.
-		if tfInfo.Profile.Isolation != tfv1.IsolationModePartitioned {
+		// Partitioned (MIG) and shared (whole-card) don't need it — neither has
+		// a limiter or worker that reads this hostPath. Skip the volume so the
+		// pod spec stays clean and we don't leak /run/tensor-fusion into pods
+		// with no consumer.
+		if tfInfo.Profile.Isolation != tfv1.IsolationModePartitioned &&
+			tfInfo.Profile.Isolation != tfv1.IsolationModeShared {
 			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
 				Name: constants.DataVolumeName,
 				VolumeSource: v1.VolumeSource{
@@ -522,12 +525,15 @@ func AddTFDefaultClientConfBeforePatch(
 				// Soft isolation already handled volumes and env in its own block above.
 				continue
 			}
-			if tfInfo.Profile.Isolation == tfv1.IsolationModePartitioned {
-				// Partitioned (MIG) relies on hardware isolation — no limiter, no
-				// worker shm, no hypervisor RPC. Device plugin already sets
-				// NVIDIA_VISIBLE_DEVICES to the MIG UUID, which is everything the
-				// pod actually needs. Skipping the worker-shm mount also avoids
-				// leaking /run/tensor-fusion into a container that has no consumer.
+			if tfInfo.Profile.Isolation == tfv1.IsolationModePartitioned ||
+				tfInfo.Profile.Isolation == tfv1.IsolationModeShared {
+				// Partitioned (MIG/vNPU) relies on hardware isolation; shared
+				// (whole-card) has no isolation at all. Neither needs the
+				// limiter / worker shm or the hypervisor RPC env. Device
+				// plugin or container runtime already exposes the right
+				// device(s) to the pod. Skipping the worker-shm mount also
+				// avoids leaking /run/tensor-fusion into a container that
+				// has no consumer.
 				continue
 			}
 			if useLocalWorkerSidecar {
@@ -1198,14 +1204,20 @@ func SetWorkerContainerSpec(
 	// vgpu.rs limiter will limit to specific devices after Pod started
 	container.Name = constants.TFContainerNameWorker
 	container.Image = GetWorkerImage(workloadProfile.GPUVendor, workerConfig.Image)
-	container.VolumeMounts = append(
-		container.VolumeMounts,
-		v1.VolumeMount{
-			Name:             constants.DataVolumeName,
-			MountPath:        constants.TFDataPath + constants.SharedMemMountSubPath,
-			SubPathExpr:      constants.TFDataPathWorkerExpr,
-			MountPropagation: ptr.To(v1.MountPropagationHostToContainer),
-		})
+	// Shared mode (whole-card dedicated) has no limiter and no per-pod
+	// quota state for the worker to read or write, so the host-backed
+	// /run/tensor-fusion shm is dead weight for it. Skip the mount so the
+	// worker pod's spec stays clean.
+	if workloadProfile.Isolation != tfv1.IsolationModeShared {
+		container.VolumeMounts = append(
+			container.VolumeMounts,
+			v1.VolumeMount{
+				Name:             constants.DataVolumeName,
+				MountPath:        constants.TFDataPath + constants.SharedMemMountSubPath,
+				SubPathExpr:      constants.TFDataPathWorkerExpr,
+				MountPropagation: ptr.To(v1.MountPropagationHostToContainer),
+			})
+	}
 	container.Env = append(container.Env, v1.EnvVar{
 		Name: constants.HypervisorIPEnv,
 		ValueFrom: &v1.EnvVarSource{
@@ -1379,16 +1391,20 @@ func AddWorkerConfAfterTemplate(
 		applyProviderRemoteWorkerConfig(spec, workloadProfile.GPUVendor)
 	}
 
-	// Add volume from host for CUDA hot migration and snapshot
-	spec.Volumes = append(spec.Volumes, v1.Volume{
-		Name: constants.DataVolumeName,
-		VolumeSource: v1.VolumeSource{
-			HostPath: &v1.HostPathVolumeSource{
-				Path: constants.TFDataPath,
-				Type: ptr.To(v1.HostPathDirectoryOrCreate),
+	// Add volume from host for CUDA hot migration and snapshot.
+	// Shared (whole-card) workers don't read or write this shm, so skip the
+	// volume to avoid leaking /run/tensor-fusion into the pod spec.
+	if workloadProfile == nil || workloadProfile.Isolation != tfv1.IsolationModeShared {
+		spec.Volumes = append(spec.Volumes, v1.Volume{
+			Name: constants.DataVolumeName,
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: constants.TFDataPath,
+					Type: ptr.To(v1.HostPathDirectoryOrCreate),
+				},
 			},
-		},
-	})
+		})
+	}
 
 	spec.TerminationGracePeriodSeconds = constants.GracefulPeriodSeconds
 	applyAscendRuntimeClassIfNeeded(spec, workloadProfile)

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -248,7 +248,13 @@ var _ = Describe("Compose Utils", func() {
 			value, found := envValue(pod.Spec.Containers[0].Env, constants.ContainerNameEnv)
 			Expect(found).To(BeTrue())
 			Expect(value).To(Equal("main"))
-			Expect(hasNvidiaVisibleEnv(pod.Spec.Containers[0].Env)).To(BeTrue())
+			// NVIDIA_VISIBLE_DEVICES must NOT be pre-set by the webhook for hard
+			// local sidecar pods. The TF device plugin's Allocate response is the
+			// single source of truth and will populate the specific GPU UUID; a
+			// pod-spec `=all` would override that at kubelet merge time and let
+			// the client container reach every GPU on the node, bypassing the
+			// sidecar limiter's per-card boundary.
+			Expect(hasNvidiaVisibleEnv(pod.Spec.Containers[0].Env)).To(BeFalse())
 			cudaHooksValue, found := envValue(pod.Spec.Containers[0].Env, constants.EnableCudaHooksEnv)
 			Expect(found).To(BeTrue())
 			Expect(cudaHooksValue).To(Equal("false"))
@@ -542,6 +548,23 @@ var _ = Describe("Compose Utils", func() {
 				"infinity",
 			}, false, false),
 			Entry("worker without nvidia visible env for Ascend", "Ascend", "worker:latest", "", false, tfv1.IsolationModeType(tfv1.IsolationModeHard), []string{
+				"./tensor-fusion-worker",
+				"-p",
+				"8000",
+			}, false, false),
+			// Regression: SetWorkerContainerSpec used to inject =all for any
+			// non-soft non-hard isolation, which silently overrode the MIG-<uuid>
+			// the NVIDIA provider returned in PartitionResult.envVars (pod-spec
+			// env wins over device-plugin envs at kubelet merge time). That
+			// would expose the parent card and break MIG isolation. Hold the
+			// line: partitioned worker container must NOT have NVIDIA_VISIBLE_DEVICES
+			// pre-set; the device plugin Allocate response is the only writer.
+			Entry("partitioned worker: no NVIDIA_VISIBLE_DEVICES=all (device plugin keeps MIG-<uuid>)", "NVIDIA", "worker:latest", "", false, tfv1.IsolationModeType(tfv1.IsolationModePartitioned), []string{
+				"./tensor-fusion-worker",
+				"-p",
+				"8000",
+			}, false, false),
+			Entry("shared worker: no NVIDIA_VISIBLE_DEVICES=all (device plugin writes specific UUID)", "NVIDIA", "worker:latest", "", false, tfv1.IsolationModeType(tfv1.IsolationModeShared), []string{
 				"./tensor-fusion-worker",
 				"-p",
 				"8000",

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Compose Utils", func() {
 			Expect(cudaHooksValue).To(Equal("false"))
 		})
 
-		It("should keep local shared mode as embedded worker", func() {
+		It("should keep local shared mode as embedded worker without tf-data shm", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
 				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
@@ -269,11 +269,14 @@ var _ = Describe("Compose Utils", func() {
 
 			Expect(pod.Spec.InitContainers).To(BeEmpty())
 			Expect(pod.Spec.Containers).To(HaveLen(1))
+			// Shared mode has no limiter and no worker process, so the
+			// hypervisor shm has no consumer in the pod. Skip the mount to
+			// avoid leaking /run/tensor-fusion into pods that don't use it.
 			Expect(hasVolumeMount(
 				pod.Spec.Containers[0].VolumeMounts,
 				constants.DataVolumeName,
 				constants.TFDataPath+constants.SharedMemMountSubPath,
-			)).To(BeTrue())
+			)).To(BeFalse())
 			Expect(hasVolumeMount(
 				pod.Spec.Containers[0].VolumeMounts,
 				constants.TFLibsVolumeName,


### PR DESCRIPTION
## Summary

Two follow-ups to #664. Both address cases where the webhook silently
broke the per-card / per-MIG boundary the device plugin was supposed
to enforce.

### 1. `refactor(operator): extend tf-data shm skip to shared isolation`

#664 already skipped the host `/run/tensor-fusion` shm mount for
partitioned (MIG / vNPU) pods because hardware isolation has no
limiter or worker that reads it. Shared (whole-card dedicated) is in
the same boat — no limiter, no worker process, no per-pod quota
state — so the mount is also dead weight there. Drop it for both
local-shared client pods and remote-shared worker pods.

Four call sites updated:
- `AddTFDefaultClientConfBeforePatch` pod-level Volume add
- `AddTFDefaultClientConfBeforePatch` container-level loop body
- `SetWorkerContainerSpec` worker container VolumeMount
- `AddWorkerConfAfterTemplate` spec-level Volume

Soft / hard still mount shm (limiter / sidecar reads it). Partitioned
and shared remain mount-free.

### 2. `fix(operator): stop pre-setting NVIDIA_VISIBLE_DEVICES on user pods`

Pod-spec env wins over device-plugin envs at kubelet merge time. The
webhook used to inject `NVIDIA_VISIBLE_DEVICES=all` on:
- any client / remote pod that needed the inject-lib bootstrap (hard
  local sidecar reaches this path), and
- any worker pod whose isolation was not soft and not hard (i.e.
  partitioned and shared).

Both clobber the device plugin's per-card or per-MIG response:

* Confirmed on tf-dev that a hard-local pod assigned a single
  RTX 3090 ended up with both `/dev/nvidia0` and `/dev/nvidia1`
  visible because the webhook's `=all` won over Allocate's
  single-GPU UUID.
* For partitioned (MIG), the hypervisor's `AllocateWorkerDevices` in
  `pkg/hypervisor/worker/allocation.go` intentionally keeps the
  provider's `MIG-<uuid>` from `PartitionResult.envVars` and refuses
  to canonicalize it to the parent UUID
  (`allocation.go:107` + `allocation_test.go:69` both assert this).
  A pre-set `=all` on the worker container would still win at kubelet
  merge time and silently break MIG isolation by exposing the whole
  parent card. Even though partitioned is conceptually local-only,
  `internal/webhook/v1/tf_parser.go` does not enforce that, so this
  is not strictly dead code.

Drop both injections; let `AllocateWorkerDevices` (or the device
plugin Allocate for client pods) be the single writer. Hypervisor
pods (`composeHypervisorContainer`) intentionally keep `=all` —
they are node-level managers and need every GPU.

Updates the matching unit tests:
- `should inject worker sidecar in local hard mode` now asserts the
  env is absent at webhook time
- New `SetWorkerContainerSpec` table entries for partitioned + shared
  worker pods explicitly assert no `NVIDIA_VISIBLE_DEVICES` is set,
  to prevent regression

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/utils/... ./pkg/hypervisor/worker/...` all pass
- [x] tf-dev cluster, NVIDIA shared remote: client pod no longer has
      `NVIDIA_VISIBLE_DEVICES=all`; worker pod gets specific GPU UUID
      from `AllocateWorkerDevices`
- [x] tf-dev cluster, hard local sidecar: client container no longer
      gets `=all`; only the assigned UUID is visible
- [x] tf-dev cluster, NVIDIA partitioned (MIG) on NEO from #664 still
      works — `AllocateWorkerDevices` writes `MIG-<uuid>` and the
      webhook no longer clobbers it

## Out of scope

- Validating that partitioned isolation is local-only at the webhook
  layer (`tf_parser.go:200`). Today the operator just relies on the
  partition controller path being local-only. Worth a follow-up but
  not needed for this fix.
- Auto-injecting Ascend `LD_LIBRARY_PATH` on local partitioned
  workload pods (Ascend Container Runtime quirk). Discussed offline,
  decided to keep using the per-yaml manual env for now.