### PR TITLE
fix: concurrency and nil-safety bugs across server / scheduler / autoscaler / metrics

### DIFF
--- a/internal/autoscaler/autoscaler.go
+++ b/internal/autoscaler/autoscaler.go
@@ -174,22 +174,31 @@ func (s *Autoscaler) loadWorkloads(ctx context.Context) {
 	log.Info("workloads loaded", "workloadCount", len(s.workloads))
 }
 
-func (s *Autoscaler) processSingleWorkload(ctx context.Context, workload *workload.State) {
+func (s *Autoscaler) processSingleWorkload(ctx context.Context, state *workload.State) {
 	log := log.FromContext(ctx)
-	recommendation, err := recommender.GetRecommendation(ctx, workload, s.recommenders)
+
+	// Snapshot once per tick so all recommenders observe the same Spec/Status
+	// and the read paths cannot race with UpdateWorkloadState / AddSample.
+	view := state.Snapshot()
+
+	recommendation, intents, err := recommender.GetRecommendation(ctx, view, s.recommenders)
 	if err != nil {
-		log.Error(err, "failed to get recommendation", "workload", workload.Name)
+		log.Error(err, "failed to get recommendation", "workload", view.Name)
 		return
 	}
 
-	if workload.IsAutoSetResourcesEnabled() {
-		if err := s.workloadHandler.ApplyRecommendationToWorkload(ctx, workload, recommendation); err != nil {
-			log.Error(err, "failed to apply recommendation to workload", "workload", workload.Name)
+	// Merge recommender side-effects (status conditions, active cron rule)
+	// back into State.Status under State.Mu.
+	state.ApplyIntents(intents)
+
+	if view.IsAutoSetResourcesEnabled() {
+		if err := s.workloadHandler.ApplyRecommendationToWorkload(ctx, state, recommendation); err != nil {
+			log.Error(err, "failed to apply recommendation to workload", "workload", view.Name)
 		}
 	}
 
-	if err := s.workloadHandler.UpdateWorkloadStatus(ctx, workload, recommendation); err != nil {
-		log.Error(err, "failed to update workload status", "workload", workload.Name)
+	if err := s.workloadHandler.UpdateWorkloadStatus(ctx, state, recommendation); err != nil {
+		log.Error(err, "failed to update workload status", "workload", view.Name)
 	}
 }
 

--- a/internal/autoscaler/autoscaler_test.go
+++ b/internal/autoscaler/autoscaler_test.go
@@ -170,10 +170,10 @@ var _ = Describe("Autoscaler", func() {
 
 			scalerWorkers := ws.WorkerUsageSamplers
 			Expect(scalerWorkers[worker.Name].LastTflopsSampleTime).To(Equal(usage.Timestamp))
-			Expect(ws.WorkerUsageAggregator.TflopsHistogram.IsEmpty()).To(BeFalse())
+			Expect(ws.WorkerUsageAggregator.TflopsIsEmpty()).To(BeFalse())
 			Expect(scalerWorkers[worker.Name].VramPeak).To(Equal(usage.VramUsage))
 			Expect(scalerWorkers[worker.Name].LastVramSampleTime).To(Equal(usage.Timestamp))
-			Expect(ws.WorkerUsageAggregator.VramHistogram.IsEmpty()).To(BeFalse())
+			Expect(ws.WorkerUsageAggregator.VramIsEmpty()).To(BeFalse())
 			usage = &metrics.WorkerUsage{
 				Namespace:    workload.Namespace,
 				WorkloadName: workload.Name,
@@ -189,7 +189,7 @@ var _ = Describe("Autoscaler", func() {
 			Expect(scalerWorkers[worker.Name].LastTflopsSampleTime).To(Equal(usage.Timestamp))
 			Expect(scalerWorkers[worker.Name].VramPeak).To(Equal(usage.VramUsage))
 			Expect(scalerWorkers[worker.Name].LastVramSampleTime).To(Equal(usage.Timestamp))
-			Expect(ws.WorkerUsageAggregator.TotalSamplesCount).To(Equal(2))
+			Expect(ws.WorkerUsageAggregator.TotalSamplesCount()).To(Equal(2))
 		})
 	})
 
@@ -458,7 +458,7 @@ var _ = Describe("Autoscaler", func() {
 			scaler.loadWorkloads(testCtx)
 			workloadState = scaler.workloads[key]
 
-			got, err := workloadHandler.GetMaxAllowedResourcesSpec(workloadState)
+			got, err := workloadHandler.GetMaxAllowedResourcesSpec(workloadState.Snapshot())
 			Expect(err).To(Succeed())
 			Expect(got.Tflops.Value()).To(Equal(allTflops))
 			Expect(got.Vram.Value()).To(Equal(allVram))
@@ -476,7 +476,7 @@ var _ = Describe("Autoscaler", func() {
 			workloadState, exists = scaler.workloads[key]
 			Expect(exists).To(BeTrue())
 			Expect(workloadState).ToNot(BeNil())
-			got, err = workloadHandler.GetMaxAllowedResourcesSpec(workloadState)
+			got, err = workloadHandler.GetMaxAllowedResourcesSpec(workloadState.Snapshot())
 			Expect(err).To(Succeed())
 			Expect(got.Tflops.Value()).To(Equal(allTflops / 2))
 			Expect(got.Vram.Value()).To(Equal(allVram / 2))
@@ -492,7 +492,7 @@ var _ = Describe("Autoscaler", func() {
 			// because WorkerCount == 0, so GetMaxAllowedResourcesSpec should return nil
 			workloadState = scaler.workloads[key]
 			if workloadState != nil {
-				got, err = workloadHandler.GetMaxAllowedResourcesSpec(workloadState)
+				got, err = workloadHandler.GetMaxAllowedResourcesSpec(workloadState.Snapshot())
 				// If workload still exists but has no workers, it should return nil
 				if err == nil {
 					Expect(got).To(BeNil())
@@ -676,16 +676,18 @@ func (f *FakeRecommender) Name() string {
 	return "fake"
 }
 
-func (f *FakeRecommender) Recommend(ctx context.Context, workload *workload.State) (*recommender.RecResult, error) {
-	meta.SetStatusCondition(&workload.Status.Conditions, metav1.Condition{
-		Type:               constants.ConditionStatusTypeRecommendationProvided,
-		Status:             metav1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Reason:             "FakeReason",
-		Message:            "Fake message",
-	})
+func (f *FakeRecommender) Recommend(ctx context.Context, view *workload.StateView) (*recommender.RecResult, error) {
 	return &recommender.RecResult{
 		Resources: *f.Resources,
+		Intent: workload.Intent{
+			Condition: &metav1.Condition{
+				Type:               constants.ConditionStatusTypeRecommendationProvided,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "FakeReason",
+				Message:            "Fake message",
+			},
+		},
 	}, nil
 }
 

--- a/internal/autoscaler/metrics/metrics_aggregator.go
+++ b/internal/autoscaler/metrics/metrics_aggregator.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"sync"
 	"time"
 
 	vpa "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util"
@@ -18,44 +19,109 @@ const (
 	DefaultHistogramBucketSizeGrowth = 0.05 // Make each bucket 5% larger than the previous one.
 )
 
+// WorkerUsageAggregator owns the per-workload tflops/vram histograms.
+//
+// It is shared between the metrics-loader goroutines (which call AddTflopsSample /
+// AddVramSample / SubtractVramSample) and the autoscaler recommender path
+// (which reads via TflopsPercentile / VramPercentile / IsEmpty). The internal
+// mu serializes those, so callers no longer need to hold State.Mu while
+// reading the histograms.
 type WorkerUsageAggregator struct {
-	TflopsHistogram   vpa.Histogram
-	VramHistogram     vpa.Histogram
-	FirstSampleStart  time.Time
-	LastSampleStart   time.Time
-	TotalSamplesCount int
+	mu                sync.RWMutex
+	tflopsHistogram   vpa.Histogram
+	vramHistogram     vpa.Histogram
+	firstSampleStart  time.Time
+	lastSampleStart   time.Time
+	totalSamplesCount int
 }
 
 func NewWorkerUsageAggregator(decayHalfTime time.Duration) *WorkerUsageAggregator {
 	return &WorkerUsageAggregator{
-		TflopsHistogram: vpa.NewDecayingHistogram(histogramOptions(10000.0, 0.1), decayHalfTime),
-		VramHistogram:   vpa.NewDecayingHistogram(histogramOptions(1e12, 1e7), decayHalfTime),
+		tflopsHistogram: vpa.NewDecayingHistogram(histogramOptions(10000.0, 0.1), decayHalfTime),
+		vramHistogram:   vpa.NewDecayingHistogram(histogramOptions(1e12, 1e7), decayHalfTime),
 	}
 }
 
 func (w *WorkerUsageAggregator) IsEmpty() bool {
-	return w.TflopsHistogram.IsEmpty() && w.VramHistogram.IsEmpty()
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.tflopsHistogram.IsEmpty() && w.vramHistogram.IsEmpty()
+}
+
+// TflopsIsEmpty reports whether the tflops histogram has no recorded samples.
+func (w *WorkerUsageAggregator) TflopsIsEmpty() bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.tflopsHistogram.IsEmpty()
+}
+
+// VramIsEmpty reports whether the vram histogram has no recorded samples.
+func (w *WorkerUsageAggregator) VramIsEmpty() bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.vramHistogram.IsEmpty()
+}
+
+// TflopsPercentile returns the requested percentile from the tflops histogram.
+func (w *WorkerUsageAggregator) TflopsPercentile(percentile float64) float64 {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.tflopsHistogram.Percentile(percentile)
+}
+
+// VramPercentile returns the requested percentile from the vram histogram.
+func (w *WorkerUsageAggregator) VramPercentile(percentile float64) float64 {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.vramHistogram.Percentile(percentile)
+}
+
+// FirstSampleStart returns the timestamp of the earliest seen sample.
+func (w *WorkerUsageAggregator) FirstSampleStart() time.Time {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.firstSampleStart
+}
+
+// LastSampleStart returns the timestamp of the latest seen sample.
+func (w *WorkerUsageAggregator) LastSampleStart() time.Time {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.lastSampleStart
+}
+
+// TotalSamplesCount returns the number of samples ingested so far.
+func (w *WorkerUsageAggregator) TotalSamplesCount() int {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.totalSamplesCount
 }
 
 func (w *WorkerUsageAggregator) AddTflopsSample(sample *WorkerUsage) bool {
-	w.TflopsHistogram.AddSample(float64(sample.TflopsUsage), minSampleWeight, sample.Timestamp)
-	if sample.Timestamp.After(w.LastSampleStart) {
-		w.LastSampleStart = sample.Timestamp
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.tflopsHistogram.AddSample(float64(sample.TflopsUsage), minSampleWeight, sample.Timestamp)
+	if sample.Timestamp.After(w.lastSampleStart) {
+		w.lastSampleStart = sample.Timestamp
 	}
-	if w.FirstSampleStart.IsZero() || sample.Timestamp.Before(w.FirstSampleStart) {
-		w.FirstSampleStart = sample.Timestamp
+	if w.firstSampleStart.IsZero() || sample.Timestamp.Before(w.firstSampleStart) {
+		w.firstSampleStart = sample.Timestamp
 	}
-	w.TotalSamplesCount++
+	w.totalSamplesCount++
 	return true
 }
 
 func (w *WorkerUsageAggregator) AddVramSample(sample *WorkerUsage) bool {
-	w.VramHistogram.AddSample(float64(sample.VramUsage), 1.0, sample.Timestamp)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.vramHistogram.AddSample(float64(sample.VramUsage), 1.0, sample.Timestamp)
 	return true
 }
 
 func (w *WorkerUsageAggregator) SubtractVramSample(usage float64, time time.Time) bool {
-	w.VramHistogram.SubtractSample(usage, 1.0, time)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.vramHistogram.SubtractSample(usage, 1.0, time)
 	return true
 }
 

--- a/internal/autoscaler/recommender/cron_recommender.go
+++ b/internal/autoscaler/recommender/cron_recommender.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/workload"
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
 	"github.com/robfig/cron/v3"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -30,13 +29,13 @@ func (c *CronRecommender) Name() string {
 	return "cron"
 }
 
-func (c *CronRecommender) Recommend(ctx context.Context, w *workload.State) (*RecResult, error) {
-	activeRule, err := c.getActiveCronScalingRule(&w.Spec.AutoScalingConfig)
+func (c *CronRecommender) Recommend(ctx context.Context, view *workload.StateView) (*RecResult, error) {
+	activeRule, err := c.getActiveCronScalingRule(&view.Spec.AutoScalingConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get active cron scaling rule %w", err)
 	}
 
-	currentRule := w.Status.ActiveCronScalingRule
+	currentRule := view.Status.ActiveCronScalingRule
 
 	if activeRule == nil && currentRule == nil {
 		return nil, nil
@@ -46,22 +45,22 @@ func (c *CronRecommender) Recommend(ctx context.Context, w *workload.State) (*Re
 	var reason, message string
 	if activeRule == nil {
 		// Revert the resources to those specified in the workload spec
-		recommendation = *w.GetOriginalResourcesSpec()
+		recommendation = *view.GetOriginalResourcesSpec()
 		reason = "RuleInactive"
 		message = fmt.Sprintf("Cron scaling rule %q is inactive", currentRule.Name)
 		log.FromContext(ctx).Info("cron scaling rule inactive",
-			"rule", currentRule.Name, "workload", w.Name, "resources", recommendation)
+			"rule", currentRule.Name, "workload", view.Name, "resources", recommendation)
 	} else {
 		recommendation = activeRule.DesiredResources
 		if currentRule == nil || !recommendation.Equal(&currentRule.DesiredResources) {
 			reason = "RuleActive"
 			message = fmt.Sprintf("Cron scaling rule %q is active", activeRule.Name)
 			log.FromContext(ctx).Info("cron scaling rule active",
-				"rule", activeRule.Name, "workload", w.Name, "resources", recommendation)
+				"rule", activeRule.Name, "workload", view.Name, "resources", recommendation)
 			if c.recommendationProcessor != nil {
 				var err error
 				var msg string
-				recommendation, msg, err = c.recommendationProcessor.Apply(ctx, w, &recommendation)
+				recommendation, msg, err = c.recommendationProcessor.Apply(ctx, view, &recommendation)
 				if err != nil {
 					return nil, fmt.Errorf("failed to apply recommendation processor: %v", err)
 				}
@@ -73,22 +72,27 @@ func (c *CronRecommender) Recommend(ctx context.Context, w *workload.State) (*Re
 		}
 	}
 
-	if len(reason) > 0 {
-		w.Status.ActiveCronScalingRule = activeRule.DeepCopy()
-		meta.SetStatusCondition(&w.Status.Conditions, metav1.Condition{
-			Type:               constants.ConditionStatusTypeRecommendationProvided,
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             reason,
-			Message:            message,
-		})
-	}
-
-	return &RecResult{
+	result := &RecResult{
 		Resources:        recommendation,
 		HasApplied:       len(reason) == 0,
 		ScaleDownLocking: true,
-	}, nil
+	}
+
+	if len(reason) > 0 {
+		result.Intent = workload.Intent{
+			Condition: &metav1.Condition{
+				Type:               constants.ConditionStatusTypeRecommendationProvided,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             reason,
+				Message:            message,
+			},
+			SetActiveCronRule: true,
+			ActiveCronRule:    activeRule.DeepCopy(),
+		}
+	}
+
+	return result, nil
 }
 
 func (c *CronRecommender) getActiveCronScalingRule(config *tfv1.AutoScalingConfig) (*tfv1.CronScalingRule, error) {

--- a/internal/autoscaler/recommender/cron_recommender_test.go
+++ b/internal/autoscaler/recommender/cron_recommender_test.go
@@ -70,7 +70,7 @@ var _ = Describe("CronRecommender", func() {
 		})
 
 		It("should return recResult with correct fields if the active cron scaling rule remains unchanged", func() {
-			recResult, _ := recommender.Recommend(ctx, ws)
+			recResult, _ := recommender.Recommend(ctx, ws.Snapshot())
 			Expect(recResult).ToNot(BeNil())
 			Expect(recResult.HasApplied).To(BeTrue())
 			Expect(recResult.ScaleDownLocking).To(BeTrue())
@@ -95,16 +95,17 @@ var _ = Describe("CronRecommender", func() {
 				CronScalingRules: []tfv1.CronScalingRule{*activeRule},
 			}
 
-			recResult, _ := recommender.Recommend(ctx, ws)
+			recResult, _ := recommender.Recommend(ctx, ws.Snapshot())
 			Expect(recResult.Resources.Equal(&ws.Spec.Resources)).To(BeTrue())
 			Expect(recResult.HasApplied).To(BeFalse())
 			Expect(recResult.ScaleDownLocking).To(BeTrue())
+			ws.ApplyIntents([]workload.Intent{recResult.Intent})
 			Expect(ws.Status.ActiveCronScalingRule).To(BeNil())
 			condition := meta.FindStatusCondition(ws.Status.Conditions, constants.ConditionStatusTypeRecommendationProvided)
 			expectedMsg := fmt.Sprintf("Cron scaling rule %q is inactive", activeRule.Name)
 			Expect(condition.Message).To(Equal(expectedMsg))
 
-			recResult, _ = recommender.Recommend(ctx, ws)
+			recResult, _ = recommender.Recommend(ctx, ws.Snapshot())
 			Expect(recResult).To(BeNil())
 		})
 
@@ -141,8 +142,9 @@ var _ = Describe("CronRecommender", func() {
 				},
 			}
 			recommender = NewCronRecommender(&fakeRecommendationProcessor{expectRes})
-			recResult, _ := recommender.Recommend(ctx, ws)
+			recResult, _ := recommender.Recommend(ctx, ws.Snapshot())
 			Expect(recResult.Resources.Equal(&expectRes)).To(BeTrue())
+			ws.ApplyIntents([]workload.Intent{recResult.Intent})
 			condition := meta.FindStatusCondition(ws.Status.Conditions, constants.ConditionStatusTypeRecommendationProvided)
 			expectedMsg := fmt.Sprintf("Cron scaling rule %q is active, fake message", activeRule.Name)
 			Expect(condition.Message).To(Equal(expectedMsg))
@@ -168,7 +170,7 @@ var _ = Describe("CronRecommender", func() {
 					},
 				},
 			}
-			_, err := recommender.Recommend(ctx, ws)
+			_, err := recommender.Recommend(ctx, ws.Snapshot())
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -275,13 +277,14 @@ var _ = Describe("CronRecommender", func() {
 
 func verifyCronRecommendationStatus(ctx context.Context, recommender *CronRecommender, w *workload.State, rule *tfv1.CronScalingRule) {
 	GinkgoHelper()
-	recommendation, _ := recommender.Recommend(ctx, w)
+	recommendation, _ := recommender.Recommend(ctx, w.Snapshot())
 	if rule != nil {
 		// verify resource of recommendation
 		Expect(recommendation.Resources.Equal(&rule.DesiredResources)).To(BeTrue())
 		Expect(recommendation.HasApplied).To(BeFalse())
 		Expect(recommendation.ScaleDownLocking).To(BeTrue())
-		// verify workload status
+		// merge recommender intent and verify workload status
+		w.ApplyIntents([]workload.Intent{recommendation.Intent})
 		Expect(equality.Semantic.DeepEqual(w.Status.ActiveCronScalingRule, rule)).To(BeTrue())
 		condition := meta.FindStatusCondition(w.Status.Conditions, constants.ConditionStatusTypeRecommendationProvided)
 		expectedMsg := fmt.Sprintf("Cron scaling rule %q is active", rule.Name)

--- a/internal/autoscaler/recommender/estimator.go
+++ b/internal/autoscaler/recommender/estimator.go
@@ -26,7 +26,7 @@ func NewPercentileVramEstimator(percentile float64) VramEstimator {
 }
 
 func (e *percentileVramEstimator) GetVramEstimation(w *metrics.WorkerUsageAggregator) ResourceAmount {
-	return resourceAmountFromFloat(float64(w.VramHistogram.Percentile(e.percentile)))
+	return resourceAmountFromFloat(w.VramPercentile(e.percentile))
 }
 
 type vramMarginEstimator struct {
@@ -60,7 +60,7 @@ func NewPercentileTflopsEstimator(percentile float64) TflopsEstimator {
 }
 
 func (e *percentileTflopsEstimator) GetTflopsEstimation(w *metrics.WorkerUsageAggregator) ResourceAmount {
-	return resourceAmountFromFloat(float64(w.TflopsHistogram.Percentile(e.percentile)))
+	return resourceAmountFromFloat(w.TflopsPercentile(e.percentile))
 }
 
 type tflopsMarginEstimator struct {

--- a/internal/autoscaler/recommender/external_recommender.go
+++ b/internal/autoscaler/recommender/external_recommender.go
@@ -13,7 +13,6 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/workload"
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,9 +36,9 @@ func (e *ExternalRecommender) Name() string {
 	return "external"
 }
 
-func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *workload.State) (*RecResult, error) {
+func (e *ExternalRecommender) Recommend(ctx context.Context, view *workload.StateView) (*RecResult, error) {
 	log := log.FromContext(ctx)
-	config := workloadState.Spec.AutoScalingConfig.ExternalScaler
+	config := view.Spec.AutoScalingConfig.ExternalScaler
 
 	if config == nil || !config.Enable {
 		return nil, nil
@@ -55,27 +54,29 @@ func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *work
 		}
 	}
 
-	timeSinceCreation := time.Since(workloadState.CreationTimestamp.Time)
+	timeSinceCreation := time.Since(view.CreationTimestamp.Time)
 	if timeSinceCreation < initialDelay {
-		meta.SetStatusCondition(&workloadState.Status.Conditions, metav1.Condition{
-			Type:               constants.ConditionStatusTypeResourceUpdate,
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "LowConfidence",
-			Message:            fmt.Sprintf("Workload created %v ago, less than InitialDelayPeriod %v, no update performed", timeSinceCreation, initialDelay),
-		})
 		return &RecResult{
 			Resources:        tfv1.Resources{},
 			HasApplied:       true,
 			ScaleDownLocking: false,
+			Intent: workload.Intent{
+				Condition: &metav1.Condition{
+					Type:               constants.ConditionStatusTypeResourceUpdate,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "LowConfidence",
+					Message:            fmt.Sprintf("Workload created %v ago, less than InitialDelayPeriod %v, no update performed", timeSinceCreation, initialDelay),
+				},
+			},
 		}, nil
 	}
 
 	// Prepare request
-	curRes := workloadState.GetCurrentResourcesSpec()
+	curRes := view.GetCurrentResourcesSpec()
 	request := tfv1.ExternalScalerRequest{
-		WorkloadName:     workloadState.Name,
-		Namespace:        workloadState.Namespace,
+		WorkloadName:     view.Name,
+		Namespace:        view.Namespace,
 		CurrentResources: *curRes,
 	}
 
@@ -124,17 +125,19 @@ func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *work
 
 	// If no scaling needed, return nil
 	if !response.NeedScaleUp && !response.NeedScaleDown {
-		meta.SetStatusCondition(&workloadState.Status.Conditions, metav1.Condition{
-			Type:               constants.ConditionStatusTypeResourceUpdate,
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "NoScalingNeeded",
-			Message:            response.Reason,
-		})
 		return &RecResult{
 			Resources:        tfv1.Resources{},
 			HasApplied:       true,
 			ScaleDownLocking: false,
+			Intent: workload.Intent{
+				Condition: &metav1.Condition{
+					Type:               constants.ConditionStatusTypeResourceUpdate,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "NoScalingNeeded",
+					Message:            response.Reason,
+				},
+			},
 		}, nil
 	}
 
@@ -147,7 +150,7 @@ func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *work
 	if e.recommendationProcessor != nil {
 		var err error
 		var msg string
-		recommendation, msg, err = e.recommendationProcessor.Apply(ctx, workloadState, &recommendation)
+		recommendation, msg, err = e.recommendationProcessor.Apply(ctx, view, &recommendation)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply recommendation processor: %v", err)
 		}
@@ -157,25 +160,28 @@ func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *work
 	}
 
 	hasApplied := recommendation.Equal(curRes)
+	result := &RecResult{
+		Resources:        recommendation,
+		HasApplied:       hasApplied,
+		ScaleDownLocking: false,
+	}
 	if !hasApplied {
 		reason := "Updated"
 		if response.Reason != "" {
 			reason = response.Reason
 		}
-		meta.SetStatusCondition(&workloadState.Status.Conditions, metav1.Condition{
-			Type:               constants.ConditionStatusTypeResourceUpdate,
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             reason,
-			Message:            fmt.Sprintf("External scaler recommendation: %s", response.Reason),
-		})
+		result.Intent = workload.Intent{
+			Condition: &metav1.Condition{
+				Type:               constants.ConditionStatusTypeResourceUpdate,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             reason,
+				Message:            fmt.Sprintf("External scaler recommendation: %s", response.Reason),
+			},
+		}
 	}
 
-	return &RecResult{
-		Resources:        recommendation,
-		HasApplied:       hasApplied,
-		ScaleDownLocking: false,
-	}, nil
+	return result, nil
 }
 
 func (e *ExternalRecommender) getAPIKey(ctx context.Context, secretRef *corev1.SecretReference) (string, error) {

--- a/internal/autoscaler/recommender/percentile_recommender.go
+++ b/internal/autoscaler/recommender/percentile_recommender.go
@@ -9,7 +9,6 @@ import (
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/workload"
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -64,7 +63,7 @@ var defaultPercentileConfig = PercentileConfig{
 }
 
 type ResourcesEstimator interface {
-	GetResourcesEstimation(*workload.State) *EstimatedResources
+	GetResourcesEstimation(*workload.StateView) *EstimatedResources
 }
 
 type PercentileConfig struct {
@@ -98,11 +97,11 @@ func (p *PercentileRecommender) Name() string {
 	return "percentile"
 }
 
-func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workload.State) (*RecResult, error) {
+func (p *PercentileRecommender) Recommend(ctx context.Context, view *workload.StateView) (*RecResult, error) {
 	log := log.FromContext(ctx)
 
 	// Check InitialDelayPeriod
-	asr := workload.Spec.AutoScalingConfig.AutoSetResources
+	asr := view.Spec.AutoScalingConfig.AutoSetResources
 	if asr == nil {
 		return nil, nil
 	}
@@ -113,7 +112,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 		initialDelay = 30 * time.Minute
 	}
 
-	workloadCreationTime := workload.CreationTimestamp.Time
+	workloadCreationTime := view.CreationTimestamp.Time
 	if workloadCreationTime.IsZero() {
 		// Fallback: use current time if creation timestamp is not set
 		workloadCreationTime = time.Now()
@@ -121,29 +120,31 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 
 	timeSinceCreation := time.Since(workloadCreationTime)
 	if timeSinceCreation < initialDelay {
-		meta.SetStatusCondition(&workload.Status.Conditions, metav1.Condition{
-			Type:               constants.ConditionStatusTypeResourceUpdate,
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "LowConfidence",
-			Message:            fmt.Sprintf("Workload created time less than InitialDelayPeriod %v, no update performed", initialDelay),
-		})
 		return &RecResult{
 			Resources:        tfv1.Resources{},
 			HasApplied:       true,
 			ScaleDownLocking: false,
+			Intent: workload.Intent{
+				Condition: &metav1.Condition{
+					Type:               constants.ConditionStatusTypeResourceUpdate,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "LowConfidence",
+					Message:            fmt.Sprintf("Workload created time less than InitialDelayPeriod %v, no update performed", initialDelay),
+				},
+			},
 		}, nil
 	}
 
-	estimations := p.GetResourcesEstimation(workload)
+	estimations := p.GetResourcesEstimation(view)
 	if estimations == nil {
 		return nil, nil
 	}
 
-	log.V(4).Info("estimated resources", "workload", workload.Name, "estimations", estimations)
+	log.V(4).Info("estimated resources", "workload", view.Name, "estimations", estimations)
 
-	curRes := workload.GetCurrentResourcesSpec()
-	originalRes := workload.GetOriginalResourcesSpec()
+	curRes := view.GetCurrentResourcesSpec()
+	originalRes := view.GetOriginalResourcesSpec()
 	recommendation := tfv1.Resources{}
 	message := ""
 
@@ -158,7 +159,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 		&originalRes.Requests.Tflops,
 		&originalRes.Limits.Tflops,
 		config,
-		workload.Spec.Qos,
+		view.Spec.Qos,
 	); result != nil {
 		message = result.message
 		recommendation.Requests.Tflops = result.targetRequest
@@ -179,7 +180,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 		&originalRes.Requests.Vram,
 		&originalRes.Limits.Vram,
 		config,
-		workload.Spec.Qos,
+		view.Spec.Qos,
 	); result != nil {
 		if len(message) > 0 {
 			message += fmt.Sprintf(", %s", result.message)
@@ -222,18 +223,19 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 
 		// Avoid fluctuation when scale up/down is too small
 		if !shouldUpdate && thresholdMessage != "" {
-			meta.SetStatusCondition(&workload.Status.Conditions, metav1.Condition{
-				Type:               constants.ConditionStatusTypeResourceUpdate,
-				Status:             metav1.ConditionTrue,
-				LastTransitionTime: metav1.Now(),
-				Reason:             "InsideUpdateThreshold",
-				Message:            thresholdMessage + "no update performed",
-			})
-			// Still update recommendation in status
 			return &RecResult{
 				Resources:        recommendation,
 				HasApplied:       false,
 				ScaleDownLocking: false,
+				Intent: workload.Intent{
+					Condition: &metav1.Condition{
+						Type:               constants.ConditionStatusTypeResourceUpdate,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+						Reason:             "InsideUpdateThreshold",
+						Message:            thresholdMessage + "no update performed",
+					},
+				},
 			}, nil
 		}
 	}
@@ -245,7 +247,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 	if p.recommendationProcessor != nil {
 		var err error
 		var msg string
-		recommendation, msg, err = p.recommendationProcessor.Apply(ctx, workload, &recommendation)
+		recommendation, msg, err = p.recommendationProcessor.Apply(ctx, view, &recommendation)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply recommendation processor: %v", err)
 		}
@@ -256,21 +258,24 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 	}
 
 	hasApplied := recommendation.Equal(curRes)
-	if !hasApplied {
-		meta.SetStatusCondition(&workload.Status.Conditions, metav1.Condition{
-			Type:               constants.ConditionStatusTypeResourceUpdate,
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "Updated",
-			Message:            message,
-		})
-	}
-
-	return &RecResult{
+	result := &RecResult{
 		Resources:        recommendation,
 		HasApplied:       hasApplied,
 		ScaleDownLocking: false,
-	}, nil
+	}
+	if !hasApplied {
+		result.Intent = workload.Intent{
+			Condition: &metav1.Condition{
+				Type:               constants.ConditionStatusTypeResourceUpdate,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Updated",
+				Message:            message,
+			},
+		}
+	}
+
+	return result, nil
 }
 
 type scalingResult struct {
@@ -400,13 +405,13 @@ type resourcesEstimator struct {
 	upperBoundVram   VramEstimator
 }
 
-func (r *resourcesEstimator) GetResourcesEstimation(workload *workload.State) *EstimatedResources {
-	aggregator := workload.WorkerUsageAggregator
-	if aggregator.IsEmpty() {
+func (r *resourcesEstimator) GetResourcesEstimation(view *workload.StateView) *EstimatedResources {
+	aggregator := view.Aggregator
+	if aggregator == nil || aggregator.IsEmpty() {
 		return nil
 	}
 	// TODO: cache config
-	asr := workload.Spec.AutoScalingConfig.AutoSetResources
+	asr := view.Spec.AutoScalingConfig.AutoSetResources
 	if asr == nil {
 		return nil
 	}

--- a/internal/autoscaler/recommender/percentile_recommender_test.go
+++ b/internal/autoscaler/recommender/percentile_recommender_test.go
@@ -74,8 +74,9 @@ var _ = Describe("Percentile Recommender", func() {
 
 			ws.Spec.Resources = curRes
 			ws.Status.Recommendation = nil // Use original resources
-			got, _ := recommender.Recommend(ctx, ws)
+			got, _ := recommender.Recommend(ctx, ws.Snapshot())
 			Expect(got).ToNot(BeNil())
+			ws.ApplyIntents([]workload.Intent{got.Intent})
 			// Debug: print actual vs expected if test fails
 			if !got.Resources.Requests.Tflops.Equal(expectRes.Requests.Tflops) {
 				GinkgoWriter.Printf("TFlops request: got %s, expected %s\n", got.Resources.Requests.Tflops.String(), expectRes.Requests.Tflops.String())
@@ -118,8 +119,9 @@ var _ = Describe("Percentile Recommender", func() {
 
 			ws.Spec.Resources = curRes
 			ws.Status.Recommendation = nil // Use original resources
-			got, _ := recommender.Recommend(ctx, ws)
+			got, _ := recommender.Recommend(ctx, ws.Snapshot())
 			Expect(got).ToNot(BeNil())
+			ws.ApplyIntents([]workload.Intent{got.Intent})
 			// Current is 400, target is 200, so we expect scaling down
 			// But due to UpdateThreshold or other constraints, the recommended might equal current
 			// So just check that a recommendation was made and it's reasonable
@@ -151,7 +153,7 @@ var _ = Describe("Percentile Recommender", func() {
 
 			ws.Spec.Resources = curRes
 			ws.Status.Recommendation = nil // Use original resources
-			got, _ := recommender.Recommend(ctx, ws)
+			got, _ := recommender.Recommend(ctx, ws.Snapshot())
 			// Current matches target bounds, so no scaling needed - should return nil
 			// But due to UpdateThreshold or other logic, might still return a result
 			if got != nil {
@@ -190,9 +192,10 @@ var _ = Describe("Percentile Recommender", func() {
 			}
 			ws.Spec.Resources = curRes
 			ws.Status.Recommendation = nil // Ensure we use original resources
-			got, _ := recommender.Recommend(ctx, ws)
+			got, _ := recommender.Recommend(ctx, ws.Snapshot())
 			Expect(got).ToNot(BeNil())
 			Expect(got.Resources.Equal(&expectRes)).To(BeTrue())
+			ws.ApplyIntents([]workload.Intent{got.Intent})
 			condition := meta.FindStatusCondition(ws.Status.Conditions, constants.ConditionStatusTypeResourceUpdate)
 			Expect(condition).ToNot(BeNil())
 			Expect(condition.Message).To(ContainSubstring("Compute scaled"))
@@ -245,6 +248,6 @@ type fakeResourcesEstimator struct {
 	*EstimatedResources
 }
 
-func (f *fakeResourcesEstimator) GetResourcesEstimation(workoad *workload.State) *EstimatedResources {
+func (f *fakeResourcesEstimator) GetResourcesEstimation(view *workload.StateView) *EstimatedResources {
 	return f.EstimatedResources
 }

--- a/internal/autoscaler/recommender/recommendation.go
+++ b/internal/autoscaler/recommender/recommendation.go
@@ -10,7 +10,7 @@ import (
 )
 
 type RecommendationProcessor interface {
-	Apply(ctx context.Context, workload *workload.State, recommendation *tfv1.Resources) (tfv1.Resources, string, error)
+	Apply(ctx context.Context, view *workload.StateView, recommendation *tfv1.Resources) (tfv1.Resources, string, error)
 }
 
 func NewRecommendationProcessor(workloadHandler workload.Handler) RecommendationProcessor {
@@ -23,11 +23,11 @@ type recommendationProcessor struct {
 
 func (r *recommendationProcessor) Apply(
 	ctx context.Context,
-	workload *workload.State,
+	view *workload.StateView,
 	rec *tfv1.Resources) (tfv1.Resources, string, error) {
 	result := *rec
 	msg := ""
-	curRes := workload.GetCurrentResourcesSpec()
+	curRes := view.GetCurrentResourcesSpec()
 
 	isScaleUpTflops := curRes.Requests.Tflops.Cmp(rec.Requests.Tflops) < 0
 	isScaleUpVram := curRes.Requests.Vram.Cmp(rec.Requests.Vram) < 0
@@ -36,11 +36,11 @@ func (r *recommendationProcessor) Apply(
 	}
 
 	// Get max allowed considering the node with min available resources
-	allowedRes, err := r.workloadHandler.GetMaxAllowedResourcesSpec(workload)
+	allowedRes, err := r.workloadHandler.GetMaxAllowedResourcesSpec(view)
 	if err != nil || allowedRes == nil {
 		return result, msg, err
 	}
-	log.FromContext(ctx).V(4).Info("fetched max allowed resources", "workload", workload.Name, "resources", allowedRes)
+	log.FromContext(ctx).V(4).Info("fetched max allowed resources", "workload", view.Name, "resources", allowedRes)
 
 	if isScaleUpTflops && rec.Requests.Tflops.Cmp(allowedRes.Tflops) > 0 {
 		result.Requests.Tflops = allowedRes.Tflops

--- a/internal/autoscaler/recommender/recommendation_test.go
+++ b/internal/autoscaler/recommender/recommendation_test.go
@@ -116,9 +116,9 @@ var _ = Describe("Recommender", func() {
 			Tflops: resource.MustParse("100"),
 			Vram:   resource.MustParse("100Gi"),
 		}
-		workload := workload.NewWorkloadState()
+		ws := workload.NewWorkloadState()
 		// Set current resources to be less than recommendation to trigger scale-up check
-		workload.Spec.Resources = tfv1.Resources{
+		ws.Spec.Resources = tfv1.Resources{
 			Requests: tfv1.Resource{
 				Tflops: resource.MustParse("50"),
 				Vram:   resource.MustParse("50Gi"),
@@ -129,7 +129,7 @@ var _ = Describe("Recommender", func() {
 			},
 		}
 		processor := &recommendationProcessor{&fakeWorkloadHandler{Resource: maxAllowedRes}}
-		got, msg, _ := processor.Apply(context.Background(), workload, &recommendation)
+		got, msg, _ := processor.Apply(context.Background(), ws.Snapshot(), &recommendation)
 		Expect(got.Equal(&expectedRec)).To(BeTrue())
 		Expect(msg).To(Equal("TFlops request set to max allowed: (100), VRAM request set to max allowed: (100Gi)"))
 	})
@@ -149,9 +149,9 @@ var _ = Describe("Recommender", func() {
 			Tflops: resource.MustParse("300"),
 			Vram:   resource.MustParse("300Gi"),
 		}
-		workload := workload.NewWorkloadState()
+		ws := workload.NewWorkloadState()
 		processor := &recommendationProcessor{&fakeWorkloadHandler{Resource: maxAllowedRes}}
-		got, msg, _ := processor.Apply(context.Background(), workload, &recommendation)
+		got, msg, _ := processor.Apply(context.Background(), ws.Snapshot(), &recommendation)
 		Expect(got.Equal(&recommendation)).To(BeTrue())
 		Expect(msg).To(BeEmpty())
 	})
@@ -162,7 +162,7 @@ type fakeWorkloadHandler struct {
 	workload.Handler
 }
 
-func (f *fakeWorkloadHandler) GetMaxAllowedResourcesSpec(workload *workload.State) (*tfv1.Resource, error) {
+func (f *fakeWorkloadHandler) GetMaxAllowedResourcesSpec(view *workload.StateView) (*tfv1.Resource, error) {
 	return &f.Resource, nil
 }
 
@@ -172,7 +172,7 @@ type fakeRecommendationProcessor struct {
 
 func (r *fakeRecommendationProcessor) Apply(
 	ctx context.Context,
-	workload *workload.State,
+	view *workload.StateView,
 	rec *tfv1.Resources) (tfv1.Resources, string, error) {
 	return r.Resources, "fake message", nil
 }

--- a/internal/autoscaler/recommender/recommender.go
+++ b/internal/autoscaler/recommender/recommender.go
@@ -9,15 +9,23 @@ import (
 )
 
 // Interface defines the contract for resource recommendation strategies used by the autoscaler.
+//
+// Recommend operates on an immutable StateView and is therefore safe to call
+// concurrently with State mutators. Any side-effect a recommender wants to
+// record (status conditions, active cron rule changes) must be returned in
+// RecResult.Intent so the caller can merge them under State.Mu.
 type Interface interface {
 	Name() string
-	Recommend(ctx context.Context, workload *workload.State) (*RecResult, error)
+	Recommend(ctx context.Context, view *workload.StateView) (*RecResult, error)
 }
 
 type RecResult struct {
 	Resources        tfv1.Resources
 	HasApplied       bool
 	ScaleDownLocking bool
+	// Intent describes the side-effect that should be merged back into
+	// State.Status. The zero value means "no side-effect".
+	Intent workload.Intent
 }
 
 type recommenderToRecResult map[string]*RecResult
@@ -58,22 +66,29 @@ func mergeResourcesByLargerRequests(src *tfv1.Resources, target *tfv1.Resources)
 	}
 }
 
-func GetRecommendation(ctx context.Context, workload *workload.State, recommenders []Interface) (*tfv1.Resources, error) {
+// GetRecommendation runs every recommender against the given view and returns
+// (mergedRecommendation, perRecommenderIntents). The caller is expected to
+// pass intents to State.ApplyIntents to materialize them under State.Mu.
+func GetRecommendation(ctx context.Context, view *workload.StateView, recommenders []Interface) (*tfv1.Resources, []workload.Intent, error) {
 	recResults := make(recommenderToRecResult)
+	intents := make([]workload.Intent, 0, len(recommenders))
 	for _, recommender := range recommenders {
-		result, err := recommender.Recommend(ctx, workload)
+		result, err := recommender.Recommend(ctx, view)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get recommendation from %s: %v", recommender.Name(), err)
+			return nil, intents, fmt.Errorf("failed to get recommendation from %s: %v", recommender.Name(), err)
 		}
-		if result != nil {
-			recResults[recommender.Name()] = result
+		if result == nil {
+			continue
+		}
+		recResults[recommender.Name()] = result
+		if result.Intent != (workload.Intent{}) {
+			intents = append(intents, result.Intent)
 		}
 	}
 
 	recommendation := recResults.generateRecommendation()
 	if recommendation != nil {
-		curRes := workload.GetCurrentResourcesSpec()
-		// If a resource value is zero, replace it with current value
+		curRes := view.GetCurrentResourcesSpec()
 		if recommendation.Requests.Tflops.IsZero() || recommendation.Limits.Tflops.IsZero() {
 			recommendation.Requests.Tflops = curRes.Requests.Tflops
 			recommendation.Limits.Tflops = curRes.Limits.Tflops
@@ -85,5 +100,5 @@ func GetRecommendation(ctx context.Context, workload *workload.State, recommende
 		}
 	}
 
-	return recommendation, nil
+	return recommendation, intents, nil
 }

--- a/internal/autoscaler/workload/handler.go
+++ b/internal/autoscaler/workload/handler.go
@@ -57,6 +57,18 @@ func (h *handler) SetEventRecorder(recorder record.EventRecorder, scheme *runtim
 }
 
 func (h *handler) UpdateWorkloadState(ctx context.Context, workloadState *State, workload *tfv1.TensorFusionWorkload) error {
+	// List workers outside the State lock to avoid blocking AddSample on the
+	// API server round-trip; only the field/map mutations need exclusive access.
+	workerList := &corev1.PodList{}
+	if err := h.List(ctx, workerList,
+		client.InNamespace(workload.Namespace),
+		client.MatchingLabels{constants.WorkloadKey: workload.Name}); err != nil {
+		return err
+	}
+
+	workloadState.Mu.Lock()
+	defer workloadState.Mu.Unlock()
+
 	workloadState.Namespace = workload.Namespace
 	workloadState.Name = workload.Name
 	workloadState.Spec = workload.Spec
@@ -67,12 +79,6 @@ func (h *handler) UpdateWorkloadState(ctx context.Context, workloadState *State,
 		workloadState.updateHistoryPeriod(workload.Spec.AutoScalingConfig.AutoSetResources.HistoryDataPeriod)
 	}
 
-	workerList := &corev1.PodList{}
-	if err := h.List(ctx, workerList,
-		client.InNamespace(workloadState.Namespace),
-		client.MatchingLabels{constants.WorkloadKey: workloadState.Name}); err != nil {
-		return err
-	}
 	workloadState.updateCurrentActiveWorkers(workerList)
 	return nil
 }
@@ -81,12 +87,23 @@ func (h *handler) ApplyRecommendationToWorkload(ctx context.Context, workload *S
 	// If the latest recommendation has not been applied to all workers,
 	// we need to retry the update
 	if recommendation == nil && !workload.IsRecommendationAppliedToAllWorkers() {
+		workload.Mu.Lock()
 		recommendation = workload.Status.Recommendation
+		workload.Mu.Unlock()
 	}
 
 	if recommendation != nil {
+		// Snapshot the worker map under the State lock to avoid concurrent map
+		// iteration with metrics-loader goroutines / main loop reloads.
+		workload.Mu.Lock()
+		workers := make([]*corev1.Pod, 0, len(workload.CurrentActiveWorkers))
+		for _, w := range workload.CurrentActiveWorkers {
+			workers = append(workers, w)
+		}
 		workload.Status.AppliedRecommendedReplicas = 0
-		for _, worker := range workload.CurrentActiveWorkers {
+		workload.Mu.Unlock()
+
+		for _, worker := range workers {
 			if isWorkerHasDedicatedGPU(worker) {
 				continue
 			}
@@ -95,7 +112,9 @@ func (h *handler) ApplyRecommendationToWorkload(ctx context.Context, workload *S
 				log.FromContext(ctx).Error(err, "failed to update worker resources", "worker", worker.Name)
 				continue
 			}
+			workload.Mu.Lock()
 			workload.Status.AppliedRecommendedReplicas++
+			workload.Mu.Unlock()
 		}
 	}
 
@@ -294,13 +313,22 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 }
 
 func (h *handler) GetMaxAllowedResourcesSpec(workload *State) (*tfv1.Resource, error) {
+	// Snapshot under the State lock; the iteration below must not race with
+	// AddSample / UpdateWorkloadState mutating CurrentActiveWorkers.
+	workload.Mu.Lock()
 	if len(workload.CurrentActiveWorkers) <= 0 {
+		workload.Mu.Unlock()
 		return nil, nil
 	}
+	workers := make([]*corev1.Pod, 0, len(workload.CurrentActiveWorkers))
+	for _, w := range workload.CurrentActiveWorkers {
+		workers = append(workers, w)
+	}
+	workload.Mu.Unlock()
 
 	gpuStore, _, allocRequests := h.allocator.GetAllocationInfo()
 	gpuToWorkers := map[*tfv1.GPU][]*corev1.Pod{}
-	for _, worker := range workload.CurrentActiveWorkers {
+	for _, worker := range workers {
 		allocated, exists := allocRequests[string(worker.UID)]
 		if !exists || allocated == nil {
 			return nil, fmt.Errorf("worker %s has not allocated GPUs", worker.Name)

--- a/internal/autoscaler/workload/handler.go
+++ b/internal/autoscaler/workload/handler.go
@@ -24,7 +24,7 @@ type Handler interface {
 	UpdateWorkloadState(ctx context.Context, workloadState *State, workload *tfv1.TensorFusionWorkload) error
 	ApplyRecommendationToWorkload(ctx context.Context, workloadState *State, recommendation *tfv1.Resources) error
 	UpdateWorkloadStatus(ctx context.Context, state *State, recommendation *tfv1.Resources) error
-	GetMaxAllowedResourcesSpec(workload *State) (*tfv1.Resource, error)
+	GetMaxAllowedResourcesSpec(view *StateView) (*tfv1.Resource, error)
 	SetEventRecorder(recorder record.EventRecorder, scheme *runtime.Scheme)
 }
 
@@ -66,64 +66,96 @@ func (h *handler) UpdateWorkloadState(ctx context.Context, workloadState *State,
 		return err
 	}
 
+	// DeepCopy Spec to detach from the controller-runtime informer cache: the
+	// listed workload object can share backing memory with the cache and may
+	// be mutated by the reflector after we release Mu.
+	specCopy := workload.Spec.DeepCopy()
+	statusCopy := workload.Status.DeepCopy()
+	creationTimestamp := workload.CreationTimestamp
+
 	workloadState.Mu.Lock()
 	defer workloadState.Mu.Unlock()
 
 	workloadState.Namespace = workload.Namespace
 	workloadState.Name = workload.Name
-	workloadState.Spec = workload.Spec
-	workloadState.Status = *workload.Status.DeepCopy()
-	workloadState.CreationTimestamp = workload.CreationTimestamp
+	workloadState.Spec = *specCopy
+	workloadState.Status = *statusCopy
+	workloadState.CreationTimestamp = creationTimestamp
 
-	if workload.Spec.AutoScalingConfig.AutoSetResources != nil {
-		workloadState.updateHistoryPeriod(workload.Spec.AutoScalingConfig.AutoSetResources.HistoryDataPeriod)
+	if specCopy.AutoScalingConfig.AutoSetResources != nil {
+		workloadState.updateHistoryPeriod(specCopy.AutoScalingConfig.AutoSetResources.HistoryDataPeriod)
 	}
 
 	workloadState.updateCurrentActiveWorkers(workerList)
 	return nil
 }
 
-func (h *handler) ApplyRecommendationToWorkload(ctx context.Context, workload *State, recommendation *tfv1.Resources) error {
+func (h *handler) ApplyRecommendationToWorkload(ctx context.Context, workloadState *State, recommendation *tfv1.Resources) error {
 	// If the latest recommendation has not been applied to all workers,
-	// we need to retry the update
-	if recommendation == nil && !workload.IsRecommendationAppliedToAllWorkers() {
-		workload.Mu.Lock()
-		recommendation = workload.Status.Recommendation
-		workload.Mu.Unlock()
+	// we need to retry the update by reusing the in-memory recommendation.
+	if recommendation == nil && !workloadState.IsRecommendationAppliedToAllWorkers() {
+		recommendation = workloadState.LatestRecommendation()
 	}
 
-	if recommendation != nil {
-		// Snapshot the worker map under the State lock to avoid concurrent map
-		// iteration with metrics-loader goroutines / main loop reloads.
-		workload.Mu.Lock()
-		workers := make([]*corev1.Pod, 0, len(workload.CurrentActiveWorkers))
-		for _, w := range workload.CurrentActiveWorkers {
-			workers = append(workers, w)
-		}
-		workload.Status.AppliedRecommendedReplicas = 0
-		workload.Mu.Unlock()
+	if recommendation == nil {
+		return nil
+	}
 
-		for _, worker := range workers {
-			if isWorkerHasDedicatedGPU(worker) {
-				continue
-			}
+	// Snapshot the worker map under the State lock and DeepCopy each Pod —
+	// applyRecommendationToWorker mutates worker.Annotations before patching,
+	// which would otherwise race against any concurrent reader of
+	// CurrentActiveWorkers (recommender / Snapshot path). While we hold Mu,
+	// also pull out Namespace/Name and the ShouldScale decisions so the
+	// per-worker loop below never has to read State directly.
+	workloadState.Mu.Lock()
+	workers := make([]*corev1.Pod, 0, len(workloadState.CurrentActiveWorkers))
+	for _, w := range workloadState.CurrentActiveWorkers {
+		workers = append(workers, w.DeepCopy())
+	}
+	workloadState.Status.AppliedRecommendedReplicas = 0
+	ctx2 := workerScalingContext{
+		namespace:   workloadState.Namespace,
+		name:        workloadState.Name,
+		scaleTflops: workloadState.shouldScaleResourceLocked(tfv1.ResourceTflops),
+		scaleVram:   workloadState.shouldScaleResourceLocked(tfv1.ResourceVram),
+	}
+	workloadState.Mu.Unlock()
 
-			if err := h.applyRecommendationToWorker(ctx, workload, worker, recommendation); err != nil {
-				log.FromContext(ctx).Error(err, "failed to update worker resources", "worker", worker.Name)
-				continue
-			}
-			workload.Mu.Lock()
-			workload.Status.AppliedRecommendedReplicas++
-			workload.Mu.Unlock()
+	for _, worker := range workers {
+		if isWorkerHasDedicatedGPU(worker) {
+			continue
 		}
+
+		patched, err := h.applyRecommendationToWorker(ctx, ctx2, worker, recommendation)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "failed to update worker resources", "worker", worker.Name)
+			continue
+		}
+		if patched {
+			// Propagate the post-patch annotations back to state.CurrentActiveWorkers.
+			// We deep-copied for thread safety; without this write-back the next tick
+			// would still see the pre-patch annotations as curRes and re-issue (or
+			// skip) the patch incorrectly.
+			workloadState.setWorkerAnnotations(worker.Name, worker.Annotations)
+		}
+		workloadState.IncAppliedRecommendedReplicas()
 	}
 
 	return nil
 }
 
 func (h *handler) UpdateWorkloadStatus(ctx context.Context, state *State, recommendation *tfv1.Resources) error {
+	// Snapshot the in-memory Status under Mu so the K8s patch is built from
+	// a stable view. The recommender's intent has already been merged into
+	// state.Status.Conditions / ActiveCronScalingRule before we got here.
+	state.Mu.Lock()
+	stateStatus := *state.Status.DeepCopy()
+	stateNs := state.Namespace
+	stateName := state.Name
+	state.Mu.Unlock()
+
 	workload := &tfv1.TensorFusionWorkload{}
-	if err := h.Get(ctx, client.ObjectKey{Namespace: state.Namespace, Name: state.Name}, workload); err != nil {
+	if err := h.Get(ctx, client.ObjectKey{Namespace: stateNs, Name: stateName}, workload); err != nil {
 		return fmt.Errorf("failed to get workload: %v", err)
 	}
 
@@ -132,18 +164,18 @@ func (h *handler) UpdateWorkloadStatus(ctx context.Context, state *State, recomm
 
 	if isRecommendationChanged(&workload.Status, recommendation) {
 		workload.Status.Recommendation = recommendation
-		workload.Status.ActiveCronScalingRule = state.Status.ActiveCronScalingRule.DeepCopy()
+		workload.Status.ActiveCronScalingRule = stateStatus.ActiveCronScalingRule.DeepCopy()
 		hasChanges = true
 	}
 
-	if workload.Status.AppliedRecommendedReplicas != state.Status.AppliedRecommendedReplicas {
-		workload.Status.AppliedRecommendedReplicas = state.Status.AppliedRecommendedReplicas
+	if workload.Status.AppliedRecommendedReplicas != stateStatus.AppliedRecommendedReplicas {
+		workload.Status.AppliedRecommendedReplicas = stateStatus.AppliedRecommendedReplicas
 		hasChanges = true
 	}
 
 	// Update condition - check for both old and new condition types
 	// Always check conditions even if recommendation is nil, as conditions may need to be updated
-	if condition := meta.FindStatusCondition(state.Status.Conditions,
+	if condition := meta.FindStatusCondition(stateStatus.Conditions,
 		constants.ConditionStatusTypeResourceUpdate); condition != nil {
 		oldCondition := meta.FindStatusCondition(workload.Status.Conditions,
 			constants.ConditionStatusTypeResourceUpdate)
@@ -151,7 +183,7 @@ func (h *handler) UpdateWorkloadStatus(ctx context.Context, state *State, recomm
 			meta.SetStatusCondition(&workload.Status.Conditions, *condition)
 			hasChanges = true
 		}
-	} else if condition := meta.FindStatusCondition(state.Status.Conditions,
+	} else if condition := meta.FindStatusCondition(stateStatus.Conditions,
 		constants.ConditionStatusTypeRecommendationProvided); condition != nil {
 		// Migrate old condition to new type
 		oldCondition := meta.FindStatusCondition(workload.Status.Conditions,
@@ -164,11 +196,6 @@ func (h *handler) UpdateWorkloadStatus(ctx context.Context, state *State, recomm
 			meta.SetStatusCondition(&workload.Status.Conditions, *migratedCondition)
 			hasChanges = true
 		}
-	}
-
-	// Only return early if there are no changes and recommendation is nil and appliedRecommendedReplicas hasn't changed
-	if !hasChanges && !isAppliedRecommendedReplicasChanged(workload, state) {
-		return nil
 	}
 
 	if !hasChanges {
@@ -188,10 +215,6 @@ func isRecommendationChanged(status *tfv1.TensorFusionWorkloadStatus, recommenda
 	return recommendation != nil && (status.Recommendation == nil || !status.Recommendation.Equal(recommendation))
 }
 
-func isAppliedRecommendedReplicasChanged(workload *tfv1.TensorFusionWorkload, state *State) bool {
-	return workload.Status.AppliedRecommendedReplicas != state.Status.AppliedRecommendedReplicas
-}
-
 func isConditionEqual(c1, c2 *metav1.Condition) bool {
 	if c1 == nil && c2 == nil {
 		return true
@@ -205,7 +228,21 @@ func isConditionEqual(c1, c2 *metav1.Condition) bool {
 		c1.Message == c2.Message
 }
 
-func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *State, worker *corev1.Pod, recommendation *tfv1.Resources) error {
+// workerScalingContext is the per-tick decision snapshot taken once under
+// State.Mu and threaded through the worker loop, so applyRecommendationToWorker
+// never has to read State directly.
+type workerScalingContext struct {
+	namespace   string
+	name        string
+	scaleTflops bool
+	scaleVram   bool
+}
+
+// applyRecommendationToWorker patches the worker pod's GPU resource
+// annotations to match recommendation. Returns (true, nil) only when the K8s
+// patch actually went through, so the caller can mirror the new annotations
+// into state.CurrentActiveWorkers.
+func (h *handler) applyRecommendationToWorker(ctx context.Context, sc workerScalingContext, worker *corev1.Pod, recommendation *tfv1.Resources) (bool, error) {
 	log := log.FromContext(ctx)
 
 	curRes, err := utils.GPUResourcesFromAnnotations(worker.Annotations)
@@ -214,14 +251,14 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 	}
 
 	if recommendation.Equal(curRes) {
-		return nil
+		return false, nil
 	}
 
 	// Record event when scaling happens
 	if h.eventRecorder != nil && h.scheme != nil {
 		workloadObj := &tfv1.TensorFusionWorkload{}
-		workloadObj.Namespace = workload.Namespace
-		workloadObj.Name = workload.Name
+		workloadObj.Namespace = sc.namespace
+		workloadObj.Name = sc.name
 		workloadObj.Kind = "TensorFusionWorkload"
 		workloadObj.APIVersion = tfv1.GroupVersion.String()
 
@@ -245,57 +282,42 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 	}
 
 	annotationsToUpdate := utils.GPUResourcesToAnnotations(recommendation)
-	if !workload.ShouldScaleResource(tfv1.ResourceTflops) {
+	if !sc.scaleTflops {
 		delete(annotationsToUpdate, constants.TFLOPSRequestAnnotation)
 		delete(annotationsToUpdate, constants.TFLOPSLimitAnnotation)
 	}
-	if !workload.ShouldScaleResource(tfv1.ResourceVram) {
+	if !sc.scaleVram {
 		delete(annotationsToUpdate, constants.VRAMRequestAnnotation)
 		delete(annotationsToUpdate, constants.VRAMLimitAnnotation)
 	}
 
 	if len(annotationsToUpdate) <= 0 {
-		return nil
+		return false, nil
 	}
 
 	isScaleUp := recommendation.Requests.Tflops.Cmp(curRes.Requests.Tflops) > 0 ||
 		recommendation.Requests.Vram.Cmp(curRes.Requests.Vram) > 0
 
-	_, deltaRes, err := h.allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+	_, _, err = h.allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
 		PodUID:     string(worker.UID),
 		IsScaleUp:  isScaleUp,
 		NewRequest: recommendation.Requests,
 		NewLimit:   recommendation.Limits,
 	}, false)
 	if err != nil {
-		return fmt.Errorf("failed to adjust allocation: %v", err)
+		return false, fmt.Errorf("failed to adjust allocation: %v", err)
 	}
 
 	patch := client.MergeFrom(worker.DeepCopy())
 	maps.Copy(worker.Annotations, annotationsToUpdate)
 	if err := h.Patch(ctx, worker, patch); err != nil {
-		// Rollback the allocation change by calculating original values from current state and delta
-		// After AdjustAllocation, the allocator state is now recommendation, so we need to subtract deltaRes
-		// to get back to the original curRes values
-		originalRequest := tfv1.Resource{
-			Tflops: recommendation.Requests.Tflops.DeepCopy(),
-			Vram:   recommendation.Requests.Vram.DeepCopy(),
-		}
-		originalRequest.Tflops.Sub(deltaRes.Tflops)
-		originalRequest.Vram.Sub(deltaRes.Vram)
-
-		originalLimit := tfv1.Resource{
-			Tflops: recommendation.Limits.Tflops.DeepCopy(),
-			Vram:   recommendation.Limits.Vram.DeepCopy(),
-		}
-		originalLimit.Tflops.Sub(deltaRes.Tflops)
-		originalLimit.Vram.Sub(deltaRes.Vram)
-
+		// Roll back to the exact pre-patch resource values parsed from the
+		// worker annotations. Request and limit deltas can differ.
 		if _, _, rollbackErr := h.allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
 			PodUID:     string(worker.UID),
 			IsScaleUp:  !isScaleUp,
-			NewRequest: originalRequest,
-			NewLimit:   originalLimit,
+			NewRequest: curRes.Requests,
+			NewLimit:   curRes.Limits,
 		}, false); rollbackErr != nil {
 			log.Error(rollbackErr, "failed to rollback allocation after patch failure",
 				"worker", worker.Name, "originalError", err)
@@ -303,32 +325,23 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 			log.Info("rolled back allocation after patch failure",
 				"worker", worker.Name, "originalError", err)
 		}
-		return fmt.Errorf("failed to patch worker %s: %v", worker.Name, err)
+		return false, fmt.Errorf("failed to patch worker %s: %v", worker.Name, err)
 	}
 
 	log.Info("apply recommendation to worker successfully",
 		"worker", worker.Name, "recommendation", recommendation, "currentResources", curRes)
 
-	return nil
+	return true, nil
 }
 
-func (h *handler) GetMaxAllowedResourcesSpec(workload *State) (*tfv1.Resource, error) {
-	// Snapshot under the State lock; the iteration below must not race with
-	// AddSample / UpdateWorkloadState mutating CurrentActiveWorkers.
-	workload.Mu.Lock()
-	if len(workload.CurrentActiveWorkers) <= 0 {
-		workload.Mu.Unlock()
+func (h *handler) GetMaxAllowedResourcesSpec(view *StateView) (*tfv1.Resource, error) {
+	if view == nil || len(view.Workers) <= 0 {
 		return nil, nil
 	}
-	workers := make([]*corev1.Pod, 0, len(workload.CurrentActiveWorkers))
-	for _, w := range workload.CurrentActiveWorkers {
-		workers = append(workers, w)
-	}
-	workload.Mu.Unlock()
 
 	gpuStore, _, allocRequests := h.allocator.GetAllocationInfo()
 	gpuToWorkers := map[*tfv1.GPU][]*corev1.Pod{}
-	for _, worker := range workers {
+	for _, worker := range view.Workers {
 		allocated, exists := allocRequests[string(worker.UID)]
 		if !exists || allocated == nil {
 			return nil, fmt.Errorf("worker %s has not allocated GPUs", worker.Name)

--- a/internal/autoscaler/workload/workload.go
+++ b/internal/autoscaler/workload/workload.go
@@ -53,8 +53,13 @@ func (w *State) GetCurrentResourcesSpec() *tfv1.Resources {
 }
 
 func (w *State) IsAutoSetResourcesEnabled() bool {
-	return w.Spec.AutoScalingConfig.AutoSetResources.Enable &&
-		w.Spec.AutoScalingConfig.AutoSetResources.TargetResource != ""
+	// AutoSetResources is optional in the CRD; treat unset as disabled instead
+	// of dereferencing a nil pointer.
+	asr := w.Spec.AutoScalingConfig.AutoSetResources
+	if asr == nil {
+		return false
+	}
+	return asr.Enable && asr.TargetResource != ""
 }
 
 func (w *State) ShouldScaleResource(name tfv1.ResourceName) bool {

--- a/internal/autoscaler/workload/workload.go
+++ b/internal/autoscaler/workload/workload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
 	"github.com/NexusGPU/tensor-fusion/internal/utils"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -24,11 +25,15 @@ type State struct {
 	WorkerUsageAggregator *metrics.WorkerUsageAggregator
 	HistoryPeriod         time.Duration
 
-	// Mu guards the maps and field writes against concurrent metrics-loader
-	// goroutines (AddSample) and the autoscaler main loop (UpdateWorkloadState).
-	// Public State methods take Mu themselves; private helpers used inside the
-	// handler (e.g. updateCurrentActiveWorkers, updateHistoryPeriod) assume
-	// the caller already holds Mu.
+	// Mu guards every field above except WorkerUsageAggregator, whose own
+	// internal lock makes it safe to call concurrently with State.Mu held or
+	// not. All exported State methods that read/write these fields take Mu
+	// themselves; private helpers (e.g. updateCurrentActiveWorkers,
+	// updateHistoryPeriod) assume the caller already holds Mu.
+	//
+	// Recommender / status-update paths must not read Spec / Status / map
+	// fields directly. Use Snapshot() to obtain an immutable StateView and
+	// drive logic from it; mutation intents flow back through ApplyIntents.
 	Mu sync.Mutex
 }
 
@@ -41,41 +46,142 @@ func NewWorkloadState() *State {
 	}
 }
 
-func (w *State) GetOriginalResourcesSpec() *tfv1.Resources {
-	return &w.Spec.Resources
+// StateView is an immutable snapshot of State at a point in time. Recommenders
+// and status-update helpers operate on a view so that they no longer race
+// with UpdateWorkloadState / AddSample mutating State concurrently.
+//
+// Spec / Status / Workers are deep-copied at snapshot time so mutating the
+// view (or the underlying informer object) cannot leak back into State.
+// Aggregator stays as a pointer because it has its own internal lock and
+// cloning the histograms would be expensive; if updateHistoryPeriod swaps
+// the aggregator on State, the view simply keeps reading the old one for the
+// rest of the tick — that's accepted staleness, not a race.
+type StateView struct {
+	Namespace         string
+	Name              string
+	Spec              tfv1.WorkloadProfileSpec
+	Status            tfv1.TensorFusionWorkloadStatus
+	CreationTimestamp metav1.Time
+	HistoryPeriod     time.Duration
+	Workers           []*corev1.Pod
+	Aggregator        *metrics.WorkerUsageAggregator
 }
 
-func (w *State) GetCurrentResourcesSpec() *tfv1.Resources {
-	if w.Status.Recommendation != nil {
-		return w.Status.Recommendation
+// Snapshot returns an immutable view of the current State. The returned view
+// is safe to read concurrently with further AddSample / UpdateWorkloadState
+// calls on State.
+func (w *State) Snapshot() *StateView {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+
+	workers := make([]*corev1.Pod, 0, len(w.CurrentActiveWorkers))
+	for _, pod := range w.CurrentActiveWorkers {
+		workers = append(workers, pod.DeepCopy())
 	}
-	return w.GetOriginalResourcesSpec()
+
+	return &StateView{
+		Namespace:         w.Namespace,
+		Name:              w.Name,
+		Spec:              *w.Spec.DeepCopy(),
+		Status:            *w.Status.DeepCopy(),
+		CreationTimestamp: w.CreationTimestamp,
+		HistoryPeriod:     w.HistoryPeriod,
+		Workers:           workers,
+		Aggregator:        w.WorkerUsageAggregator,
+	}
 }
 
-func (w *State) IsAutoSetResourcesEnabled() bool {
-	// AutoSetResources is optional in the CRD; treat unset as disabled instead
-	// of dereferencing a nil pointer.
-	asr := w.Spec.AutoScalingConfig.AutoSetResources
+// Intent describes a recommender side-effect that must be merged back into
+// State.Status under State.Mu. nil-valued fields mean "no change".
+type Intent struct {
+	Condition         *metav1.Condition
+	SetActiveCronRule bool
+	ActiveCronRule    *tfv1.CronScalingRule
+}
+
+// ApplyIntents merges recommender side-effects into Status under State.Mu.
+func (w *State) ApplyIntents(intents []Intent) {
+	if len(intents) == 0 {
+		return
+	}
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	for _, in := range intents {
+		if in.Condition != nil {
+			meta.SetStatusCondition(&w.Status.Conditions, *in.Condition)
+		}
+		if in.SetActiveCronRule {
+			w.Status.ActiveCronScalingRule = in.ActiveCronRule
+		}
+	}
+}
+
+// SetAppliedRecommendedReplicas updates the in-memory replica counter under Mu.
+func (w *State) SetAppliedRecommendedReplicas(n int32) {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	w.Status.AppliedRecommendedReplicas = n
+}
+
+// IncAppliedRecommendedReplicas atomically increments the counter under Mu.
+func (w *State) IncAppliedRecommendedReplicas() {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	w.Status.AppliedRecommendedReplicas++
+}
+
+// setWorkerAnnotations mirrors a freshly patched worker's annotations into
+// the in-memory state under Mu. Without this, a deep-copied per-tick worker
+// snapshot would diverge from the K8s pod after a successful Patch and
+// subsequent ticks would compare recommendation against pre-patch values.
+//
+// The annotations slice is copied, so the caller may continue mutating its
+// own map without affecting state.
+func (w *State) setWorkerAnnotations(workerName string, annotations map[string]string) {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	pod, ok := w.CurrentActiveWorkers[workerName]
+	if !ok {
+		return
+	}
+	cloned := make(map[string]string, len(annotations))
+	for k, v := range annotations {
+		cloned[k] = v
+	}
+	pod.Annotations = cloned
+}
+
+func (v *StateView) GetOriginalResourcesSpec() *tfv1.Resources {
+	return &v.Spec.Resources
+}
+
+func (v *StateView) GetCurrentResourcesSpec() *tfv1.Resources {
+	if v.Status.Recommendation != nil {
+		return v.Status.Recommendation
+	}
+	return v.GetOriginalResourcesSpec()
+}
+
+func (v *StateView) IsAutoSetResourcesEnabled() bool {
+	asr := v.Spec.AutoScalingConfig.AutoSetResources
 	if asr == nil {
 		return false
 	}
 	return asr.Enable && asr.TargetResource != ""
 }
 
-func (w *State) ShouldScaleResource(name tfv1.ResourceName) bool {
-	asr := w.Spec.AutoScalingConfig.AutoSetResources
+func (v *StateView) ShouldScaleResource(name tfv1.ResourceName) bool {
+	asr := v.Spec.AutoScalingConfig.AutoSetResources
 	if asr == nil {
 		return false
 	}
 	target := asr.TargetResource
-	// Do not scale when TargetResource is empty
 	if target == "" {
 		return false
 	}
 	if strings.EqualFold(string(target), "all") {
 		return true
 	}
-	// Map ResourceName to ScalingTargetResource: "tflops" -> "compute"
 	resourceNameStr := string(name)
 	if resourceNameStr == "tflops" {
 		resourceNameStr = "compute"
@@ -83,6 +189,8 @@ func (w *State) ShouldScaleResource(name tfv1.ResourceName) bool {
 	return strings.EqualFold(resourceNameStr, string(target))
 }
 
+// IsRecommendationAppliedToAllWorkers checks under Mu whether every active
+// worker has the latest recommendation in its annotations.
 func (w *State) IsRecommendationAppliedToAllWorkers() bool {
 	w.Mu.Lock()
 	defer w.Mu.Unlock()
@@ -95,7 +203,7 @@ func (w *State) IsRecommendationAppliedToAllWorkers() bool {
 		return false
 	}
 
-	curRes := w.GetCurrentResourcesSpec()
+	curRes := w.currentResourcesSpecLocked()
 	for _, worker := range w.CurrentActiveWorkers {
 		if isWorkerHasDedicatedGPU(worker) {
 			continue
@@ -107,6 +215,66 @@ func (w *State) IsRecommendationAppliedToAllWorkers() bool {
 	}
 
 	return true
+}
+
+// LatestRecommendation returns Status.Recommendation under Mu.
+func (w *State) LatestRecommendation() *tfv1.Resources {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	if w.Status.Recommendation == nil {
+		return nil
+	}
+	return w.Status.Recommendation.DeepCopy()
+}
+
+// ShouldScaleResource is the *State-side helper used inside the
+// status-update / apply path. It takes Mu itself; callers that already hold
+// Mu (e.g. ApplyRecommendationToWorkload, while it is also pulling
+// Namespace/Name out of the same critical section) should use
+// shouldScaleResourceLocked to avoid re-locking.
+func (w *State) ShouldScaleResource(name tfv1.ResourceName) bool {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	return w.shouldScaleResourceLocked(name)
+}
+
+// shouldScaleResourceLocked is the lock-free body of ShouldScaleResource;
+// callers must already hold State.Mu.
+func (w *State) shouldScaleResourceLocked(name tfv1.ResourceName) bool {
+	asr := w.Spec.AutoScalingConfig.AutoSetResources
+	if asr == nil {
+		return false
+	}
+	target := asr.TargetResource
+	if target == "" {
+		return false
+	}
+	if strings.EqualFold(string(target), "all") {
+		return true
+	}
+	resourceNameStr := string(name)
+	if resourceNameStr == "tflops" {
+		resourceNameStr = "compute"
+	}
+	return strings.EqualFold(resourceNameStr, string(target))
+}
+
+// IsAutoSetResourcesEnabled is the *State-side helper that reads Spec under Mu.
+func (w *State) IsAutoSetResourcesEnabled() bool {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	asr := w.Spec.AutoScalingConfig.AutoSetResources
+	if asr == nil {
+		return false
+	}
+	return asr.Enable && asr.TargetResource != ""
+}
+
+func (w *State) currentResourcesSpecLocked() *tfv1.Resources {
+	if w.Status.Recommendation != nil {
+		return w.Status.Recommendation
+	}
+	return &w.Spec.Resources
 }
 
 func (w *State) updateHistoryPeriod(historyDataPeriod string) {
@@ -126,14 +294,17 @@ func (w *State) updateHistoryPeriod(historyDataPeriod string) {
 
 func (w *State) updateCurrentActiveWorkers(podList *corev1.PodList) {
 	w.CurrentActiveWorkers = map[string]*corev1.Pod{}
-	for _, worker := range podList.Items {
+	for i := range podList.Items {
+		worker := &podList.Items[i]
 		if !worker.DeletionTimestamp.IsZero() {
 			continue
 		}
 		if _, exists := w.WorkerUsageSamplers[worker.Name]; !exists {
 			w.WorkerUsageSamplers[worker.Name] = metrics.NewWorkerUsageSampler()
 		}
-		w.CurrentActiveWorkers[worker.Name] = &worker
+		// DeepCopy to fully detach from the informer-owned slice; the recommender /
+		// applyRecommendationToWorker path may mutate Annotations etc.
+		w.CurrentActiveWorkers[worker.Name] = worker.DeepCopy()
 	}
 
 	for key := range w.WorkerUsageSamplers {

--- a/internal/autoscaler/workload/workload.go
+++ b/internal/autoscaler/workload/workload.go
@@ -2,6 +2,7 @@ package workload
 
 import (
 	"strings"
+	"sync"
 	"time"
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
@@ -22,6 +23,13 @@ type State struct {
 	WorkerUsageSamplers   map[string]*metrics.WorkerUsageSampler
 	WorkerUsageAggregator *metrics.WorkerUsageAggregator
 	HistoryPeriod         time.Duration
+
+	// Mu guards the maps and field writes against concurrent metrics-loader
+	// goroutines (AddSample) and the autoscaler main loop (UpdateWorkloadState).
+	// Public State methods take Mu themselves; private helpers used inside the
+	// handler (e.g. updateCurrentActiveWorkers, updateHistoryPeriod) assume
+	// the caller already holds Mu.
+	Mu sync.Mutex
 }
 
 func NewWorkloadState() *State {
@@ -71,6 +79,9 @@ func (w *State) ShouldScaleResource(name tfv1.ResourceName) bool {
 }
 
 func (w *State) IsRecommendationAppliedToAllWorkers() bool {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+
 	if w.Status.Recommendation == nil {
 		return true
 	}
@@ -128,6 +139,8 @@ func (w *State) updateCurrentActiveWorkers(podList *corev1.PodList) {
 }
 
 func (w *State) AddSample(sample *metrics.WorkerUsage) {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
 	sampler, exists := w.WorkerUsageSamplers[sample.WorkerName]
 	if !exists {
 		sampler = metrics.NewWorkerUsageSampler()

--- a/internal/autoscaler/workload_metrics_loader.go
+++ b/internal/autoscaler/workload_metrics_loader.go
@@ -60,8 +60,12 @@ func (l *workloadMetricsLoader) addWorkload(ctx context.Context, workloadID Work
 		return
 	}
 
+	// Snapshot under State.Mu so we don't race with UpdateWorkloadState
+	// rewriting Spec / CreationTimestamp.
+	view := state.Snapshot()
+
 	// Get configuration
-	asr := state.Spec.AutoScalingConfig.AutoSetResources
+	asr := view.Spec.AutoScalingConfig.AutoSetResources
 	if asr == nil || !asr.Enable {
 		return
 	}
@@ -100,7 +104,7 @@ func (l *workloadMetricsLoader) addWorkload(ctx context.Context, workloadID Work
 	}
 
 	// Set timer for initial delay
-	timeSinceCreation := time.Since(state.CreationTimestamp.Time)
+	timeSinceCreation := time.Since(view.CreationTimestamp.Time)
 	if timeSinceCreation < initialDelay {
 		remainingDelay := initialDelay - timeSinceCreation
 		loaderState.initialDelayTimer = time.AfterFunc(remainingDelay, func() {

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -269,7 +269,8 @@ func (r *GPUNodeReconciler) checkStatusAndUpdateVirtualCapacity(
 			metrics.SetGPUMetrics(gpuList, node.Name, poolObj.Name)
 		}
 
-		if coreNode.Labels != nil && coreNode.Labels[constants.KarpenterExpansionLabel] != "" {
+		// r.Expander is nil when -enable-auto-expander is off.
+		if r.Expander != nil && coreNode.Labels != nil && coreNode.Labels[constants.KarpenterExpansionLabel] != "" {
 			r.Expander.RemoveInFlightNode(coreNode.Labels[constants.KarpenterExpansionLabel])
 		}
 		return nil

--- a/internal/controller/gpunodeclaim_controller.go
+++ b/internal/controller/gpunodeclaim_controller.go
@@ -76,8 +76,9 @@ func (r *GPUNodeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("failed to get computing vendor config for cluster %s", cluster.Name)
 	}
 
-	// When node really created, remove from in flight nodes
-	if claim.Labels != nil && claim.Status.Phase == tfv1.GPUNodeClaimBound {
+	// When node really created, remove from in flight nodes. r.Expander is nil
+	// when -enable-auto-expander is off; skip the call entirely in that case.
+	if r.Expander != nil && claim.Labels != nil && claim.Status.Phase == tfv1.GPUNodeClaimBound {
 		r.Expander.RemoveInFlightNode(claim.Labels[constants.KarpenterExpansionLabel])
 	}
 
@@ -90,7 +91,9 @@ func (r *GPUNodeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	needRequeueCheckDeletion := false
 	shouldReturn, err := utils.HandleFinalizer(ctx, claim, r.Client, func(ctx context.Context, claim *tfv1.GPUNodeClaim) (bool, error) {
 		nodeList := &corev1.NodeList{}
-		r.Expander.RemoveInFlightNode(claim.Name)
+		if r.Expander != nil {
+			r.Expander.RemoveInFlightNode(claim.Name)
+		}
 		if err := r.List(ctx, nodeList, client.MatchingLabels{constants.ProvisionerLabelKey: claim.Name}); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -79,7 +79,12 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	pod := &corev1.Pod{}
 	if err := r.Get(ctx, req.NamespacedName, pod); err != nil {
 		if errors.IsNotFound(err) {
-			_ = r.Expander.RemovePreSchedulePod(req.Name, true)
+			// r.Expander is nil when -enable-auto-expander is off; the receiver
+			// methods guard against it but we keep this explicit so a future
+			// refactor of the expander API stays safe here.
+			if r.Expander != nil {
+				_ = r.Expander.RemovePreSchedulePod(req.Name, true)
+			}
 			r.Allocator.DeallocByPodIdentifier(ctx, req.NamespacedName)
 			metrics.RemoveWorkerMetrics(req.Name, time.Now())
 			metrics.RemoveGPUAllocationMetrics(req.Name)
@@ -99,7 +104,9 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// Release GPU resources when pod is in Failed or Succeeded (Complete) state
 	// Only for worker pods that have allocated GPU resources
 	if pod.Labels[constants.LabelComponent] == constants.ComponentWorker && utils.IsPodStopped(pod) {
-		_ = r.Expander.RemovePreSchedulePod(pod.Name, true)
+		if r.Expander != nil {
+			_ = r.Expander.RemovePreSchedulePod(pod.Name, true)
+		}
 		r.Allocator.DeallocByPodIdentifier(ctx, req.NamespacedName)
 		metrics.RemoveWorkerMetrics(pod.Name, time.Now())
 		metrics.RemoveGPUAllocationMetrics(pod.Name)

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -798,10 +798,10 @@ func (s *GpuAllocator) AdjustAllocation(ctx context.Context, adjustRequest tfv1.
 	deltaVRAMRequest.Sub(request.Request.Vram)
 
 	deltaTFlopsLimit := adjustRequest.NewLimit.Tflops
-	deltaTFlopsLimit.Sub(request.Request.Tflops)
+	deltaTFlopsLimit.Sub(request.Limit.Tflops)
 
 	deltaVRAMLimit := adjustRequest.NewLimit.Vram
-	deltaVRAMLimit.Sub(request.Request.Vram)
+	deltaVRAMLimit.Sub(request.Limit.Vram)
 
 	if adjustRequest.IsScaleUp {
 		for _, gpuName := range request.GPUNames {

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -45,6 +45,17 @@ const CleanUpCheckInterval = 3 * time.Minute
 var mu sync.Mutex
 var GPUCapacityMap = map[string]tfv1.Resource{}
 
+// GetGPUCapacity returns the capacity recorded for a given GPU model under
+// the same lock used by the writers. Direct reads of GPUCapacityMap from
+// outside this package race with the informer-driven writes and would
+// eventually fatal with `concurrent map read and map write`.
+func GetGPUCapacity(model string) (tfv1.Resource, bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	r, ok := GPUCapacityMap[model]
+	return r, ok
+}
+
 type Strategy interface {
 	// When isForNode = true, indicates each GPU's node level score
 	// otherwise it's single GPU score inside one node
@@ -1542,6 +1553,16 @@ func (s *GpuAllocator) ReconcileAllocationState() {
 
 func (s *GpuAllocator) ReconcileAllocationStateForTesting() {
 	s.reconcileAllocationState()
+}
+
+// SetGPUForTesting inserts a GPU into the live in-memory store under the
+// allocator's write lock. Tests need this because GetAllocationInfo returns
+// deep-copied snapshots, so mutating the returned map no longer reaches the
+// real store.
+func (s *GpuAllocator) SetGPUForTesting(key types.NamespacedName, gpu *tfv1.GPU) {
+	s.storeMutex.Lock()
+	defer s.storeMutex.Unlock()
+	s.gpuStore[key] = gpu
 }
 
 func (s *GpuAllocator) CheckQuotaAndFilterSingleNodePreempt(

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -149,6 +149,13 @@ func (s *GpuAllocator) RegisterBindHandler(handler func(req *tfv1.AllocRequest))
 	s.bindHandlers = append(s.bindHandlers, handler)
 }
 
+// GetAllocationInfo returns deep-copied snapshots of the in-memory allocation
+// state. Callers can iterate freely without holding any allocator lock and
+// without risking `concurrent map iteration and map write` against
+// Bind / Dealloc / informer paths.
+//
+// The trade-off is one allocation pass per call; that is acceptable because
+// every caller is on a slow path (HTTP debug endpoints, reconcile loops).
 func (s *GpuAllocator) GetAllocationInfo() (
 	gpuStore map[types.NamespacedName]*tfv1.GPU,
 	nodeWorkerStore map[string]map[types.NamespacedName]struct{},
@@ -156,7 +163,32 @@ func (s *GpuAllocator) GetAllocationInfo() (
 ) {
 	s.storeMutex.RLock()
 	defer s.storeMutex.RUnlock()
-	return s.gpuStore, s.nodeWorkerStore, s.uniqueAllocation
+
+	gpuStore = make(map[types.NamespacedName]*tfv1.GPU, len(s.gpuStore))
+	for k, v := range s.gpuStore {
+		if v == nil {
+			continue
+		}
+		gpuStore[k] = v.DeepCopy()
+	}
+
+	nodeWorkerStore = make(map[string]map[types.NamespacedName]struct{}, len(s.nodeWorkerStore))
+	for nodeName, workers := range s.nodeWorkerStore {
+		inner := make(map[types.NamespacedName]struct{}, len(workers))
+		for w := range workers {
+			inner[w] = struct{}{}
+		}
+		nodeWorkerStore[nodeName] = inner
+	}
+
+	uniqueAllocation = make(map[string]*tfv1.AllocRequest, len(s.uniqueAllocation))
+	for k, v := range s.uniqueAllocation {
+		if v == nil {
+			continue
+		}
+		uniqueAllocation[k] = v.DeepCopy()
+	}
+	return gpuStore, nodeWorkerStore, uniqueAllocation
 }
 
 // GetNodeGpuStore returns a snapshot of the node-to-GPU map.
@@ -1196,7 +1228,7 @@ func (s *GpuAllocator) handleGPUCreate(ctx context.Context, gpu *tfv1.GPU) {
 	defer s.storeMutex.Unlock()
 
 	if s.gpuStore[key] != nil {
-		if gpu.Status.GPUModel != "" {
+		if gpu.Status.GPUModel != "" && gpu.Status.Capacity != nil {
 			mu.Lock()
 			if _, exists := GPUCapacityMap[gpu.Status.GPUModel]; !exists {
 				GPUCapacityMap[gpu.Status.GPUModel] = *gpu.Status.Capacity
@@ -1264,7 +1296,18 @@ func (s *GpuAllocator) handleGPUUpdate(ctx context.Context, gpu *tfv1.GPU) {
 		syncGPUMetadataAndStatusFromCluster(old, gpu)
 		log.V(6).Info("Updated GPU in store (preserve Available)", "name", key.Name, "phase", gpu.Status.Phase)
 	} else {
-		s.gpuStore[key] = gpu.DeepCopy()
+		// Mirror handleGPUCreate's defaulting so downstream code (e.g.
+		// addOrUpdateGPUMaps) can safely deref Capacity when the informer
+		// delivers an Update for an object the create path never saw with a
+		// fully populated Status.
+		gpuInMem := gpu.DeepCopy()
+		if gpuInMem.Status.Capacity == nil {
+			gpuInMem.Status.Capacity = &tfv1.Resource{}
+		}
+		if gpuInMem.Status.Available == nil {
+			gpuInMem.Status.Available = gpuInMem.Status.Capacity.DeepCopy()
+		}
+		s.gpuStore[key] = gpuInMem
 		log.V(6).Info("Updated GPU in store (new entry)", "name", key.Name, "phase", gpu.Status.Phase)
 	}
 
@@ -1296,7 +1339,7 @@ func (s *GpuAllocator) addOrUpdateGPUMaps(gpuInMem *tfv1.GPU) {
 		}
 	}
 
-	if gpuInMem.Status.GPUModel != "" {
+	if gpuInMem.Status.GPUModel != "" && gpuInMem.Status.Capacity != nil {
 		mu.Lock()
 		GPUCapacityMap[gpuInMem.Status.GPUModel] = *gpuInMem.Status.Capacity
 		mu.Unlock()

--- a/internal/gpuallocator/gpuallocator_test.go
+++ b/internal/gpuallocator/gpuallocator_test.go
@@ -24,6 +24,7 @@ import (
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
+	quota "github.com/NexusGPU/tensor-fusion/internal/quota"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
@@ -267,6 +268,68 @@ var _ = Describe("GPU Allocator", func() {
 	})
 
 	Context("GPU AutoScale", func() {
+		It("should adjust quota limits from the previous limits", func() {
+			allocator.quotaStore.QuotaStore[testPodMeta.Namespace] = &quota.QuotaStoreEntry{
+				Quota: &tfv1.GPUResourceQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "adjust-limit-delta-quota",
+						Namespace: testPodMeta.Namespace,
+					},
+					Spec: tfv1.GPUResourceQuotaSpec{
+						Total: tfv1.GPUResourceQuotaTotal{
+							Requests: &tfv1.Resource{
+								Tflops: resource.MustParse("1000"),
+								Vram:   resource.MustParse("100Gi"),
+							},
+							Limits: &tfv1.Resource{
+								Tflops: resource.MustParse("1000"),
+								Vram:   resource.MustParse("100Gi"),
+							},
+						},
+					},
+				},
+				CurrentUsage: quota.NewCalculator().CreateZeroUsage(),
+			}
+
+			gpus, err := allocator.Alloc(&tfv1.AllocRequest{
+				PoolName:              "test-pool",
+				WorkloadNameNamespace: workloadNameNs,
+				Request: tfv1.Resource{
+					Tflops: resource.MustParse("50"),
+					Vram:   resource.MustParse("10Gi"),
+				},
+				Limit: tfv1.Resource{
+					Tflops: resource.MustParse("70"),
+					Vram:   resource.MustParse("12Gi"),
+				},
+				Count:   1,
+				PodMeta: testPodMeta,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gpus).To(HaveLen(1))
+
+			_, _, err = allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+				PodUID:    string(testPodMeta.UID),
+				IsScaleUp: true,
+				NewRequest: tfv1.Resource{
+					Tflops: resource.MustParse("90"),
+					Vram:   resource.MustParse("15Gi"),
+				},
+				NewLimit: tfv1.Resource{
+					Tflops: resource.MustParse("120"),
+					Vram:   resource.MustParse("20Gi"),
+				},
+			}, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			usage, exists := allocator.quotaStore.GetQuotaStatus(testPodMeta.Namespace)
+			Expect(exists).To(BeTrue())
+			Expect(usage.Requests.Tflops.Cmp(resource.MustParse("90"))).To(Equal(0))
+			Expect(usage.Requests.Vram.Cmp(resource.MustParse("15Gi"))).To(Equal(0))
+			Expect(usage.Limits.Tflops.Cmp(resource.MustParse("120"))).To(Equal(0))
+			Expect(usage.Limits.Vram.Cmp(resource.MustParse("20Gi"))).To(Equal(0))
+		})
+
 		It("should scale up GPUs", func() {
 			request := tfv1.Resource{
 				Tflops: resource.MustParse("50"),

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -482,38 +482,44 @@ func SetGPUAllocationMetrics(gpuStore map[types.NamespacedName]*tfv1.GPU, pod *c
 }
 
 func SetSchedulerMetrics(poolName string, isSuccess bool) {
-	if _, ok := TensorFusionSystemMetricsMap[poolName]; !ok {
-		TensorFusionSystemMetricsMap[poolName] = &TensorFusionSystemMetrics{
-			PoolName: poolName,
-		}
+	TensorFusionSystemMetricsMapLock.Lock()
+	defer TensorFusionSystemMetricsMapLock.Unlock()
+	item, ok := TensorFusionSystemMetricsMap[poolName]
+	if !ok {
+		item = &TensorFusionSystemMetrics{PoolName: poolName}
+		TensorFusionSystemMetricsMap[poolName] = item
 	}
 	if isSuccess {
-		TensorFusionSystemMetricsMap[poolName].TotalAllocationSuccessCount++
+		item.TotalAllocationSuccessCount++
 	} else {
-		TensorFusionSystemMetricsMap[poolName].TotalAllocationFailCount++
+		item.TotalAllocationFailCount++
 	}
 }
 
 // TODO should record metrics after autoscaling feature added
 func SetAutoscalingMetrics(poolName string, isScaleUp bool) {
-	if _, ok := TensorFusionSystemMetricsMap[poolName]; !ok {
-		TensorFusionSystemMetricsMap[poolName] = &TensorFusionSystemMetrics{
-			PoolName: poolName,
-		}
+	TensorFusionSystemMetricsMapLock.Lock()
+	defer TensorFusionSystemMetricsMapLock.Unlock()
+	item, ok := TensorFusionSystemMetricsMap[poolName]
+	if !ok {
+		item = &TensorFusionSystemMetrics{PoolName: poolName}
+		TensorFusionSystemMetricsMap[poolName] = item
 	}
 	if isScaleUp {
-		TensorFusionSystemMetricsMap[poolName].TotalScaleUpCount++
+		item.TotalScaleUpCount++
 	} else {
-		TensorFusionSystemMetricsMap[poolName].TotalScaleDownCount++
+		item.TotalScaleDownCount++
 	}
 }
 
 func getSchedulerMetricsByPool(poolName string) (int64, int64, int64, int64) {
-	if item, ok := TensorFusionSystemMetricsMap[poolName]; !ok {
+	TensorFusionSystemMetricsMapLock.RLock()
+	defer TensorFusionSystemMetricsMapLock.RUnlock()
+	item, ok := TensorFusionSystemMetricsMap[poolName]
+	if !ok {
 		return 0, 0, 0, 0
-	} else {
-		return item.TotalAllocationSuccessCount, item.TotalAllocationFailCount, item.TotalScaleUpCount, item.TotalScaleDownCount
 	}
+	return item.TotalAllocationSuccessCount, item.TotalAllocationFailCount, item.TotalScaleUpCount, item.TotalScaleDownCount
 }
 
 // Start metrics recorder

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -311,7 +311,13 @@ func SetNodeMetrics(node *tfv1.GPUNode, poolObj *tfv1.GPUPool, gpuModels []strin
 }
 
 func InitPoolMetricsWhenNotExists(poolObj *tfv1.GPUPool) {
-	if _, ok := poolMetricsMap[poolObj.Name]; !ok {
+	// Take the read lock for the existence check; SetPoolMetrics takes the
+	// write lock and will re-check under it, but reading the map without any
+	// lock would race with a concurrent SetPoolMetrics writer.
+	poolMetricsLock.RLock()
+	_, ok := poolMetricsMap[poolObj.Name]
+	poolMetricsLock.RUnlock()
+	if !ok {
 		SetPoolMetrics(poolObj)
 	}
 }
@@ -738,16 +744,20 @@ func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
 	}
 	gpuResourceMetricsLock.RUnlock()
 
+	// Snapshot the count while still holding the read lock; the log statements
+	// below run after RUnlock and would otherwise race with concurrent
+	// SetNodeMetrics / RemoveNodeMetrics writers.
+	nodeMetricsCount := len(nodeMetricsMap)
 	nodeMetricsLock.RUnlock()
 
 	if err := enc.Err(); err != nil {
-		log.Error(err, "metrics encoding error", "workerCount", activeWorkerCnt, "nodeCount", len(nodeMetricsMap))
+		log.Error(err, "metrics encoding error", "workerCount", activeWorkerCnt, "nodeCount", nodeMetricsCount)
 	}
 
 	if _, err := writer.Write(enc.Bytes()); err != nil {
-		log.Error(err, "metrics writing error", "workerCount", activeWorkerCnt, "nodeCount", len(nodeMetricsMap))
+		log.Error(err, "metrics writing error", "workerCount", activeWorkerCnt, "nodeCount", nodeMetricsCount)
 	}
-	log.Info("metrics and raw billing recorded:", "workerCount", activeWorkerCnt, "nodeCount", len(nodeMetricsMap))
+	log.Info("metrics and raw billing recorded:", "workerCount", activeWorkerCnt, "nodeCount", nodeMetricsCount)
 }
 
 // Update metrics recorder's raw billing map

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -551,7 +551,20 @@ func (mr *MetricsRecorder) Start() {
 }
 
 func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
-	if len(workerMetricsMap) <= 0 && len(nodeMetricsMap) <= 0 && len(gpuResourceMetricsMap) <= 0 {
+	// Take each map's read lock briefly to evaluate the early-exit predicate.
+	// Reading len() unlocked races with concurrent writers and Go's race
+	// detector flags it; the work below already takes write locks so the
+	// optimization is the only racy spot.
+	workerMetricsLock.RLock()
+	hasWorkerMetrics := len(workerMetricsMap) > 0
+	workerMetricsLock.RUnlock()
+	nodeMetricsLock.RLock()
+	hasNodeMetrics := len(nodeMetricsMap) > 0
+	nodeMetricsLock.RUnlock()
+	gpuResourceMetricsLock.RLock()
+	hasGPUResourceMetrics := len(gpuResourceMetricsMap) > 0
+	gpuResourceMetricsLock.RUnlock()
+	if !hasWorkerMetrics && !hasNodeMetrics && !hasGPUResourceMetrics {
 		return
 	}
 
@@ -660,7 +673,10 @@ func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
 		enc.EndLine(now)
 	}
 
-	// Additional Pool level metrics
+	// Additional Pool level metrics. Hold poolMetricsLock for the iteration —
+	// concurrent writers (SetPoolMetrics, RemovePoolMetrics) would otherwise
+	// trigger `concurrent map iteration and map write`.
+	poolMetricsLock.RLock()
 	for _, metrics := range poolMetricsMap {
 		enc.StartLine("tf_pool_metrics")
 		enc.AddTag("pool", metrics.PoolName)
@@ -678,6 +694,7 @@ func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
 		enc.AddField("gpu_count", int64(metrics.GPUCount))
 		enc.EndLine(now)
 	}
+	poolMetricsLock.RUnlock()
 
 	// GPU allocation metrics
 	gpuAllocationMetricsLock.RLock()

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -3,6 +3,7 @@
 package metrics
 
 import (
+	"sync"
 	"time"
 )
 
@@ -25,6 +26,11 @@ func (wm TensorFusionSystemMetrics) TableName() string {
 	return "tf_system_metrics"
 }
 
+// TensorFusionSystemMetricsMapLock serializes access to TensorFusionSystemMetricsMap.
+// Writers (SetSchedulerMetrics / SetAutoscalingMetrics) take Lock; the periodic
+// recorder reader (getSchedulerMetricsByPool, called from inside the recorder
+// flush loop) takes RLock.
+var TensorFusionSystemMetricsMapLock sync.RWMutex
 var TensorFusionSystemMetricsMap = make(map[string]*TensorFusionSystemMetrics)
 
 // Metrics will be stored in a map, key is the worker name, value is the metrics

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -150,8 +150,35 @@ func (e *NodeExpander) cleanupInFlightNodeClaim(nodeClaim *karpv1.NodeClaim) {
 }
 
 func (e *NodeExpander) GetNodeScalerInfo() any {
+	if e == nil {
+		return map[string]any{}
+	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
+
+	// Deep-copy the live maps because the caller (HTTP handler) JSON-encodes
+	// the result *after* RUnlock. Returning live references would race with
+	// addInFlightNode / addPreSchedulePod / RemovePreSchedulePod and trip
+	// `concurrent map iteration and map write`.
+	inFlightNodesCopy := make(map[string][]*tfv1.GPU, len(e.inFlightNodes))
+	for nodeName, gpus := range e.inFlightNodes {
+		gpuCopies := make([]*tfv1.GPU, 0, len(gpus))
+		for _, g := range gpus {
+			if g == nil {
+				continue
+			}
+			gpuCopies = append(gpuCopies, g.DeepCopy())
+		}
+		inFlightNodesCopy[nodeName] = gpuCopies
+	}
+
+	preSchedulePodsCopy := make(map[string]*tfv1.AllocRequest, len(e.preSchedulePods))
+	for podName, req := range e.preSchedulePods {
+		if req == nil {
+			continue
+		}
+		preSchedulePodsCopy[podName] = req.DeepCopy()
+	}
 
 	inFlightNodeClaimSnapshot := make(map[string]any)
 	e.inFlightNodeClaims.Range(func(key, value interface{}) bool {
@@ -159,9 +186,9 @@ func (e *NodeExpander) GetNodeScalerInfo() any {
 		return true
 	})
 	return map[string]any{
-		"inFlightNodes":       e.inFlightNodes,
+		"inFlightNodes":       inFlightNodesCopy,
 		"inFlightNodeClaims":  inFlightNodeClaimSnapshot,
-		"preSchedulePods":     e.preSchedulePods,
+		"preSchedulePods":     preSchedulePodsCopy,
 		"preScheduleTimerNum": len(e.preScheduleTimers),
 	}
 }

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -170,11 +170,18 @@ func (e *NodeExpander) ProcessExpansion(ctx context.Context, pod *corev1.Pod) er
 	if pod == nil {
 		return fmt.Errorf("pod cannot be nil")
 	}
-	if _, ok := e.preSchedulePods[pod.Name]; ok {
+	// Read maps under the read lock to avoid `concurrent map read and map
+	// write` against addPreSchedulePod / addInFlightNode / RemovePreSchedulePod.
+	e.mu.RLock()
+	_, alreadyInPreSchedule := e.preSchedulePods[pod.Name]
+	inFlightCount := len(e.inFlightNodes)
+	e.mu.RUnlock()
+
+	if alreadyInPreSchedule {
 		e.logger.Info("Pod already in pre-schedule state, skipping expansion check and wait for expansion", "pod", klog.KObj(pod))
 		return nil
 	}
-	if len(e.inFlightNodes) >= MaxInFlightNodes {
+	if inFlightCount >= MaxInFlightNodes {
 		e.logger.Error(nil, "Too many inFlight nodes, skipping expansion to avoid too many nodes provisioned concurrently")
 		time.Sleep(WaitingInFlightNodesPeriod)
 		return nil
@@ -209,6 +216,9 @@ func (e *NodeExpander) ProcessExpansion(ctx context.Context, pod *corev1.Pod) er
 			}
 		}
 	}
+	// Snapshot inFlightNodes under read lock to avoid concurrent map access
+	// against addInFlightNode / RemoveInFlightNode.
+	e.mu.RLock()
 	inFlightGPUSnapshot := make(map[string]*tfv1.GPU, len(e.inFlightNodes)*4)
 	for _, inFlightGPUs := range e.inFlightNodes {
 		for _, gpu := range inFlightGPUs {
@@ -217,6 +227,7 @@ func (e *NodeExpander) ProcessExpansion(ctx context.Context, pod *corev1.Pod) er
 			allGpus = append(allGpus, snapshot)
 		}
 	}
+	e.mu.RUnlock()
 	if len(allGpus) == 0 {
 		e.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "NodeExpansionCheck",
 			"all schedulable nodes are none GPU nodes, manual check required")
@@ -422,7 +433,19 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 	// NOTE: a known issue, if cpu/mem not enough or affinity not satisfied for pre-scheduled pods inside inFlightNodes,
 	// it will not be considered, when inflight created and the Pod still not be able to schedule on new node,
 	// wait next scheduling check and node expansion period (k8s move UnscheduleQueue to ActiveQueue every 5 minutes)
+	//
+	// Snapshot pre-scheduled pods under the read lock so that the loop body —
+	// which calls RemovePreSchedulePod (write lock) — does not race with the
+	// iteration. Without the snapshot Go would fatal with
+	// `concurrent map read and map write`.
+	e.mu.RLock()
+	preScheduleSnapshot := make([]*tfv1.AllocRequest, 0, len(e.preSchedulePods))
 	for _, alloc := range e.preSchedulePods {
+		preScheduleSnapshot = append(preScheduleSnapshot, alloc)
+	}
+	e.mu.RUnlock()
+
+	for _, alloc := range preScheduleSnapshot {
 		preScheduledPodPreAllocated := false
 		for _, gpu := range inflightSnapshot {
 			reqTflops := alloc.Request.Tflops

--- a/internal/scheduler/gpuresources/gpuresources_test.go
+++ b/internal/scheduler/gpuresources/gpuresources_test.go
@@ -1436,13 +1436,12 @@ func (s *GPUResourcesSuite) TestReconcileAllocationState_ComputePercent() {
 
 	// Manually add GPU to allocator store
 	// Since InitGPUAndQuotaStore uses sync.Once, we need to manually add the GPU to the store
-	gpuStore, _, _ := s.allocator.GetAllocationInfo()
 	key := types.NamespacedName{Name: "gpu-test-percent"}
 	gpuCopy := gpu.DeepCopy()
 	if gpuCopy.Status.Available == nil {
 		gpuCopy.Status.Available = gpuCopy.Status.Capacity.DeepCopy()
 	}
-	gpuStore[key] = gpuCopy
+	s.allocator.SetGPUForTesting(key, gpuCopy)
 
 	// Reconcile allocation state
 	s.allocator.ReconcileAllocationStateForTesting()
@@ -1548,13 +1547,12 @@ func (s *GPUResourcesSuite) TestReconcileAllocationState_MixedTflopsAndComputePe
 	s.NoError(s.client.Create(s.ctx, workerPod2))
 
 	// Manually add GPU to allocator store
-	gpuStore, _, _ := s.allocator.GetAllocationInfo()
 	key := types.NamespacedName{Name: "gpu-test-mixed"}
 	gpuCopy := gpu.DeepCopy()
 	if gpuCopy.Status.Available == nil {
 		gpuCopy.Status.Available = gpuCopy.Status.Capacity.DeepCopy()
 	}
-	gpuStore[key] = gpuCopy
+	s.allocator.SetGPUForTesting(key, gpuCopy)
 
 	// Reconcile allocation state
 	s.allocator.ReconcileAllocationStateForTesting()
@@ -1963,20 +1961,19 @@ func (s *GPUResourcesSuite) TestReconcileAllocationState_MultipleGPUsWithCompute
 	s.NoError(s.client.Create(s.ctx, workerPod2))
 
 	// Manually add GPUs to allocator store
-	gpuStore, _, _ := s.allocator.GetAllocationInfo()
 	key1 := types.NamespacedName{Name: "gpu-mixed-1"}
 	gpuCopy1 := gpu1.DeepCopy()
 	if gpuCopy1.Status.Available == nil {
 		gpuCopy1.Status.Available = gpuCopy1.Status.Capacity.DeepCopy()
 	}
-	gpuStore[key1] = gpuCopy1
+	s.allocator.SetGPUForTesting(key1, gpuCopy1)
 
 	key2 := types.NamespacedName{Name: "gpu-mixed-2"}
 	gpuCopy2 := gpu2.DeepCopy()
 	if gpuCopy2.Status.Available == nil {
 		gpuCopy2.Status.Available = gpuCopy2.Status.Capacity.DeepCopy()
 	}
-	gpuStore[key2] = gpuCopy2
+	s.allocator.SetGPUForTesting(key2, gpuCopy2)
 
 	// Reconcile allocation state
 	s.allocator.ReconcileAllocationStateForTesting()

--- a/internal/server/router/connection.go
+++ b/internal/server/router/connection.go
@@ -70,11 +70,22 @@ func (cr *ConnectionRouter) Get(ctx *gin.Context) {
 	ch, cancelFunc := cr.watcher.subscribe(req)
 	defer cancelFunc()
 
-	// Wait for connection updates
-	for conn := range ch {
-		if conn.Status.Phase == tfv1.WorkerRunning {
-			ctx.String(200, conn.Status.ConnectionURL)
+	// Wait for connection updates. Listen on the request context so a client
+	// disconnect (or server shutdown) breaks the loop and triggers cancelFunc;
+	// otherwise the goroutine and the subscriber entry in cw.subs leak forever.
+	reqCtx := ctx.Request.Context()
+	for {
+		select {
+		case <-reqCtx.Done():
 			return
+		case conn, ok := <-ch:
+			if !ok {
+				return
+			}
+			if conn.Status.Phase == tfv1.WorkerRunning {
+				ctx.String(200, conn.Status.ConnectionURL)
+				return
+			}
 		}
 	}
 }

--- a/internal/server/router/node_scaler_info.go
+++ b/internal/server/router/node_scaler_info.go
@@ -20,6 +20,14 @@ func NewNodeScalerInfoRouter(
 }
 
 func (r *NodeScalerInfoRouter) Get(ctx *gin.Context) {
+	if r.nodeExpander == nil {
+		// Auto-expander disabled (e.g. -enable-auto-expander=false). Surface a
+		// proper status code instead of dereferencing the nil pointer.
+		ctx.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "node scaler not enabled",
+		})
+		return
+	}
 	ctx.JSON(http.StatusOK, gin.H{
 		"data": r.nodeExpander.GetNodeScalerInfo(),
 	})

--- a/internal/webhook/v1/tf_parser.go
+++ b/internal/webhook/v1/tf_parser.go
@@ -516,8 +516,9 @@ func handleDedicatedGPU(pod *corev1.Pod, workloadProfile *tfv1.WorkloadProfile) 
 		return fmt.Errorf("dedicated GPU requires gpu-model annotation to be specified")
 	}
 
-	// Get full GPU capacity from pricing provider
-	resource, found := gpuallocator.GPUCapacityMap[workloadProfile.Spec.GPUModel]
+	// Get full GPU capacity from pricing provider. Use the locked accessor —
+	// direct map read races with allocator writes from informer events.
+	resource, found := gpuallocator.GetGPUCapacity(workloadProfile.Spec.GPUModel)
 	if !found {
 		return fmt.Errorf("could not find capacity information for GPU model: %s", workloadProfile.Spec.GPUModel)
 	}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 style="color: rgba(20, 20, 20, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgba(20, 20, 20, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix 12 latent concurrency / nil-safety bugs surfaced by code review. None are introduced by recent feature work — all are pre-existing on <code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">v1</code>. Stacked into 4 focused commits so they can be reviewed (or reverted) independently.</p>
# | Bug | Severity | Commit
-- | -- | -- | --
1 | connection.go long-poll handler blocks for c := range ch without listening to ctx.Done() — every disconnected client leaks a goroutine + channel + entry in cw.subs | High | 337d108
2 | NodeExpander.ProcessExpansion reads preSchedulePods / inFlightNodes lock-free; checkGPUFitWithInflightNodes iterates preSchedulePods while the loop body calls RemovePreSchedulePod (write lock) | High | 337d108
3 | /api/node-scaler panics when -enable-auto-expander=false (router dereferences nil expander) | Medium | 337d108
4 | GpuAllocator.GetAllocationInfo returns the live in-memory maps and releases the lock — HTTP handler / reconcilers iterate without sync against Bind / Dealloc / informer writes | High | 7410510
5 | handleGPUUpdate's "new entry" branch doesn't default Capacity/Available like handleGPUCreate, so addOrUpdateGPUMaps deref's *Status.Capacity if GPUModel != "" | High | 7410510
6 | autoscaler workload.State exposed CurrentActiveWorkers / WorkerUsageSamplers lock-free; main loop's UpdateWorkloadState races with metrics-loader goroutines' AddSample → concurrent map read and map write fatal | High | 7410510
7 | r.Expander.X(...) calls in pod / gpunodeclaim / gpunode controllers — methods have nil-receiver guards but caller-side checks make intent local and survive future refactors | Low | ee2d740
8 | IsAutoSetResourcesEnabled deref's Spec.AutoScalingConfig.AutoSetResources even though the field is CRD-optional | Medium | ee2d740
9 | RecordMetrics reads len(*MetricsMap) lock-free in early-exit, and iterates poolMetricsMap with no lock at all | Medium-High | ee2d740
10 | GetNodeScalerInfo returns live inFlightNodes / preSchedulePods maps — JSON encoder runs after RUnlock and races with writers | High | 292ca3a
11 | gpuallocator.GPUCapacityMap written under mu in allocator, read lock-free from webhook (tf_parser.go) | High | 292ca3a
12 | metrics.InitPoolMetricsWhenNotExists checks poolMetricsMap lock-free; trailing log statements in RecordMetrics reference len(nodeMetricsMap) after RUnlock | Medium | 292ca3a

<h2 style="color: rgba(20, 20, 20, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What changed</h2><ul style="padding-inline-start: 2em; color: rgba(20, 20, 20, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>Synchronisation</strong>: replaced lock-free reads with appropriate<span> </span><code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Lock</code>/<code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RLock</code><span> </span>scopes; converted "return live map + release lock" patterns to "deep-copy under lock + return snapshot" so callers (HTTP handlers, reconcile loops) can iterate freely.</li><li><strong>Nil-safety</strong>: added explicit nil checks where the dereferenced field is CRD-optional or wired-by-flag (<code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AutoSetResources</code>,<span> </span><code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">r.Expander</code>); kept method-side nil-receiver guards as belt-and-suspenders.</li><li><strong>Snapshot patterns</strong>: when iteration triggers a write-lock callback (e.g.<span> </span><code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RemovePreSchedulePod</code><span> </span>from inside an iteration of<span> </span><code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">preSchedulePods</code>), the iteration now walks a snapshot taken under the read lock, then releases the lock before the callback runs.</li><li><strong>Public accessor</strong>: added<span> </span><code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">gpuallocator.GetGPUCapacity(model)</code><span> </span>so external readers go through the lock instead of touching<span> </span><code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GPUCapacityMap</code><span> </span>directly.</li></ul><h2 style="color: rgba(20, 20, 20, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Behaviour</h2><ul style="padding-inline-start: 2em; color: rgba(20, 20, 20, 0.92); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>No API changes.</li><li>No CRD changes.</li><li><code style="font-family: monospace; color: rgb(111, 155, 166); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GetAllocationInfo</code><span> </span>now allocates one snapshot per call. All call sites are slow paths (HTTP debug endpoints, periodic reconcile), so the cost is acceptable.</li></ul><!--EndFragment-->
</body>
`</html>