### PR TITLE
fix(gpupool): extract pod preparation logic for defragmentation

### DIFF
--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -548,10 +548,7 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 	budget map[string]*nodeBudget,
 	maxWorkerPerNode int,
 ) (bool, error) {
-	podCopy := pod.DeepCopy()
-	// Clear source-node hints before asking the scheduler for placement.
-	podCopy.Spec.NodeName = ""
-	podCopy.Status.NominatedNodeName = ""
+	podCopy := prepareDefragSimulationPod(pod)
 
 	fwkInstance := r.Scheduler.Profiles[podCopy.Spec.SchedulerName]
 	if fwkInstance == nil {
@@ -668,6 +665,20 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 	nb.nodeInfo = best.nodeInfo
 	nb.workerCount++
 	return true, nil
+}
+
+func prepareDefragSimulationPod(pod *corev1.Pod) *corev1.Pod {
+	podCopy := pod.DeepCopy()
+
+	// Clear source-node and assigned-GPU state before asking the scheduler
+	// whether this worker can be placed somewhere else.
+	podCopy.Spec.NodeName = ""
+	podCopy.Status.NominatedNodeName = ""
+	if podCopy.Annotations != nil {
+		delete(podCopy.Annotations, constants.GPUDeviceIDsAnnotation)
+		delete(podCopy.Annotations, constants.ContainerGPUsAnnotation)
+	}
+	return podCopy
 }
 
 func canFitVirtualNodeResources(nodeInfo fwk.NodeInfo, pod *corev1.Pod) bool {

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -318,6 +318,51 @@ func TestGetDefragConfig(t *testing.T) {
 	}
 }
 
+func TestPrepareDefragSimulationPod_ClearsAssignedGPUState(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "worker-1",
+			Annotations: map[string]string{
+				constants.GPUDeviceIDsAnnotation:  "gpu-source",
+				constants.ContainerGPUsAnnotation: `{"tensorfusion-worker":["gpu-source"]}`,
+				constants.GpuCountAnnotation:      "1",
+				constants.GpuPoolKey:              "pool-a",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "source-node",
+		},
+		Status: corev1.PodStatus{
+			NominatedNodeName: "source-node",
+		},
+	}
+
+	got := prepareDefragSimulationPod(pod)
+
+	if got == pod {
+		t.Fatalf("expected a deep copy, got original pointer")
+	}
+	if got.Spec.NodeName != "" {
+		t.Fatalf("Spec.NodeName=%q, want empty for simulation", got.Spec.NodeName)
+	}
+	if got.Status.NominatedNodeName != "" {
+		t.Fatalf("Status.NominatedNodeName=%q, want empty for simulation", got.Status.NominatedNodeName)
+	}
+	if _, exists := got.Annotations[constants.GPUDeviceIDsAnnotation]; exists {
+		t.Fatalf("assigned GPU ids annotation should be cleared: %+v", got.Annotations)
+	}
+	if _, exists := got.Annotations[constants.ContainerGPUsAnnotation]; exists {
+		t.Fatalf("container GPU assignment annotation should be cleared: %+v", got.Annotations)
+	}
+	if got.Annotations[constants.GpuCountAnnotation] != "1" {
+		t.Fatalf("gpu count request annotation was not preserved: %+v", got.Annotations)
+	}
+	if pod.Annotations[constants.GPUDeviceIDsAnnotation] == "" {
+		t.Fatalf("original pod annotations were mutated")
+	}
+}
+
 func TestCanFitVirtualNodeResources_RejectsOversubscribedCPU(t *testing.T) {
 	nodeInfo := newFrameworkNodeInfo(
 		"node-b",

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -435,7 +435,7 @@ func TestRunDefrag_PersistsLastDefragTimeWhenRunContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	pool := newDefragTestPool("pool-a", "30m")
+	pool := newDefragTestPool()
 	r, kubeClient := newDefragControllerTestReconciler(t, pool)
 	runStart := time.Now().Add(-time.Minute).Round(time.Second)
 
@@ -454,7 +454,7 @@ func TestRunDefrag_PersistsLastDefragTimeWhenRunContextCanceled(t *testing.T) {
 }
 
 func TestDefragStaleLabelCleanupTick_ScopedToPool(t *testing.T) {
-	pool := newDefragTestPool("pool-a", "30m")
+	pool := newDefragTestPool()
 	staleSince := time.Now().Add(-2 * time.Hour)
 
 	nodeA := newDefragDrainingNode("node-a", "pool-a", staleSince)
@@ -481,7 +481,7 @@ func TestDefragStaleLabelCleanupTick_ScopedToPool(t *testing.T) {
 }
 
 func TestDefragStaleLabelCleanupTick_UsesGPUNodePoolWhenNodePoolLabelMissing(t *testing.T) {
-	pool := newDefragTestPool("pool-a", "30m")
+	pool := newDefragTestPool()
 	staleSince := time.Now().Add(-2 * time.Hour)
 
 	node := newDefragDrainingNodeWithoutPoolLabel("node-a", staleSince)
@@ -500,7 +500,7 @@ func TestDefragStaleLabelCleanupTick_UsesGPUNodePoolWhenNodePoolLabelMissing(t *
 }
 
 func TestDefragDrainWatcherTick_ScopedToPool(t *testing.T) {
-	pool := newDefragTestPool("pool-a", "30m")
+	pool := newDefragTestPool()
 	nodeB := newDefragDrainingNode("node-b", "pool-b", time.Now().Add(-10*time.Minute))
 
 	r, kubeClient := newDefragControllerTestReconciler(t, pool, nodeB)
@@ -518,7 +518,7 @@ func TestDefragDrainWatcherTick_ScopedToPool(t *testing.T) {
 }
 
 func TestDefragDrainWatcherTick_UsesGPUNodePoolWhenNodePoolLabelMissing(t *testing.T) {
-	pool := newDefragTestPool("pool-a", "30m")
+	pool := newDefragTestPool()
 	node := newDefragDrainingNodeWithoutPoolLabel("node-a", time.Now().Add(-10*time.Minute))
 	gpuNode := newDefragGPUNode("node-a", "pool-a")
 
@@ -654,16 +654,16 @@ func newDefragControllerTestReconciler(
 	}, kubeClient
 }
 
-func newDefragTestPool(name, maxDuration string) *tfv1.GPUPool {
+func newDefragTestPool() *tfv1.GPUPool {
 	return &tfv1.GPUPool{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-a"},
 		Spec: tfv1.GPUPoolSpec{
 			NodeManagerConfig: &tfv1.NodeManagerConfig{
 				NodeCompaction: &tfv1.NodeCompaction{
 					Defrag: &tfv1.NodeDefragConfig{
 						Enabled:     true,
 						Schedule:    "0 3 * * *",
-						MaxDuration: maxDuration,
+						MaxDuration: "30m",
 					},
 				},
 			},


### PR DESCRIPTION
- Introduced `prepareDefragSimulationPod` function to encapsulate pod preparation steps, including clearing node assignments and GPU annotations.
- Simplified the `placeSinglePod` method by replacing direct pod manipulation with the new helper function, enhancing code readability and maintainability.