### PR TITLE
fix(gpupool): update defrag logic and introduce evicted pod label

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -196,14 +196,8 @@ const (
 	// Refer: https://karpenter.sh/docs/concepts/disruption/
 	SchedulingDoNotDisruptLabel = Domain + "/do-not-disrupt"
 
-	// Marks a node that defrag is draining.
-	DefragDrainingLabel = Domain + "/defrag-draining"
-
-	// RFC3339 time when the drain label was applied.
-	DefragDrainingSinceAnnotation = Domain + "/defrag-draining-since"
-
-	// GPUPool that owns the current defrag drain operation.
-	DefragDrainingPoolAnnotation = Domain + "/defrag-draining-pool"
+	// Marks a pod that has been evicted by GPUPool defrag.
+	DefragEvictedPodLabel = Domain + "/defrag-evicted"
 )
 
 const (

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -198,6 +198,12 @@ const (
 
 	// Marks a pod that has been evicted by GPUPool defrag.
 	DefragEvictedPodLabel = Domain + "/defrag-evicted"
+
+	// RFC3339 time when the pod was evicted by GPUPool defrag.
+	DefragEvictedPodSinceAnnotation = Domain + "/defrag-evicted-since"
+
+	// GPUPool that owns the pod eviction marker.
+	DefragEvictedPodPoolAnnotation = Domain + "/defrag-evicted-pool"
 )
 
 const (

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -204,6 +204,9 @@ const (
 
 	// GPUPool that owns the pod eviction marker.
 	DefragEvictedPodPoolAnnotation = Domain + "/defrag-evicted-pool"
+
+	// Marks a node that is being emptied by GPUPool defrag.
+	DefragSourceNodeLabel = Domain + "/defrag-source"
 )
 
 const (

--- a/internal/controller/gpupool_compaction_controller.go
+++ b/internal/controller/gpupool_compaction_controller.go
@@ -46,9 +46,6 @@ type GPUPoolCompactionReconciler struct {
 	// key = pool name, value = *atomic.Bool.
 	defragRunning sync.Map
 
-	// key = k8s node name, value = drainStartTime (time.Time).
-	defragDrainingNodes sync.Map
-
 	markDeletionNodes map[string]struct{}
 }
 
@@ -284,10 +281,6 @@ func (r *GPUPoolCompactionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	// Run defrag maintenance even when compaction is skipped.
-	r.defragDrainWatcherTick(ctx, pool)
-	r.defragStaleLabelCleanupTick(ctx, pool)
-
 	needStartCompactionJob := true
 	nextDuration := r.getCompactionDuration(ctx, pool.Spec.NodeManagerConfig)
 
@@ -335,8 +328,8 @@ func (r *GPUPoolCompactionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, compactionErr
 	}
 
-	// Strategy #2: cron-driven defrag in a background goroutine.
-	r.maybeStartDefragRun(ctx, pool)
+	// Strategy #2: cron-driven defrag, one source node per reconcile.
+	r.maybeRunDefragStep(ctx, pool)
 
 	// Next ticker, timer set by user, won't impacted by other reconcile requests
 	return ctrl.Result{RequeueAfter: nextDuration}, nil
@@ -346,8 +339,6 @@ func (r *GPUPoolCompactionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 func (r *GPUPoolCompactionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.markDeletionNodes = make(map[string]struct{})
 	r.defragParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	// Rebuild drain watcher state from already-labeled nodes.
-	r.scheduleDefragDrainWatcherBootstrap(mgr)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("gpupool-compaction").
 		WatchesMetadata(&tfv1.GPUPool{}, &handler.EnqueueRequestForObject{}).

--- a/internal/controller/gpupool_compaction_controller.go
+++ b/internal/controller/gpupool_compaction_controller.go
@@ -309,6 +309,11 @@ func (r *GPUPoolCompactionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if !needStartCompactionJob || len(PendingGPUNodeClaim[pool.Name]) > 0 {
+		if len(PendingGPUNodeClaim[pool.Name]) == 0 {
+			if requeueAfter := r.maybeRunDefragStep(ctx, pool, nextDuration); requeueAfter > 0 && requeueAfter < nextDuration {
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
+			}
+		}
 		log.Info("Skip compaction because node creating or duration not met", "name", req.Name)
 		return ctrl.Result{RequeueAfter: nextDuration}, nil
 	}
@@ -329,10 +334,13 @@ func (r *GPUPoolCompactionReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// Strategy #2: cron-driven defrag, one source node per reconcile.
-	r.maybeRunDefragStep(ctx, pool)
+	requeueAfter := nextDuration
+	if defragRequeueAfter := r.maybeRunDefragStep(ctx, pool, nextDuration); defragRequeueAfter > 0 && defragRequeueAfter < requeueAfter {
+		requeueAfter = defragRequeueAfter
+	}
 
 	// Next ticker, timer set by user, won't impacted by other reconcile requests
-	return ctrl.Result{RequeueAfter: nextDuration}, nil
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -1,6 +1,7 @@
 // Strategy #2 for GPUPool compaction: move TF workers off low-utilization
 // nodes so Strategy #1 can later reclaim the emptied nodes.
 //
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;patch
 // +kubebuilder:rbac:groups=core,resources=pods/eviction,verbs=create
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;patch;update
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list
@@ -30,38 +31,25 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
-	// How long the watcher waits for allocator state to observe an empty node.
-	drainConfirmationTimeout = 10 * time.Minute
-
 	// Fallback when MaxDuration is empty or invalid.
 	defaultDefragMaxDuration = 2 * time.Hour
 
 	// Independent timeout for persisting LastDefragTime.
 	defragStatusPersistTimeout = 30 * time.Second
-
-	// Bound how long we wait for scheduler cache to observe the drain label.
-	defragSchedulerCacheSyncTimeout = 30 * time.Second
-	defragSchedulerCacheSyncPoll    = 200 * time.Millisecond
 )
 
 const (
 	defragEventStarted           = "DefragStarted"
-	defragEventNodeDraining      = "DefragNodeDraining"
 	defragEventPodEvicted        = "DefragPodEvicted"
 	defragEventPodEvictFailed    = "DefragPodEvictFailed"
 	defragEventAbortNode         = "DefragAbortNode"
 	defragEventSkipUnschedulable = "DefragSkipUnschedulable"
 	defragEventSkipPDBBlocked    = "DefragSkipPDBBlocked"
-	defragEventNodeDrained       = "DefragNodeDrained"
-	defragEventDrainTimeout      = "DefragDrainTimeout"
-	defragEventStaleLabelCleared = "DefragStaleLabelCleared"
 	defragEventFinished          = "DefragFinished"
 )
 
@@ -80,30 +68,18 @@ type schedulerFitPodAPI interface {
 	) ([]fwk.NodeInfo, framework.Diagnosis, error)
 }
 
-func refreshSchedulerNodeInfoSnapshot(ctx context.Context, sched any) error {
-	if sched == nil {
-		return errors.New("scheduler is nil")
-	}
-	refresher, ok := sched.(schedulerSnapshotRefreshAPI)
-	if !ok {
-		return errors.New("scheduler vendor patch missing: UpdateNodeInfoSnapshot not available")
-	}
-	return refresher.UpdateNodeInfoSnapshot(ctx)
-}
-
 // Snapshot of the most recent defrag run for a pool.
 type defragRunStats struct {
-	StartTime          time.Time `json:"startTime"`
-	EndTime            time.Time `json:"endTime"`
-	CandidateNodes     int       `json:"candidateNodes"`
-	ProcessedNodes     int       `json:"processedNodes"`
-	EvictedPods        int       `json:"evictedPods"`
-	EvictionFailures   int       `json:"evictionFailures"`
-	UnmovableNodes     int       `json:"unmovableNodes"`
-	PDBBlockedNodes    int       `json:"pdbBlockedNodes"`
-	FreshPodSkips      int       `json:"freshPodSkips"`
-	DeadlineExceeded   bool      `json:"deadlineExceeded"`
-	DrainingCandidates []string  `json:"drainingCandidates,omitempty"`
+	StartTime        time.Time `json:"startTime"`
+	EndTime          time.Time `json:"endTime"`
+	CandidateNodes   int       `json:"candidateNodes"`
+	ProcessedNodes   int       `json:"processedNodes"`
+	EvictedPods      int       `json:"evictedPods"`
+	EvictionFailures int       `json:"evictionFailures"`
+	UnmovableNodes   int       `json:"unmovableNodes"`
+	PDBBlockedNodes  int       `json:"pdbBlockedNodes"`
+	FreshPodSkips    int       `json:"freshPodSkips"`
+	DeadlineExceeded bool      `json:"deadlineExceeded"`
 }
 
 // sync.Map keyed by pool name -> *defragRunStats.
@@ -125,9 +101,9 @@ func GetDefragLastRunStats() map[string]defragRunStats {
 
 // ----- cron gating ------------------------------------------------------
 
-// maybeStartDefragRun validates the config, checks the schedule, and starts
-// a background run when the pool is due.
-func (r *GPUPoolCompactionReconciler) maybeStartDefragRun(ctx context.Context, pool *tfv1.GPUPool) {
+// maybeRunDefragStep validates the config, checks the schedule, and processes
+// at most one defrag source node when the current campaign is due.
+func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, pool *tfv1.GPUPool) {
 	logger := log.FromContext(ctx).WithValues("pool", pool.Name, "component", "defrag")
 
 	cfg := getDefragConfig(pool)
@@ -153,15 +129,25 @@ func (r *GPUPoolCompactionReconciler) maybeStartDefragRun(ctx context.Context, p
 	}
 	maxDuration := parseDefragMaxDuration(cfg.MaxDuration, logger)
 
-	// Treat a run as due once a scheduled tick has elapsed since the anchor.
+	// Treat a campaign as due once a scheduled tick has elapsed since the anchor.
 	now := time.Now()
 	anchor := now.Add(-maxDuration).Add(-time.Minute)
 	if pool.Status.LastDefragTime != nil {
 		anchor = pool.Status.LastDefragTime.Time
 	}
-	next := schedule.Next(anchor)
-	if next.After(now) {
-		logger.V(5).Info("defrag not due yet", "next", next, "anchor", anchor)
+	campaignStart := schedule.Next(anchor)
+	if campaignStart.After(now) {
+		logger.V(5).Info("defrag not due yet", "next", campaignStart, "anchor", anchor)
+		return
+	}
+	if now.Sub(campaignStart) > maxDuration {
+		logger.Info("defrag campaign expired before this reconcile; advancing schedule anchor",
+			"campaignStart", campaignStart, "maxDuration", maxDuration)
+		persistCtx, persistCancel := context.WithTimeout(ctx, defragStatusPersistTimeout)
+		defer persistCancel()
+		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaignStart); err != nil {
+			logger.Error(err, "failed to patch pool.Status.LastDefragTime after expired defrag campaign")
+		}
 		return
 	}
 
@@ -171,15 +157,18 @@ func (r *GPUPoolCompactionReconciler) maybeStartDefragRun(ctx context.Context, p
 		logger.V(4).Info("defrag already running for this pool; skipping")
 		return
 	}
+	defer flag.Store(false)
 
-	runStart := time.Now()
-	poolCopy := pool.DeepCopy()
-	go func() {
-		defer flag.Store(false)
-		runCtx, cancel := context.WithTimeout(context.Background(), maxDuration)
-		defer cancel()
-		r.runDefrag(runCtx, poolCopy, runStart)
-	}()
+	runCtx, cancel := context.WithDeadline(ctx, campaignStart.Add(maxDuration))
+	defer cancel()
+	result := r.runDefragStep(runCtx, pool.DeepCopy(), campaignStart)
+	if result.finishCampaign {
+		persistCtx, persistCancel := context.WithTimeout(ctx, defragStatusPersistTimeout)
+		defer persistCancel()
+		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaignStart); err != nil {
+			logger.Error(err, "failed to patch pool.Status.LastDefragTime after defrag step")
+		}
+	}
 }
 
 func getDefragConfig(pool *tfv1.GPUPool) *tfv1.NodeDefragConfig {
@@ -204,55 +193,61 @@ func parseDefragMaxDuration(raw string, logger interface{ Info(string, ...any) }
 
 // ----- main run ---------------------------------------------------------
 
-// runDefrag processes one pool under a MaxDuration deadline.
-func (r *GPUPoolCompactionReconciler) runDefrag(
+type defragStepResult struct {
+	evictedNode    bool
+	finishCampaign bool
+}
+
+// runDefragStep processes one pool under the current campaign deadline and
+// emits evictions for at most one source node.
+func (r *GPUPoolCompactionReconciler) runDefragStep(
 	ctx context.Context,
 	pool *tfv1.GPUPool,
 	runStart time.Time,
-) {
+) defragStepResult {
 	l := log.FromContext(ctx).WithValues("pool", pool.Name, "component", "defrag", "runStart", runStart)
 	r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventStarted,
-		"defrag run started at %s", runStart.Format(time.RFC3339))
+		"defrag step started at %s", runStart.Format(time.RFC3339))
 
 	stats := &defragRunStats{StartTime: runStart}
 	defer func() {
 		stats.EndTime = time.Now()
 		defragLastRunStats.Store(pool.Name, stats)
-		// Use a fresh context so timeouts still persist the schedule anchor.
-		persistCtx, persistCancel := context.WithTimeout(
-			context.Background(), defragStatusPersistTimeout)
-		defer persistCancel()
-		if err := r.patchPoolLastDefragTime(persistCtx, pool, runStart); err != nil {
-			l.Error(err, "failed to patch pool.Status.LastDefragTime")
-		}
 		r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventFinished,
-			"defrag run finished: candidates=%d processed=%d evicted=%d failed=%d unmovable=%d pdbBlocked=%d freshSkip=%d deadline=%t",
+			"defrag step finished: candidates=%d processed=%d evicted=%d failed=%d unmovable=%d pdbBlocked=%d freshSkip=%d deadline=%t",
 			stats.CandidateNodes, stats.ProcessedNodes, stats.EvictedPods, stats.EvictionFailures,
 			stats.UnmovableNodes, stats.PDBBlockedNodes, stats.FreshPodSkips, stats.DeadlineExceeded)
 	}()
 
+	blocked, err := r.hasDefragEvictedPods(ctx)
+	if err != nil {
+		l.Error(err, "list defrag-evicted pods failed")
+		return defragStepResult{}
+	}
+	if blocked {
+		l.Info("defrag paused: defrag-evicted pod still exists")
+		return defragStepResult{}
+	}
+
 	candidates, err := r.collectDefragCandidates(ctx, pool)
 	if err != nil {
 		l.Error(err, "collect defrag candidates failed")
-		return
+		return defragStepResult{}
 	}
 	stats.CandidateNodes = len(candidates)
 	if len(candidates) == 0 {
 		l.Info("no defrag candidates")
-		return
+		return defragStepResult{finishCampaign: true}
 	}
 
 	maxWorkerPerNode := r.Allocator.MaxWorkerPerNode()
-
-	for _, cand := range candidates {
-		if ctxDone(ctx) {
-			stats.DeadlineExceeded = true
-			l.Info("defrag deadline exceeded during candidate loop", "remaining", len(candidates)-stats.ProcessedNodes)
-			return
-		}
-		stats.ProcessedNodes++
-		r.processDefragCandidate(ctx, pool, cand, runStart, maxWorkerPerNode, stats)
+	result := runDefragCandidateLoop(ctx, candidates, stats, func(cand *defragCandidate) defragCandidateOutcome {
+		return r.processDefragCandidate(ctx, pool, cand, maxWorkerPerNode, stats)
+	})
+	if stats.DeadlineExceeded {
+		l.Info("defrag deadline exceeded during candidate loop", "remaining", len(candidates)-stats.ProcessedNodes)
 	}
+	return result
 }
 
 func ctxDone(ctx context.Context) bool {
@@ -262,6 +257,30 @@ func ctxDone(ctx context.Context) bool {
 	default:
 		return false
 	}
+}
+
+func runDefragCandidateLoop(
+	ctx context.Context,
+	candidates []*defragCandidate,
+	stats *defragRunStats,
+	process func(*defragCandidate) defragCandidateOutcome,
+) defragStepResult {
+	for _, cand := range candidates {
+		if ctxDone(ctx) {
+			stats.DeadlineExceeded = true
+			return defragStepResult{finishCampaign: true}
+		}
+		stats.ProcessedNodes++
+		switch process(cand) {
+		case defragCandidateSkipped:
+			continue
+		case defragCandidateEvicted:
+			return defragStepResult{evictedNode: true}
+		case defragCandidateAborted:
+			return defragStepResult{}
+		}
+	}
+	return defragStepResult{finishCampaign: true}
 }
 
 // ----- candidate filtering + sorting ------------------------------------
@@ -281,6 +300,8 @@ func (r *GPUPoolCompactionReconciler) collectDefragCandidates(ctx context.Contex
 	if cfg == nil {
 		return nil, nil
 	}
+	minPodAge := parseDefragMaxDuration(cfg.MaxDuration, log.FromContext(ctx))
+	now := time.Now()
 
 	allNodes := &tfv1.GPUNodeList{}
 	if err := r.List(ctx, allNodes, client.MatchingLabels(map[string]string{
@@ -318,9 +339,6 @@ func (r *GPUPoolCompactionReconciler) collectDefragCandidates(ctx context.Contex
 		if k8sNode.Spec.Unschedulable {
 			continue
 		}
-		if k8sNode.Labels[constants.DefragDrainingLabel] == constants.TrueStringValue {
-			continue
-		}
 
 		nodeGPUs := nodeGpuStore[k8sNodeName]
 		if len(nodeGPUs) == 0 {
@@ -345,6 +363,14 @@ func (r *GPUPoolCompactionReconciler) collectDefragCandidates(ctx context.Contex
 		if len(pods) == 0 {
 			continue
 		}
+		if freshPod, ok := findFreshDefragWorker(now, minPodAge, pods); ok {
+			log.FromContext(ctx).V(4).Info("skip defrag candidate: contains fresh TF worker",
+				"node", k8sNodeName,
+				"pod", freshPod.Namespace+"/"+freshPod.Name,
+				"createdAt", freshPod.CreationTimestamp.Time,
+				"minAge", minPodAge)
+			continue
+		}
 
 		out = append(out, &defragCandidate{
 			nodeName:         k8sNodeName,
@@ -361,6 +387,16 @@ func (r *GPUPoolCompactionReconciler) collectDefragCandidates(ctx context.Contex
 		return out[i].utilizationScore < out[j].utilizationScore
 	})
 	return out, nil
+}
+
+func (r *GPUPoolCompactionReconciler) hasDefragEvictedPods(ctx context.Context) (bool, error) {
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList, client.MatchingLabels{
+		constants.DefragEvictedPodLabel: constants.TrueStringValue,
+	}); err != nil {
+		return false, fmt.Errorf("list defrag-evicted pods: %w", err)
+	}
+	return len(podList.Items) > 0, nil
 }
 
 func countPoolGPUUsage(gpus map[string]*tfv1.GPU, poolName string) (total, used int) {
@@ -418,56 +454,44 @@ func (r *GPUPoolCompactionReconciler) listNodeWorkerPods(
 
 // ----- per-candidate processing ----------------------------------------
 
+type defragCandidateOutcome int
+
+const (
+	defragCandidateSkipped defragCandidateOutcome = iota
+	defragCandidateEvicted
+	defragCandidateAborted
+)
+
 func (r *GPUPoolCompactionReconciler) processDefragCandidate(
 	ctx context.Context,
 	pool *tfv1.GPUPool,
 	cand *defragCandidate,
-	runStart time.Time,
 	maxWorkerPerNode int,
 	stats *defragRunStats,
-) {
+) defragCandidateOutcome {
 	l := log.FromContext(ctx).WithValues("pool", pool.Name, "node", cand.nodeName,
 		"utilization", cand.utilizationScore, "workerCount", len(cand.workerPods))
 
-	// Label the source node before simulation so it cannot be chosen again.
-	if err := r.applyDefragDrainingLabel(ctx, cand.nodeName, pool.Name); err != nil {
-		l.Error(err, "patch draining label failed; skip candidate")
-		return
-	}
-	r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventNodeDraining,
-		"node %s labeled for defrag draining (utilization=%.1f%%, workers=%d)",
-		cand.nodeName, cand.utilizationScore, len(cand.workerPods))
-
-	if err := r.waitSchedulerObservedDefragLabel(ctx, cand); err != nil {
-		l.Error(err, "scheduler cache did not observe drain label; skip candidate")
-		if clearErr := r.clearDefragDrainingLabel(ctx, cand.nodeName); clearErr != nil {
-			l.Error(clearErr, "clear draining label failed after scheduler cache wait")
-		}
-		return
-	}
-
 	refreshedPods, err := r.currentNodeWorkerPods(ctx, cand.nodeName)
 	if err != nil {
-		l.Error(err, "refresh worker pods failed after drain label; skip candidate")
-		if clearErr := r.clearDefragDrainingLabel(ctx, cand.nodeName); clearErr != nil {
-			l.Error(clearErr, "clear draining label failed after worker refresh error")
-		}
-		return
+		l.Error(err, "refresh worker pods failed; skip candidate")
+		return defragCandidateSkipped
 	}
 	if len(refreshedPods) == 0 {
-		if clearErr := r.clearDefragDrainingLabel(ctx, cand.nodeName); clearErr != nil {
-			l.Error(clearErr, "clear draining label failed after empty worker refresh")
-		}
-		return
+		return defragCandidateSkipped
 	}
-	if freshPod, ok := findNewOrFreshDefragWorker(runStart, cand.workerPods, refreshedPods); ok {
+	cfg := getDefragConfig(pool)
+	minPodAge := defaultDefragMaxDuration
+	if cfg != nil {
+		minPodAge = parseDefragMaxDuration(cfg.MaxDuration, l)
+	}
+	if freshPod, ok := findFreshDefragWorker(time.Now(), minPodAge, refreshedPods); ok {
 		stats.FreshPodSkips++
-		l.Info("skip node: contains TF worker that appeared after candidate collection",
-			"pod", freshPod.Namespace+"/"+freshPod.Name, "createdAt", freshPod.CreationTimestamp.Time)
-		if clearErr := r.clearDefragDrainingLabel(ctx, cand.nodeName); clearErr != nil {
-			l.Error(clearErr, "clear draining label failed after fresh worker detection")
-		}
-		return
+		l.Info("skip node: contains fresh TF worker",
+			"pod", freshPod.Namespace+"/"+freshPod.Name,
+			"createdAt", freshPod.CreationTimestamp.Time,
+			"minAge", minPodAge)
+		return defragCandidateSkipped
 	}
 	cand.workerPods = refreshedPods
 
@@ -479,10 +503,7 @@ func (r *GPUPoolCompactionReconciler) processDefragCandidate(
 		stats.UnmovableNodes++
 		r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventSkipUnschedulable,
 			"node %s skipped: current TF workers cannot be jointly placed on other nodes", cand.nodeName)
-		if err := r.clearDefragDrainingLabel(ctx, cand.nodeName); err != nil {
-			l.Error(err, "clear draining label failed after unmovable verdict")
-		}
-		return
+		return defragCandidateSkipped
 	}
 
 	pdbBlocked, pdbReason, err := r.checkDefragPDBPreflight(ctx, cand)
@@ -490,31 +511,24 @@ func (r *GPUPoolCompactionReconciler) processDefragCandidate(
 		stats.EvictionFailures++
 		r.Recorder.Eventf(pool, corev1.EventTypeWarning, defragEventAbortNode,
 			"node %s: eviction preflight failed: %v", cand.nodeName, err)
-		if clearErr := r.clearDefragDrainingLabel(ctx, cand.nodeName); clearErr != nil {
-			l.Error(clearErr, "clear draining label failed after eviction preflight error")
-		}
-		return
+		return defragCandidateAborted
 	}
 	if pdbBlocked {
 		stats.PDBBlockedNodes++
 		r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventSkipPDBBlocked,
 			"node %s skipped before eviction: %s", cand.nodeName, pdbReason)
-		if err := r.clearDefragDrainingLabel(ctx, cand.nodeName); err != nil {
-			l.Error(err, "clear draining label failed after PDB preflight block")
-		}
-		return
+		return defragCandidateSkipped
 	}
 
-	// Abort the node on the first eviction failure and leave stale cleanup
-	// to remove the label later.
+	// Abort the node on the first eviction or post-eviction label failure.
 	allSucceeded := r.evictWorkerPods(ctx, pool, cand, stats, l)
 	if allSucceeded {
-		r.defragDrainingNodes.Store(cand.nodeName, time.Now())
-		stats.DrainingCandidates = append(stats.DrainingCandidates, cand.nodeName)
+		return defragCandidateEvicted
 	} else {
 		r.Recorder.Eventf(pool, corev1.EventTypeWarning, defragEventAbortNode,
-			"node %s: eviction aborted; label retained for stale cleanup", cand.nodeName)
+			"node %s: eviction aborted", cand.nodeName)
 	}
+	return defragCandidateAborted
 }
 
 // ----- simulation: joint placement using local budget -------------------
@@ -558,7 +572,6 @@ func (r *GPUPoolCompactionReconciler) simulateJointPlacement(
 		nodeGpuStore,
 		nodeWorkerStore,
 		schedFramework.SnapshotSharedLister().NodeInfos(),
-		r.snapshotDefragDrainingNodes(),
 	)
 	if len(budget) == 0 {
 		return false, nil
@@ -771,14 +784,10 @@ func buildDefragNodeBudgets(
 	nodeGpuStore map[string]map[string]*tfv1.GPU,
 	nodeWorkerStore map[string]map[types.NamespacedName]struct{},
 	nodeInfoLister framework.NodeInfoLister,
-	drainingNodes map[string]struct{},
 ) map[string]*nodeBudget {
 	budget := make(map[string]*nodeBudget, len(nodeGpuStore))
 	for nodeName, gpus := range nodeGpuStore {
 		if nodeName == sourceNode {
-			continue
-		}
-		if _, draining := drainingNodes[nodeName]; draining {
 			continue
 		}
 		nodeInfo, err := nodeInfoLister.Get(nodeName)
@@ -814,118 +823,28 @@ func buildDefragNodeBudgets(
 	return budget
 }
 
-func (r *GPUPoolCompactionReconciler) snapshotDefragDrainingNodes() map[string]struct{} {
-	out := map[string]struct{}{}
-	r.defragDrainingNodes.Range(func(k, _ any) bool {
-		nodeName, _ := k.(string)
-		if nodeName != "" {
-			out[nodeName] = struct{}{}
-		}
-		return true
-	})
-	return out
-}
-
 func (r *GPUPoolCompactionReconciler) currentNodeWorkerPods(ctx context.Context, nodeName string) ([]*corev1.Pod, error) {
 	nodeWorkerStore := r.Allocator.GetNodeWorkerStoreSnapshot()
 	return r.listNodeWorkerPods(ctx, nodeName, nodeWorkerStore[nodeName])
 }
 
-func findNewOrFreshDefragWorker(
-	runStart time.Time,
-	originalPods []*corev1.Pod,
-	currentPods []*corev1.Pod,
+func findFreshDefragWorker(
+	now time.Time,
+	minAge time.Duration,
+	pods []*corev1.Pod,
 ) (*corev1.Pod, bool) {
-	original := make(map[types.NamespacedName]struct{}, len(originalPods))
-	for _, p := range originalPods {
-		if p == nil {
-			continue
-		}
-		original[types.NamespacedName{Namespace: p.Namespace, Name: p.Name}] = struct{}{}
+	if minAge <= 0 {
+		return nil, false
 	}
-	for _, p := range currentPods {
-		if p == nil {
+	for _, p := range pods {
+		if p == nil || p.CreationTimestamp.IsZero() {
 			continue
 		}
-		if p.CreationTimestamp.After(runStart) {
-			return p, true
-		}
-		key := types.NamespacedName{Namespace: p.Namespace, Name: p.Name}
-		if _, existed := original[key]; !existed {
+		if now.Sub(p.CreationTimestamp.Time) < minAge {
 			return p, true
 		}
 	}
 	return nil, false
-}
-
-func (r *GPUPoolCompactionReconciler) waitSchedulerObservedDefragLabel(
-	ctx context.Context,
-	cand *defragCandidate,
-) error {
-	profileName := constants.SchedulerName
-	if len(cand.workerPods) > 0 && cand.workerPods[0].Spec.SchedulerName != "" {
-		profileName = cand.workerPods[0].Spec.SchedulerName
-	}
-	schedFramework := r.Scheduler.Profiles[profileName]
-	if schedFramework == nil {
-		return fmt.Errorf("scheduler framework not found for scheduler %q", profileName)
-	}
-	waitCtx, cancel := context.WithTimeout(ctx, defragSchedulerCacheSyncTimeout)
-	defer cancel()
-	return waitForSchedulerNodeDefragLabel(
-		waitCtx,
-		func(ctx context.Context) error {
-			return refreshSchedulerNodeInfoSnapshot(ctx, r.Scheduler)
-		},
-		schedFramework.SnapshotSharedLister().NodeInfos(),
-		cand.nodeName,
-		defragSchedulerCacheSyncPoll,
-	)
-}
-
-func waitForSchedulerNodeDefragLabel(
-	ctx context.Context,
-	refreshSnapshot func(context.Context) error,
-	nodeInfoLister framework.NodeInfoLister,
-	nodeName string,
-	pollInterval time.Duration,
-) error {
-	if nodeInfoLister == nil {
-		return fmt.Errorf("scheduler node info lister is nil")
-	}
-	if pollInterval <= 0 {
-		pollInterval = defragSchedulerCacheSyncPoll
-	}
-
-	ticker := time.NewTicker(pollInterval)
-	defer ticker.Stop()
-	var lastRefreshErr error
-	for {
-		if refreshSnapshot != nil {
-			if err := refreshSnapshot(ctx); err != nil {
-				lastRefreshErr = err
-			} else {
-				lastRefreshErr = nil
-			}
-		}
-
-		nodeInfo, err := nodeInfoLister.Get(nodeName)
-		if err == nil {
-			if node := nodeInfo.Node(); node != nil &&
-				node.Labels[constants.DefragDrainingLabel] == constants.TrueStringValue {
-				return nil
-			}
-		}
-
-		select {
-		case <-ctx.Done():
-			if lastRefreshErr != nil {
-				return fmt.Errorf("refresh scheduler node info snapshot while waiting for defrag drain label on node %s: %w", nodeName, lastRefreshErr)
-			}
-			return fmt.Errorf("wait for scheduler cache to observe defrag drain label on node %s: %w", nodeName, ctx.Err())
-		case <-ticker.C:
-		}
-	}
 }
 
 // subtractGPURequest mirrors GpuAllocator.Bind.
@@ -1018,6 +937,15 @@ func (r *GPUPoolCompactionReconciler) evictWorkerPods(
 		}
 		err := r.KubeClient.CoreV1().Pods(pod.Namespace).EvictV1(ctx, eviction)
 		if err == nil {
+			if markErr := r.markPodDefragEvicted(ctx, pod); markErr != nil {
+				stats.EvictionFailures++
+				r.Recorder.Eventf(pool, corev1.EventTypeWarning, defragEventPodEvictFailed,
+					"evicted pod %s/%s on node %s but failed to mark defrag label: %v (node eviction aborted)",
+					pod.Namespace, pod.Name, cand.nodeName, markErr)
+				logger.Error(markErr, "failed to mark evicted pod; aborting remaining pods on node",
+					"pod", pod.Namespace+"/"+pod.Name, "node", cand.nodeName)
+				return false
+			}
 			stats.EvictedPods++
 			r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventPodEvicted,
 				"evicted pod %s/%s on node %s for defrag", pod.Namespace, pod.Name, cand.nodeName)
@@ -1038,227 +966,35 @@ func (r *GPUPoolCompactionReconciler) evictWorkerPods(
 	return true
 }
 
-// ----- drain watcher / stale cleanup -----------------------------------
-
-// defragDrainWatcherTick clears labels once allocator state sees a node as
-// empty. Timed-out nodes stay labeled until stale cleanup removes them.
-func (r *GPUPoolCompactionReconciler) defragDrainWatcherTick(ctx context.Context, pool *tfv1.GPUPool) {
-	if r.Allocator == nil {
-		return
+func (r *GPUPoolCompactionReconciler) markPodDefragEvicted(ctx context.Context, pod *corev1.Pod) error {
+	if r.KubeClient == nil {
+		return errors.New("kube client is nil")
 	}
-	if !r.Allocator.IsReady() {
-		return
+	if pod == nil {
+		return errors.New("pod is nil")
 	}
-	nodeWorkerStore := r.Allocator.GetNodeWorkerStoreSnapshot()
-
-	r.defragDrainingNodes.Range(func(k, v any) bool {
-		nodeName, _ := k.(string)
-		start, _ := v.(time.Time)
-		node := &corev1.Node{}
-		if err := r.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
-			if apierrors.IsNotFound(err) {
-				r.defragDrainingNodes.Delete(nodeName)
-				return true
-			}
-			log.FromContext(ctx).Error(err, "get draining node in watcher", "node", nodeName)
-			return true
-		}
-		belongs, err := r.defragNodeBelongsToPool(ctx, pool.Name, node)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "check draining node pool ownership",
-				"node", nodeName, "pool", pool.Name)
-			return true
-		}
-		if !belongs {
-			return true
-		}
-
-		if len(nodeWorkerStore[nodeName]) == 0 {
-			if err := r.clearDefragDrainingLabel(ctx, nodeName); err != nil {
-				log.FromContext(ctx).Error(err, "clear draining label in watcher",
-					"node", nodeName)
-				return true
-			}
-			r.defragDrainingNodes.Delete(nodeName)
-			r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventNodeDrained,
-				"node %s fully drained after defrag", nodeName)
-			return true
-		}
-		if time.Since(start) > drainConfirmationTimeout {
-			r.Recorder.Eventf(pool, corev1.EventTypeWarning, defragEventDrainTimeout,
-				"node %s still has %d TF workers after %s; relying on stale cleanup",
-				nodeName, len(nodeWorkerStore[nodeName]), drainConfirmationTimeout)
-		}
-		return true
-	})
-}
-
-// defragStaleLabelCleanupTick removes old drain labels for the current pool.
-func (r *GPUPoolCompactionReconciler) defragStaleLabelCleanupTick(ctx context.Context, pool *tfv1.GPUPool) {
-	cfg := getDefragConfig(pool)
-	if cfg == nil {
-		return
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				constants.DefragEvictedPodLabel: constants.TrueStringValue,
+			},
+		},
 	}
-	maxDuration := parseDefragMaxDuration(cfg.MaxDuration, log.FromContext(ctx))
-	staleAfter := 2 * maxDuration
-
-	nodeList := &corev1.NodeList{}
-	if err := r.List(ctx, nodeList, client.MatchingLabels{
-		constants.DefragDrainingLabel: constants.TrueStringValue,
-	}); err != nil {
-		log.FromContext(ctx).Error(err, "list draining nodes for stale cleanup")
-		return
+	raw, err := json.Marshal(patch)
+	if err != nil {
+		return err
 	}
-	now := time.Now()
-	for i := range nodeList.Items {
-		n := &nodeList.Items[i]
-		belongs, err := r.defragNodeBelongsToPool(ctx, pool.Name, n)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "check stale draining node pool ownership",
-				"node", n.Name, "pool", pool.Name)
-			continue
-		}
-		if !belongs {
-			continue
-		}
-
-		raw := n.Annotations[constants.DefragDrainingSinceAnnotation]
-		if raw == "" {
-			_ = r.clearDefragDrainingLabel(ctx, n.Name)
-			r.defragDrainingNodes.Delete(n.Name)
-			continue
-		}
-		since, err := time.Parse(time.RFC3339, raw)
-		if err != nil {
-			_ = r.clearDefragDrainingLabel(ctx, n.Name)
-			r.defragDrainingNodes.Delete(n.Name)
-			continue
-		}
-		if now.Sub(since) > staleAfter {
-			if err := r.clearDefragDrainingLabel(ctx, n.Name); err != nil {
-				log.FromContext(ctx).Error(err, "clear stale draining label", "node", n.Name)
-				continue
-			}
-			r.defragDrainingNodes.Delete(n.Name)
-			r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventStaleLabelCleared,
-				"node %s defrag draining label cleared after %s", n.Name, now.Sub(since))
-		}
-	}
-}
-
-// scheduleDefragDrainWatcherBootstrap rebuilds in-memory drain state after
-// the manager cache is ready.
-func (r *GPUPoolCompactionReconciler) scheduleDefragDrainWatcherBootstrap(mgr manager.Manager) {
-	_ = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		if !mgr.GetCache().WaitForCacheSync(ctx) {
-			return nil
-		}
-		nodeList := &corev1.NodeList{}
-		if err := r.List(ctx, nodeList, client.MatchingLabels{
-			constants.DefragDrainingLabel: constants.TrueStringValue,
-		}); err != nil {
-			log.FromContext(ctx).Error(err, "bootstrap draining nodes list failed")
-			return nil
-		}
-		if r.Allocator == nil {
-			return nil
-		}
-		if !r.Allocator.WaitUntilReady(ctx) {
-			return nil
-		}
-		nodeWorkerStore := r.Allocator.GetNodeWorkerStoreSnapshot()
-		for i := range nodeList.Items {
-			n := &nodeList.Items[i]
-			if len(nodeWorkerStore[n.Name]) == 0 {
-				_ = r.clearDefragDrainingLabel(ctx, n.Name)
-				continue
-			}
-			since := n.Annotations[constants.DefragDrainingSinceAnnotation]
-			start := time.Now()
-			if since != "" {
-				if t, err := time.Parse(time.RFC3339, since); err == nil {
-					start = t
-				}
-			}
-			r.defragDrainingNodes.Store(n.Name, start)
-		}
+	_, err = r.KubeClient.CoreV1().Pods(pod.Namespace).Patch(
+		ctx,
+		pod.Name,
+		types.MergePatchType,
+		raw,
+		metav1.PatchOptions{},
+	)
+	if apierrors.IsNotFound(err) {
 		return nil
-	}))
-}
-
-// ----- node label / annotation helpers ---------------------------------
-
-func (r *GPUPoolCompactionReconciler) defragNodeBelongsToPool(ctx context.Context, poolName string, node *corev1.Node) (bool, error) {
-	if node == nil {
-		return false, nil
 	}
-	if node.Annotations != nil {
-		if owner := node.Annotations[constants.DefragDrainingPoolAnnotation]; owner != "" {
-			return owner == poolName, nil
-		}
-	}
-
-	poolKey := fmt.Sprintf(constants.GPUNodePoolIdentifierLabelFormat, poolName)
-	if node.Labels != nil && node.Labels[poolKey] == constants.TrueStringValue {
-		return true, nil
-	}
-
-	gpuNode := &tfv1.GPUNode{}
-	if err := r.Get(ctx, client.ObjectKey{Name: node.Name}, gpuNode); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return gpuNode.Labels[poolKey] == constants.TrueStringValue, nil
-}
-
-// applyDefragDrainingLabel writes the drain label and annotations.
-func (r *GPUPoolCompactionReconciler) applyDefragDrainingLabel(ctx context.Context, nodeName string, poolName string) error {
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"labels": map[string]any{
-				constants.DefragDrainingLabel: constants.TrueStringValue,
-			},
-			"annotations": map[string]any{
-				constants.DefragDrainingSinceAnnotation: time.Now().Format(time.RFC3339),
-				constants.DefragDrainingPoolAnnotation:  poolName,
-			},
-		},
-	}
-	raw, err := json.Marshal(patch)
-	if err != nil {
-		return err
-	}
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
-	return r.Patch(ctx, node, client.RawPatch(types.MergePatchType, raw))
-}
-
-// clearDefragDrainingLabel removes the label and annotation.
-func (r *GPUPoolCompactionReconciler) clearDefragDrainingLabel(ctx context.Context, nodeName string) error {
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"labels": map[string]any{
-				constants.DefragDrainingLabel: nil,
-			},
-			"annotations": map[string]any{
-				constants.DefragDrainingSinceAnnotation: nil,
-				constants.DefragDrainingPoolAnnotation:  nil,
-			},
-		},
-	}
-	raw, err := json.Marshal(patch)
-	if err != nil {
-		return err
-	}
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
-	if err := r.Patch(ctx, node, client.RawPatch(types.MergePatchType, raw)); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	return nil
+	return err
 }
 
 // patchPoolLastDefragTime persists the schedule anchor in status.
@@ -1272,5 +1008,3 @@ func (r *GPUPoolCompactionReconciler) patchPoolLastDefragTime(ctx context.Contex
 	live.Status.LastDefragTime = &now
 	return r.Status().Patch(ctx, live, patch)
 }
-
-var _ = ctrl.Result{}

--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -41,6 +41,9 @@ const (
 
 	// Independent timeout for persisting LastDefragTime.
 	defragStatusPersistTimeout = 30 * time.Second
+
+	// Short requeue used while a stepwise defrag campaign is still active.
+	defragActiveStepRequeue = 10 * time.Second
 )
 
 const (
@@ -102,30 +105,32 @@ func GetDefragLastRunStats() map[string]defragRunStats {
 // ----- cron gating ------------------------------------------------------
 
 // maybeRunDefragStep validates the config, checks the schedule, and processes
-// at most one defrag source node when the current campaign is due.
-func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, pool *tfv1.GPUPool) {
+// at most one defrag source node when the current campaign is due. It returns a
+// non-zero requeue when the caller should wake before the normal compaction
+// interval.
+func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, pool *tfv1.GPUPool, normalRequeue time.Duration) time.Duration {
 	logger := log.FromContext(ctx).WithValues("pool", pool.Name, "component", "defrag")
 
 	cfg := getDefragConfig(pool)
 	if cfg == nil || !cfg.Enabled {
-		return
+		return 0
 	}
 	if r.Scheduler == nil || r.KubeClient == nil {
 		logger.V(4).Info("defrag skipped: scheduler or kube client not wired; set ENABLE_SCHEDULER=true and inject KubeClient")
-		return
+		return 0
 	}
 	if r.Allocator == nil {
-		return
+		return 0
 	}
 	if !r.Allocator.IsReady() {
 		logger.V(4).Info("defrag skipped: allocator not ready")
-		return
+		return 0
 	}
 
 	schedule, err := r.defragParser.Parse(cfg.Schedule)
 	if err != nil {
 		logger.Error(err, "invalid defrag cron schedule; defrag disabled", "schedule", cfg.Schedule)
-		return
+		return 0
 	}
 	maxDuration := parseDefragMaxDuration(cfg.MaxDuration, logger)
 
@@ -138,7 +143,7 @@ func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, po
 	campaignStart := schedule.Next(anchor)
 	if campaignStart.After(now) {
 		logger.V(5).Info("defrag not due yet", "next", campaignStart, "anchor", anchor)
-		return
+		return 0
 	}
 	if now.Sub(campaignStart) > maxDuration {
 		logger.Info("defrag campaign expired before this reconcile; advancing schedule anchor",
@@ -148,14 +153,14 @@ func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, po
 		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaignStart); err != nil {
 			logger.Error(err, "failed to patch pool.Status.LastDefragTime after expired defrag campaign")
 		}
-		return
+		return 0
 	}
 
 	flagAny, _ := r.defragRunning.LoadOrStore(pool.Name, &atomic.Bool{})
 	flag, _ := flagAny.(*atomic.Bool)
 	if !flag.CompareAndSwap(false, true) {
 		logger.V(4).Info("defrag already running for this pool; skipping")
-		return
+		return defragActiveStepRequeue
 	}
 	defer flag.Store(false)
 
@@ -169,6 +174,7 @@ func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, po
 			logger.Error(err, "failed to patch pool.Status.LastDefragTime after defrag step")
 		}
 	}
+	return defragRequeueAfter(result, normalRequeue)
 }
 
 func getDefragConfig(pool *tfv1.GPUPool) *tfv1.NodeDefragConfig {
@@ -194,8 +200,21 @@ func parseDefragMaxDuration(raw string, logger interface{ Info(string, ...any) }
 // ----- main run ---------------------------------------------------------
 
 type defragStepResult struct {
-	evictedNode    bool
-	finishCampaign bool
+	evictedNode         bool
+	finishCampaign      bool
+	blockedByEvictedPod bool
+}
+
+func defragRequeueAfter(result defragStepResult, normalRequeue time.Duration) time.Duration {
+	if normalRequeue <= 0 {
+		normalRequeue = defaultCompactionDuration
+	}
+	if result.evictedNode || result.blockedByEvictedPod {
+		if defragActiveStepRequeue < normalRequeue {
+			return defragActiveStepRequeue
+		}
+	}
+	return normalRequeue
 }
 
 // runDefragStep processes one pool under the current campaign deadline and
@@ -219,14 +238,14 @@ func (r *GPUPoolCompactionReconciler) runDefragStep(
 			stats.UnmovableNodes, stats.PDBBlockedNodes, stats.FreshPodSkips, stats.DeadlineExceeded)
 	}()
 
-	blocked, err := r.hasDefragEvictedPods(ctx)
+	blocked, err := r.hasDefragEvictedPods(ctx, pool)
 	if err != nil {
 		l.Error(err, "list defrag-evicted pods failed")
 		return defragStepResult{}
 	}
 	if blocked {
 		l.Info("defrag paused: defrag-evicted pod still exists")
-		return defragStepResult{}
+		return defragStepResult{blockedByEvictedPod: true}
 	}
 
 	candidates, err := r.collectDefragCandidates(ctx, pool)
@@ -389,14 +408,72 @@ func (r *GPUPoolCompactionReconciler) collectDefragCandidates(ctx context.Contex
 	return out, nil
 }
 
-func (r *GPUPoolCompactionReconciler) hasDefragEvictedPods(ctx context.Context) (bool, error) {
+func (r *GPUPoolCompactionReconciler) hasDefragEvictedPods(ctx context.Context, pool *tfv1.GPUPool) (bool, error) {
+	if pool == nil {
+		return false, errors.New("pool is nil")
+	}
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList, client.MatchingLabels{
 		constants.DefragEvictedPodLabel: constants.TrueStringValue,
 	}); err != nil {
 		return false, fmt.Errorf("list defrag-evicted pods: %w", err)
 	}
-	return len(podList.Items) > 0, nil
+	cfg := getDefragConfig(pool)
+	maxDuration := defaultDefragMaxDuration
+	if cfg != nil {
+		maxDuration = parseDefragMaxDuration(cfg.MaxDuration, log.FromContext(ctx))
+	}
+	staleAfter := 2 * maxDuration
+	now := time.Now()
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if !defragEvictedPodBelongsToPool(pool.Name, pod) {
+			continue
+		}
+		if isDefragEvictedPodMarkerStale(pod, now, staleAfter) {
+			if err := r.clearPodDefragEvictedMarker(ctx, pod); err != nil {
+				log.FromContext(ctx).Error(err, "clear stale defrag-evicted pod marker",
+					"pod", pod.Namespace+"/"+pod.Name, "pool", pool.Name)
+			}
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func defragEvictedPodBelongsToPool(poolName string, pod *corev1.Pod) bool {
+	if pod == nil || poolName == "" {
+		return false
+	}
+	if pod.Annotations == nil {
+		return false
+	}
+	if owner := pod.Annotations[constants.DefragEvictedPodPoolAnnotation]; owner != "" {
+		return owner == poolName
+	}
+	return pod.Annotations[constants.GpuPoolKey] == poolName
+}
+
+func isDefragEvictedPodMarkerStale(pod *corev1.Pod, now time.Time, staleAfter time.Duration) bool {
+	if pod == nil || staleAfter <= 0 {
+		return false
+	}
+	var since time.Time
+	if pod.Annotations != nil {
+		if raw := pod.Annotations[constants.DefragEvictedPodSinceAnnotation]; raw != "" {
+			if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+				since = parsed
+			}
+		}
+	}
+	if since.IsZero() && !pod.CreationTimestamp.IsZero() {
+		since = pod.CreationTimestamp.Time
+	}
+	if since.IsZero() {
+		return false
+	}
+	return now.Sub(since) > staleAfter
 }
 
 func countPoolGPUUsage(gpus map[string]*tfv1.GPU, poolName string) (total, used int) {
@@ -937,7 +1014,7 @@ func (r *GPUPoolCompactionReconciler) evictWorkerPods(
 		}
 		err := r.KubeClient.CoreV1().Pods(pod.Namespace).EvictV1(ctx, eviction)
 		if err == nil {
-			if markErr := r.markPodDefragEvicted(ctx, pod); markErr != nil {
+			if markErr := r.markPodDefragEvicted(ctx, pool.Name, pod); markErr != nil {
 				stats.EvictionFailures++
 				r.Recorder.Eventf(pool, corev1.EventTypeWarning, defragEventPodEvictFailed,
 					"evicted pod %s/%s on node %s but failed to mark defrag label: %v (node eviction aborted)",
@@ -966,7 +1043,9 @@ func (r *GPUPoolCompactionReconciler) evictWorkerPods(
 	return true
 }
 
-func (r *GPUPoolCompactionReconciler) markPodDefragEvicted(ctx context.Context, pod *corev1.Pod) error {
+// ----- pod marker helpers ----------------------------------------------
+
+func (r *GPUPoolCompactionReconciler) markPodDefragEvicted(ctx context.Context, poolName string, pod *corev1.Pod) error {
 	if r.KubeClient == nil {
 		return errors.New("kube client is nil")
 	}
@@ -977,6 +1056,10 @@ func (r *GPUPoolCompactionReconciler) markPodDefragEvicted(ctx context.Context, 
 		"metadata": map[string]any{
 			"labels": map[string]any{
 				constants.DefragEvictedPodLabel: constants.TrueStringValue,
+			},
+			"annotations": map[string]any{
+				constants.DefragEvictedPodPoolAnnotation:  poolName,
+				constants.DefragEvictedPodSinceAnnotation: time.Now().Format(time.RFC3339),
 			},
 		},
 	}
@@ -995,6 +1078,35 @@ func (r *GPUPoolCompactionReconciler) markPodDefragEvicted(ctx context.Context, 
 		return nil
 	}
 	return err
+}
+
+func (r *GPUPoolCompactionReconciler) clearPodDefragEvictedMarker(ctx context.Context, pod *corev1.Pod) error {
+	if pod == nil {
+		return nil
+	}
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				constants.DefragEvictedPodLabel: nil,
+			},
+			"annotations": map[string]any{
+				constants.DefragEvictedPodPoolAnnotation:  nil,
+				constants.DefragEvictedPodSinceAnnotation: nil,
+			},
+		},
+	}
+	raw, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	target := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name}}
+	if err := r.Patch(ctx, target, client.RawPatch(types.MergePatchType, raw)); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // patchPoolLastDefragTime persists the schedule anchor in status.

--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -140,17 +140,17 @@ func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, po
 	if pool.Status.LastDefragTime != nil {
 		anchor = pool.Status.LastDefragTime.Time
 	}
-	campaignStart := schedule.Next(anchor)
-	if campaignStart.After(now) {
-		logger.V(5).Info("defrag not due yet", "next", campaignStart, "anchor", anchor)
+	campaign := selectDefragCampaign(schedule, anchor, now, maxDuration)
+	if !campaign.due {
+		logger.V(5).Info("defrag not due yet", "next", campaign.start, "anchor", anchor)
 		return 0
 	}
-	if now.Sub(campaignStart) > maxDuration {
-		logger.Info("defrag campaign expired before this reconcile; advancing schedule anchor",
-			"campaignStart", campaignStart, "maxDuration", maxDuration)
+	if campaign.skipMissed {
+		logger.Info("defrag campaign expired before this reconcile; skipping missed schedule window",
+			"advancedAnchor", campaign.start, "maxDuration", maxDuration)
 		persistCtx, persistCancel := context.WithTimeout(ctx, defragStatusPersistTimeout)
 		defer persistCancel()
-		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaignStart); err != nil {
+		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaign.start); err != nil {
 			logger.Error(err, "failed to patch pool.Status.LastDefragTime after expired defrag campaign")
 		}
 		return 0
@@ -164,17 +164,58 @@ func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, po
 	}
 	defer flag.Store(false)
 
-	runCtx, cancel := context.WithDeadline(ctx, campaignStart.Add(maxDuration))
+	runCtx, cancel := context.WithDeadline(ctx, campaign.start.Add(maxDuration))
 	defer cancel()
-	result := r.runDefragStep(runCtx, pool.DeepCopy(), campaignStart)
+	result := r.runDefragStep(runCtx, pool.DeepCopy(), campaign.start)
 	if result.finishCampaign {
 		persistCtx, persistCancel := context.WithTimeout(ctx, defragStatusPersistTimeout)
 		defer persistCancel()
-		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaignStart); err != nil {
+		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaign.start); err != nil {
 			logger.Error(err, "failed to patch pool.Status.LastDefragTime after defrag step")
 		}
 	}
 	return defragRequeueAfter(result, normalRequeue)
+}
+
+type defragSchedule interface {
+	Next(time.Time) time.Time
+}
+
+type defragCampaignDecision struct {
+	start      time.Time
+	due        bool
+	skipMissed bool
+}
+
+func selectDefragCampaign(schedule defragSchedule, anchor, now time.Time, maxDuration time.Duration) defragCampaignDecision {
+	campaignStart := schedule.Next(anchor)
+	if campaignStart.After(now) {
+		return defragCampaignDecision{start: campaignStart}
+	}
+	if now.Sub(campaignStart) <= maxDuration {
+		return defragCampaignDecision{start: campaignStart, due: true}
+	}
+
+	latestActive, ok := latestScheduledDefragTick(schedule, now.Add(-maxDuration).Add(-time.Nanosecond), now)
+	if ok {
+		return defragCampaignDecision{start: latestActive, due: true}
+	}
+	return defragCampaignDecision{start: now, due: true, skipMissed: true}
+}
+
+func latestScheduledDefragTick(schedule defragSchedule, after, now time.Time) (time.Time, bool) {
+	next := schedule.Next(after)
+	if next.After(now) {
+		return time.Time{}, false
+	}
+	latest := next
+	for {
+		candidate := schedule.Next(latest)
+		if !candidate.After(latest) || candidate.After(now) {
+			return latest, true
+		}
+		latest = candidate
+	}
 }
 
 func getDefragConfig(pool *tfv1.GPUPool) *tfv1.NodeDefragConfig {
@@ -874,7 +915,9 @@ func buildDefragNodeBudgets(
 			// it must not make the whole source candidate look unmovable.
 			continue
 		}
-		if node := nodeInfo.Node(); node == nil || node.Labels[constants.NodeDeletionMark] == constants.TrueStringValue {
+		if node := nodeInfo.Node(); node == nil ||
+			node.Labels[constants.NodeDeletionMark] == constants.TrueStringValue ||
+			node.Labels[constants.DefragSourceNodeLabel] == constants.TrueStringValue {
 			continue
 		}
 
@@ -1001,6 +1044,27 @@ func (r *GPUPoolCompactionReconciler) evictWorkerPods(
 		Error(error, string, ...any)
 	},
 ) bool {
+	if ctxDone(ctx) {
+		stats.DeadlineExceeded = true
+		return false
+	}
+	if err := r.markNodeDefragSource(ctx, cand.nodeName); err != nil {
+		stats.EvictionFailures++
+		r.Recorder.Eventf(pool, corev1.EventTypeWarning, defragEventPodEvictFailed,
+			"failed to mark node %s as defrag source: %v (node eviction aborted)", cand.nodeName, err)
+		logger.Error(err, "failed to mark defrag source node; aborting node eviction", "node", cand.nodeName)
+		return false
+	}
+	anyEvicted := false
+	defer func() {
+		if anyEvicted {
+			return
+		}
+		if clearErr := r.clearNodeDefragSourceMarker(context.Background(), cand.nodeName); clearErr != nil {
+			logger.Error(clearErr, "failed to clear unused defrag source node marker", "node", cand.nodeName)
+		}
+	}()
+
 	for _, pod := range cand.workerPods {
 		if ctxDone(ctx) {
 			stats.DeadlineExceeded = true
@@ -1014,6 +1078,7 @@ func (r *GPUPoolCompactionReconciler) evictWorkerPods(
 		}
 		err := r.KubeClient.CoreV1().Pods(pod.Namespace).EvictV1(ctx, eviction)
 		if err == nil {
+			anyEvicted = true
 			if markErr := r.markPodDefragEvicted(ctx, pool.Name, pod); markErr != nil {
 				stats.EvictionFailures++
 				r.Recorder.Eventf(pool, corev1.EventTypeWarning, defragEventPodEvictFailed,
@@ -1029,6 +1094,7 @@ func (r *GPUPoolCompactionReconciler) evictWorkerPods(
 			continue
 		}
 		if apierrors.IsNotFound(err) {
+			anyEvicted = true
 			stats.EvictedPods++
 			continue
 		}
@@ -1045,6 +1111,39 @@ func (r *GPUPoolCompactionReconciler) evictWorkerPods(
 
 // ----- pod marker helpers ----------------------------------------------
 
+func (r *GPUPoolCompactionReconciler) markNodeDefragSource(ctx context.Context, nodeName string) error {
+	if r.Client == nil {
+		return errors.New("controller client is nil")
+	}
+	if nodeName == "" {
+		return errors.New("node name is empty")
+	}
+	raw, err := metadataMergePatch(map[string]any{constants.DefragSourceNodeLabel: constants.TrueStringValue}, nil)
+	if err != nil {
+		return err
+	}
+	target := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	return r.Patch(ctx, target, client.RawPatch(types.MergePatchType, raw))
+}
+
+func (r *GPUPoolCompactionReconciler) clearNodeDefragSourceMarker(ctx context.Context, nodeName string) error {
+	if r.Client == nil || nodeName == "" {
+		return nil
+	}
+	raw, err := metadataMergePatch(map[string]any{constants.DefragSourceNodeLabel: nil}, nil)
+	if err != nil {
+		return err
+	}
+	target := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	if err := r.Patch(ctx, target, client.RawPatch(types.MergePatchType, raw)); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 func (r *GPUPoolCompactionReconciler) markPodDefragEvicted(ctx context.Context, poolName string, pod *corev1.Pod) error {
 	if r.KubeClient == nil {
 		return errors.New("kube client is nil")
@@ -1052,18 +1151,13 @@ func (r *GPUPoolCompactionReconciler) markPodDefragEvicted(ctx context.Context, 
 	if pod == nil {
 		return errors.New("pod is nil")
 	}
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"labels": map[string]any{
-				constants.DefragEvictedPodLabel: constants.TrueStringValue,
-			},
-			"annotations": map[string]any{
-				constants.DefragEvictedPodPoolAnnotation:  poolName,
-				constants.DefragEvictedPodSinceAnnotation: time.Now().Format(time.RFC3339),
-			},
+	raw, err := metadataMergePatch(
+		map[string]any{constants.DefragEvictedPodLabel: constants.TrueStringValue},
+		map[string]any{
+			constants.DefragEvictedPodPoolAnnotation:  poolName,
+			constants.DefragEvictedPodSinceAnnotation: time.Now().Format(time.RFC3339),
 		},
-	}
-	raw, err := json.Marshal(patch)
+	)
 	if err != nil {
 		return err
 	}
@@ -1084,18 +1178,13 @@ func (r *GPUPoolCompactionReconciler) clearPodDefragEvictedMarker(ctx context.Co
 	if pod == nil {
 		return nil
 	}
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"labels": map[string]any{
-				constants.DefragEvictedPodLabel: nil,
-			},
-			"annotations": map[string]any{
-				constants.DefragEvictedPodPoolAnnotation:  nil,
-				constants.DefragEvictedPodSinceAnnotation: nil,
-			},
+	raw, err := metadataMergePatch(
+		map[string]any{constants.DefragEvictedPodLabel: nil},
+		map[string]any{
+			constants.DefragEvictedPodPoolAnnotation:  nil,
+			constants.DefragEvictedPodSinceAnnotation: nil,
 		},
-	}
-	raw, err := json.Marshal(patch)
+	)
 	if err != nil {
 		return err
 	}
@@ -1107,6 +1196,17 @@ func (r *GPUPoolCompactionReconciler) clearPodDefragEvictedMarker(ctx context.Co
 		return err
 	}
 	return nil
+}
+
+func metadataMergePatch(labels, annotations map[string]any) ([]byte, error) {
+	metadata := map[string]any{}
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+	if len(annotations) > 0 {
+		metadata["annotations"] = annotations
+	}
+	return json.Marshal(map[string]any{"metadata": metadata})
 }
 
 // patchPoolLastDefragTime persists the schedule anchor in status.

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -717,6 +717,10 @@ func TestRunDefragStep_BlockedByDefragEvictedPod(t *testing.T) {
 	blocker.Labels = map[string]string{
 		constants.DefragEvictedPodLabel: constants.TrueStringValue,
 	}
+	blocker.Annotations = map[string]string{
+		constants.DefragEvictedPodPoolAnnotation:  pool.Name,
+		constants.DefragEvictedPodSinceAnnotation: time.Now().Format(time.RFC3339),
+	}
 	r, _ := newDefragControllerTestReconciler(t, pool, blocker)
 
 	result := r.runDefragStep(context.Background(), pool.DeepCopy(), time.Now().Add(-time.Minute))
@@ -726,6 +730,85 @@ func TestRunDefragStep_BlockedByDefragEvictedPod(t *testing.T) {
 	}
 	if result.evictedNode {
 		t.Fatalf("blocked defrag step should not evict a node")
+	}
+}
+
+func TestHasDefragEvictedPods_ScopedToPool(t *testing.T) {
+	pool := newDefragTestPool()
+	otherPoolPod := newPod("other-pool-evicted-worker")
+	otherPoolPod.Labels = map[string]string{
+		constants.DefragEvictedPodLabel: constants.TrueStringValue,
+	}
+	otherPoolPod.Annotations = map[string]string{
+		constants.DefragEvictedPodPoolAnnotation:  "pool-b",
+		constants.DefragEvictedPodSinceAnnotation: time.Now().Format(time.RFC3339),
+	}
+	samePoolPod := newPod("same-pool-evicted-worker")
+	samePoolPod.Labels = map[string]string{
+		constants.DefragEvictedPodLabel: constants.TrueStringValue,
+	}
+	samePoolPod.Annotations = map[string]string{
+		constants.DefragEvictedPodPoolAnnotation:  pool.Name,
+		constants.DefragEvictedPodSinceAnnotation: time.Now().Format(time.RFC3339),
+	}
+
+	rOther, _ := newDefragControllerTestReconciler(t, pool, otherPoolPod)
+	blocked, err := rOther.hasDefragEvictedPods(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("check evicted pods for other pool: %v", err)
+	}
+	if blocked {
+		t.Fatalf("evicted pod from another pool must not block pool %s", pool.Name)
+	}
+
+	rSame, _ := newDefragControllerTestReconciler(t, pool, samePoolPod)
+	blocked, err = rSame.hasDefragEvictedPods(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("check evicted pods for same pool: %v", err)
+	}
+	if !blocked {
+		t.Fatalf("evicted pod from same pool should block the next defrag step")
+	}
+}
+
+func TestHasDefragEvictedPods_ClearsStaleSamePoolMarker(t *testing.T) {
+	pool := newDefragTestPool()
+	stalePod := newPod("stale-evicted-worker")
+	stalePod.Labels = map[string]string{
+		constants.DefragEvictedPodLabel: constants.TrueStringValue,
+	}
+	stalePod.Annotations = map[string]string{
+		constants.DefragEvictedPodPoolAnnotation:  pool.Name,
+		constants.DefragEvictedPodSinceAnnotation: time.Now().Add(-2 * time.Hour).Format(time.RFC3339),
+	}
+
+	r, kubeClient := newDefragControllerTestReconciler(t, pool, stalePod)
+	blocked, err := r.hasDefragEvictedPods(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("check stale evicted pod marker: %v", err)
+	}
+	if blocked {
+		t.Fatalf("stale evicted pod marker should not block defrag")
+	}
+
+	updated := &corev1.Pod{}
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Namespace: stalePod.Namespace, Name: stalePod.Name}, updated); err != nil {
+		t.Fatalf("get stale pod after cleanup: %v", err)
+	}
+	if updated.Labels[constants.DefragEvictedPodLabel] == constants.TrueStringValue {
+		t.Fatalf("stale defrag-evicted label should be cleared, labels=%v", updated.Labels)
+	}
+}
+
+func TestDefragRequeueAfter_ContinuesActiveCampaignQuickly(t *testing.T) {
+	result := defragStepResult{evictedNode: true}
+	got := defragRequeueAfter(result, 30*time.Minute)
+	if got <= 0 || got >= 30*time.Minute {
+		t.Fatalf("active defrag campaign should requeue quickly, got %s", got)
+	}
+
+	if got := defragRequeueAfter(defragStepResult{finishCampaign: true}, 30*time.Minute); got != 30*time.Minute {
+		t.Fatalf("finished campaign should use normal compaction period, got %s", got)
 	}
 }
 

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -207,6 +207,64 @@ func TestEvictWorkerPods_AllSucceed(t *testing.T) {
 	}
 }
 
+func TestEvictWorkerPods_MarksEvictedPodLabel(t *testing.T) {
+	p1 := newPod("p1")
+	fakeClient := clientgofake.NewSimpleClientset(p1)
+	fakeClient.PrependReactor("create", "pods", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if a.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		// Keep the pod object around so the controller must patch the
+		// defrag marker after a successful eviction request.
+		return true, nil, nil
+	})
+	r := newReconcilerWithFake(fakeClient)
+	cand := &defragCandidate{
+		nodeName:   "node-a",
+		workerPods: []*corev1.Pod{p1},
+	}
+	stats := &defragRunStats{}
+
+	if !r.evictWorkerPods(context.Background(), &tfv1.GPUPool{}, cand, stats, &errLogger{}) {
+		t.Fatalf("expected eviction to succeed")
+	}
+
+	updated, err := fakeClient.CoreV1().Pods(p1.Namespace).Get(context.Background(), p1.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get patched pod: %v", err)
+	}
+	if updated.Labels[constants.DefragEvictedPodLabel] != constants.TrueStringValue {
+		t.Fatalf("expected defrag evicted label, labels=%v", updated.Labels)
+	}
+}
+
+func TestEvictWorkerPods_LabelPatchFailureAborts(t *testing.T) {
+	p1 := newPod("p1")
+	fakeClient := clientgofake.NewSimpleClientset(p1)
+	fakeClient.PrependReactor("create", "pods", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if a.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		return true, nil, nil
+	})
+	fakeClient.PrependReactor("patch", "pods", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("patch failed")
+	})
+	r := newReconcilerWithFake(fakeClient)
+	cand := &defragCandidate{
+		nodeName:   "node-a",
+		workerPods: []*corev1.Pod{p1},
+	}
+	stats := &defragRunStats{}
+
+	if r.evictWorkerPods(context.Background(), &tfv1.GPUPool{}, cand, stats, &errLogger{}) {
+		t.Fatalf("expected label patch failure to abort")
+	}
+	if stats.EvictionFailures != 1 {
+		t.Fatalf("evictionFailures=%d want 1", stats.EvictionFailures)
+	}
+}
+
 func TestEvictWorkerPods_AbortsOnFirstFailure(t *testing.T) {
 	fakeClient := clientgofake.NewSimpleClientset(
 		newPod("p1"),
@@ -441,6 +499,57 @@ func TestGetDefragConfig(t *testing.T) {
 	}
 }
 
+func TestCollectDefragCandidates_SkipsFreshWorkerPods(t *testing.T) {
+	now := time.Now()
+	pool := newDefragTestPool()
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+	gpuNode := newDefragGPUNode("node-a", "pool-a")
+	freshWorker := newDefragWorkerPod("worker-fresh", "node-a", now.Add(-10*time.Minute))
+	objects := []ctrlclient.Object{pool, node, gpuNode, freshWorker}
+	objects = append(objects, newDefragNodeGPUs("node-a", "pool-a")...)
+
+	r, _ := newDefragControllerTestReconciler(t, objects...)
+	if err := r.Allocator.InitGPUAndQuotaStore(); err != nil {
+		t.Fatalf("init GPU store: %v", err)
+	}
+	r.Allocator.ReconcileAllocationStateForTesting()
+
+	candidates, err := r.collectDefragCandidates(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("collect defrag candidates: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("fresh worker pod should make node ineligible, got %d candidates", len(candidates))
+	}
+}
+
+func TestCollectDefragCandidates_IncludesOldWorkerPods(t *testing.T) {
+	now := time.Now()
+	pool := newDefragTestPool()
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+	gpuNode := newDefragGPUNode("node-a", "pool-a")
+	oldWorker := newDefragWorkerPod("worker-old", "node-a", now.Add(-31*time.Minute))
+	objects := []ctrlclient.Object{pool, node, gpuNode, oldWorker}
+	objects = append(objects, newDefragNodeGPUs("node-a", "pool-a")...)
+
+	r, _ := newDefragControllerTestReconciler(t, objects...)
+	if err := r.Allocator.InitGPUAndQuotaStore(); err != nil {
+		t.Fatalf("init GPU store: %v", err)
+	}
+	r.Allocator.ReconcileAllocationStateForTesting()
+
+	candidates, err := r.collectDefragCandidates(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("collect defrag candidates: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("old worker pod should be eligible, got %d candidates", len(candidates))
+	}
+	if candidates[0].nodeName != "node-a" {
+		t.Fatalf("candidate node=%q want node-a", candidates[0].nodeName)
+	}
+}
+
 func TestPrepareDefragSimulationPod_ClearsAssignedGPUState(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -541,7 +650,6 @@ func TestBuildDefragNodeBudgets_SkipsDeletionMarkedNodes(t *testing.T) {
 				),
 			},
 		},
-		map[string]struct{}{},
 	)
 	if _, ok := budgets["node-delete"]; ok {
 		t.Fatalf("expected deletion-marked node to be excluded, got budgets=%v", budgets)
@@ -580,7 +688,6 @@ func TestBuildDefragNodeBudgets_SkipsMissingSchedulerNodeInfo(t *testing.T) {
 				),
 			},
 		},
-		map[string]struct{}{},
 	)
 	if _, ok := budgets["node-stale"]; ok {
 		t.Fatalf("stale node should be excluded, got budgets=%v", budgets)
@@ -590,252 +697,115 @@ func TestBuildDefragNodeBudgets_SkipsMissingSchedulerNodeInfo(t *testing.T) {
 	}
 }
 
-func TestRunDefrag_PersistsLastDefragTimeWhenRunContextCanceled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
+func TestRunDefragStep_NoCandidatesFinishesCampaign(t *testing.T) {
 	pool := newDefragTestPool()
-	r, kubeClient := newDefragControllerTestReconciler(t, pool)
-	runStart := time.Now().Add(-time.Minute).Round(time.Second)
+	r, _ := newDefragControllerTestReconciler(t, pool)
 
-	r.runDefrag(ctx, pool.DeepCopy(), runStart)
+	result := r.runDefragStep(context.Background(), pool.DeepCopy(), time.Now().Add(-time.Minute))
 
-	updated := &tfv1.GPUPool{}
-	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: pool.Name}, updated); err != nil {
-		t.Fatalf("get updated pool: %v", err)
+	if !result.finishCampaign {
+		t.Fatalf("expected empty defrag step to finish campaign")
 	}
-	if updated.Status.LastDefragTime == nil {
-		t.Fatal("expected LastDefragTime to be persisted")
-	}
-	if !updated.Status.LastDefragTime.Time.Equal(runStart) {
-		t.Fatalf("lastDefragTime=%v want %v", updated.Status.LastDefragTime.Time, runStart)
+	if result.evictedNode {
+		t.Fatalf("empty defrag step should not evict a node")
 	}
 }
 
-func TestDefragStaleLabelCleanupTick_ScopedToPool(t *testing.T) {
+func TestRunDefragStep_BlockedByDefragEvictedPod(t *testing.T) {
 	pool := newDefragTestPool()
-	staleSince := time.Now().Add(-2 * time.Hour)
-
-	nodeA := newDefragDrainingNode("node-a", "pool-a", staleSince)
-	nodeB := newDefragDrainingNode("node-b", "pool-b", staleSince)
-
-	r, kubeClient := newDefragControllerTestReconciler(t, pool, nodeA, nodeB)
-	r.defragStaleLabelCleanupTick(context.Background(), pool)
-
-	updatedA := &corev1.Node{}
-	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: nodeA.Name}, updatedA); err != nil {
-		t.Fatalf("get updated node-a: %v", err)
+	blocker := newPod("evicted-worker")
+	blocker.Labels = map[string]string{
+		constants.DefragEvictedPodLabel: constants.TrueStringValue,
 	}
-	if _, exists := updatedA.Labels[constants.DefragDrainingLabel]; exists {
-		t.Fatalf("expected node-a drain label to be cleared, labels=%v", updatedA.Labels)
-	}
+	r, _ := newDefragControllerTestReconciler(t, pool, blocker)
 
-	updatedB := &corev1.Node{}
-	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: nodeB.Name}, updatedB); err != nil {
-		t.Fatalf("get updated node-b: %v", err)
+	result := r.runDefragStep(context.Background(), pool.DeepCopy(), time.Now().Add(-time.Minute))
+
+	if result.finishCampaign {
+		t.Fatalf("defrag-evicted pod should pause, not finish campaign")
 	}
-	if updatedB.Labels[constants.DefragDrainingLabel] != constants.TrueStringValue {
-		t.Fatalf("expected node-b drain label to remain, labels=%v", updatedB.Labels)
+	if result.evictedNode {
+		t.Fatalf("blocked defrag step should not evict a node")
 	}
 }
 
-func TestDefragStaleLabelCleanupTick_UsesGPUNodePoolWhenNodePoolLabelMissing(t *testing.T) {
-	pool := newDefragTestPool()
-	staleSince := time.Now().Add(-2 * time.Hour)
+func TestRunDefragCandidateLoop_StopsAfterFirstEvictedNode(t *testing.T) {
+	candidates := []*defragCandidate{
+		{nodeName: "node-a"},
+		{nodeName: "node-b"},
+	}
+	stats := &defragRunStats{}
+	visited := []string{}
 
-	node := newDefragDrainingNodeWithoutPoolLabel("node-a", staleSince)
-	gpuNode := newDefragGPUNode("node-a", "pool-a")
-
-	r, kubeClient := newDefragControllerTestReconciler(t, pool, node, gpuNode)
-	r.defragStaleLabelCleanupTick(context.Background(), pool)
-
-	updated := &corev1.Node{}
-	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: node.Name}, updated); err != nil {
-		t.Fatalf("get updated node: %v", err)
-	}
-	if _, exists := updated.Labels[constants.DefragDrainingLabel]; exists {
-		t.Fatalf("expected drain label to be cleared via GPUNode pool ownership, labels=%v", updated.Labels)
-	}
-}
-
-func TestDefragDrainWatcherTick_ScopedToPool(t *testing.T) {
-	pool := newDefragTestPool()
-	nodeB := newDefragDrainingNode("node-b", "pool-b", time.Now().Add(-10*time.Minute))
-
-	r, kubeClient := newDefragControllerTestReconciler(t, pool, nodeB)
-	r.defragDrainingNodes.Store(nodeB.Name, time.Now().Add(-time.Minute))
-
-	r.defragDrainWatcherTick(context.Background(), pool)
-
-	updated := &corev1.Node{}
-	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: nodeB.Name}, updated); err != nil {
-		t.Fatalf("get updated node: %v", err)
-	}
-	if updated.Labels[constants.DefragDrainingLabel] != constants.TrueStringValue {
-		t.Fatalf("expected foreign-pool drain label to remain, labels=%v", updated.Labels)
-	}
-}
-
-func TestDefragDrainWatcherTick_UsesGPUNodePoolWhenNodePoolLabelMissing(t *testing.T) {
-	pool := newDefragTestPool()
-	node := newDefragDrainingNodeWithoutPoolLabel("node-a", time.Now().Add(-10*time.Minute))
-	gpuNode := newDefragGPUNode("node-a", "pool-a")
-
-	r, kubeClient := newDefragControllerTestReconciler(t, pool, node, gpuNode)
-	r.defragDrainingNodes.Store(node.Name, time.Now().Add(-time.Minute))
-
-	r.defragDrainWatcherTick(context.Background(), pool)
-
-	updated := &corev1.Node{}
-	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: node.Name}, updated); err != nil {
-		t.Fatalf("get updated node: %v", err)
-	}
-	if _, exists := updated.Labels[constants.DefragDrainingLabel]; exists {
-		t.Fatalf("expected drain label to be cleared via GPUNode pool ownership, labels=%v", updated.Labels)
-	}
-}
-
-func TestDefragDrainingLabelPatch_IncludesAndClearsPoolOwner(t *testing.T) {
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
-	r, kubeClient := newDefragControllerTestReconciler(t, node)
-
-	if err := r.applyDefragDrainingLabel(context.Background(), node.Name, "pool-a"); err != nil {
-		t.Fatalf("apply drain label: %v", err)
-	}
-
-	updated := &corev1.Node{}
-	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: node.Name}, updated); err != nil {
-		t.Fatalf("get updated node: %v", err)
-	}
-	if updated.Labels[constants.DefragDrainingLabel] != constants.TrueStringValue {
-		t.Fatalf("expected drain label, labels=%v", updated.Labels)
-	}
-	if updated.Annotations[constants.DefragDrainingPoolAnnotation] != "pool-a" {
-		t.Fatalf("expected drain pool annotation, annotations=%v", updated.Annotations)
-	}
-	if updated.Annotations[constants.DefragDrainingSinceAnnotation] == "" {
-		t.Fatalf("expected drain since annotation, annotations=%v", updated.Annotations)
-	}
-
-	if err := r.clearDefragDrainingLabel(context.Background(), node.Name); err != nil {
-		t.Fatalf("clear drain label: %v", err)
-	}
-	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: node.Name}, updated); err != nil {
-		t.Fatalf("get cleared node: %v", err)
-	}
-	if _, exists := updated.Labels[constants.DefragDrainingLabel]; exists {
-		t.Fatalf("expected drain label cleared, labels=%v", updated.Labels)
-	}
-	if _, exists := updated.Annotations[constants.DefragDrainingPoolAnnotation]; exists {
-		t.Fatalf("expected drain pool annotation cleared, annotations=%v", updated.Annotations)
-	}
-	if _, exists := updated.Annotations[constants.DefragDrainingSinceAnnotation]; exists {
-		t.Fatalf("expected drain since annotation cleared, annotations=%v", updated.Annotations)
-	}
-}
-
-func TestWaitForSchedulerNodeDefragLabel(t *testing.T) {
-	lister := &fakeNodeInfoLister{
-		infos: map[string]fwk.NodeInfo{
-			"node-a": newFrameworkNodeInfo(
-				"node-a",
-				map[string]string{constants.DefragDrainingLabel: constants.TrueStringValue},
-				corev1.ResourceList{},
-			),
-		},
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := waitForSchedulerNodeDefragLabel(ctx, nil, lister, "node-a", time.Millisecond); err != nil {
-		t.Fatalf("waitForSchedulerNodeDefragLabel returned error: %v", err)
-	}
-}
-
-func TestWaitForSchedulerNodeDefragLabel_RefreshesUntilLabelVisible(t *testing.T) {
-	lister := &fakeNodeInfoLister{
-		infos: map[string]fwk.NodeInfo{
-			"node-a": newFrameworkNodeInfo("node-a", map[string]string{}, corev1.ResourceList{}),
-		},
-	}
-	refreshCalls := 0
-	refresh := func(context.Context) error {
-		refreshCalls++
-		if refreshCalls == 2 {
-			lister.infos["node-a"] = newFrameworkNodeInfo(
-				"node-a",
-				map[string]string{constants.DefragDrainingLabel: constants.TrueStringValue},
-				corev1.ResourceList{},
-			)
-		}
-		return nil
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	if err := waitForSchedulerNodeDefragLabel(ctx, refresh, lister, "node-a", time.Millisecond); err != nil {
-		t.Fatalf("waitForSchedulerNodeDefragLabel returned error: %v", err)
-	}
-	if refreshCalls < 2 {
-		t.Fatalf("refresh calls=%d want at least 2", refreshCalls)
-	}
-}
-
-func TestWaitForSchedulerNodeDefragLabel_ReturnsRefreshErrorAfterTimeout(t *testing.T) {
-	lister := &fakeNodeInfoLister{
-		infos: map[string]fwk.NodeInfo{
-			"node-a": newFrameworkNodeInfo("node-a", map[string]string{}, corev1.ResourceList{}),
-		},
-	}
-	refreshErr := errors.New("refresh failed")
-	refreshCalls := 0
-	refresh := func(context.Context) error {
-		refreshCalls++
-		return refreshErr
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	err := waitForSchedulerNodeDefragLabel(ctx, refresh, lister, "node-a", time.Millisecond)
-	if err == nil {
-		t.Fatal("expected refresh timeout error")
-	}
-	if refreshCalls == 0 {
-		t.Fatal("expected refresh to be called")
-	}
-	got := err.Error()
-	if !strings.Contains(got, "refresh scheduler node info snapshot") || !strings.Contains(got, refreshErr.Error()) {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestFindNewOrFreshDefragWorker(t *testing.T) {
-	runStart := time.Now()
-	original := []*corev1.Pod{{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         "ns",
-			Name:              "worker-a",
-			CreationTimestamp: metav1.NewTime(runStart.Add(-time.Minute)),
-		},
-	}}
-	current := append([]*corev1.Pod{}, original...)
-	current = append(current, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         "ns",
-			Name:              "worker-b",
-			CreationTimestamp: metav1.NewTime(runStart.Add(time.Second)),
-		},
+	result := runDefragCandidateLoop(context.Background(), candidates, stats, func(cand *defragCandidate) defragCandidateOutcome {
+		visited = append(visited, cand.nodeName)
+		return defragCandidateEvicted
 	})
 
-	pod, ok := findNewOrFreshDefragWorker(runStart, original, current)
-	if !ok {
-		t.Fatal("expected new worker to be detected")
+	if !result.evictedNode {
+		t.Fatalf("expected one node to be evicted")
 	}
-	if pod.Namespace != "ns" || pod.Name != "worker-b" {
-		t.Fatalf("unexpected worker detected: %s/%s", pod.Namespace, pod.Name)
+	if result.finishCampaign {
+		t.Fatalf("evicting one node should not finish the campaign")
+	}
+	if stats.ProcessedNodes != 1 {
+		t.Fatalf("processedNodes=%d want 1", stats.ProcessedNodes)
+	}
+	if len(visited) != 1 || visited[0] != "node-a" {
+		t.Fatalf("visited=%v want only node-a", visited)
+	}
+}
+
+func TestRunDefragCandidateLoop_SkipsAndContinuesToNextCandidate(t *testing.T) {
+	candidates := []*defragCandidate{
+		{nodeName: "node-a"},
+		{nodeName: "node-b"},
+	}
+	stats := &defragRunStats{}
+	visited := []string{}
+
+	result := runDefragCandidateLoop(context.Background(), candidates, stats, func(cand *defragCandidate) defragCandidateOutcome {
+		visited = append(visited, cand.nodeName)
+		if cand.nodeName == "node-a" {
+			return defragCandidateSkipped
+		}
+		return defragCandidateEvicted
+	})
+
+	if !result.evictedNode {
+		t.Fatalf("expected second candidate to be evicted")
+	}
+	if stats.ProcessedNodes != 2 {
+		t.Fatalf("processedNodes=%d want 2", stats.ProcessedNodes)
+	}
+	if fmt.Sprint(visited) != "[node-a node-b]" {
+		t.Fatalf("visited=%v", visited)
+	}
+}
+
+func TestFindFreshDefragWorker(t *testing.T) {
+	now := time.Now()
+	fresh := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Namespace:         "ns",
+		Name:              "worker-fresh",
+		CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
+	}}
+	old := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Namespace:         "ns",
+		Name:              "worker-old",
+		CreationTimestamp: metav1.NewTime(now.Add(-time.Hour)),
+	}}
+
+	got, ok := findFreshDefragWorker(now, 30*time.Minute, []*corev1.Pod{old, fresh})
+	if !ok {
+		t.Fatal("expected fresh worker to be detected")
+	}
+	if got.Name != fresh.Name {
+		t.Fatalf("got %s want %s", got.Name, fresh.Name)
 	}
 
-	if pod, ok := findNewOrFreshDefragWorker(runStart, original, original); ok {
-		t.Fatalf("unchanged worker set should not be considered fresh, got %s/%s", pod.Namespace, pod.Name)
+	if pod, ok := findFreshDefragWorker(now, 30*time.Minute, []*corev1.Pod{old}); ok {
+		t.Fatalf("old worker should not be fresh, got %s/%s", pod.Namespace, pod.Name)
 	}
 }
 
@@ -877,9 +847,10 @@ func newDefragTestPool() *tfv1.GPUPool {
 			NodeManagerConfig: &tfv1.NodeManagerConfig{
 				NodeCompaction: &tfv1.NodeCompaction{
 					Defrag: &tfv1.NodeDefragConfig{
-						Enabled:     true,
-						Schedule:    "0 3 * * *",
-						MaxDuration: "30m",
+						Enabled:                     true,
+						Schedule:                    "0 3 * * *",
+						MaxDuration:                 "30m",
+						UtilizationThresholdPercent: 40,
 					},
 				},
 			},
@@ -887,33 +858,62 @@ func newDefragTestPool() *tfv1.GPUPool {
 	}
 }
 
-func newDefragDrainingNode(name, poolName string, since time.Time) *corev1.Node {
-	return &corev1.Node{
+func newDefragWorkerPod(name, nodeName string, createdAt time.Time) *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Namespace:         "ns1",
+			Name:              name,
+			UID:               types.UID(name + "-uid"),
+			CreationTimestamp: metav1.NewTime(createdAt),
 			Labels: map[string]string{
-				constants.DefragDrainingLabel:                                     constants.TrueStringValue,
-				fmt.Sprintf(constants.GPUNodePoolIdentifierLabelFormat, poolName): constants.TrueStringValue,
+				constants.LabelComponent: constants.ComponentWorker,
+				constants.WorkloadKey:    "workload-a",
 			},
 			Annotations: map[string]string{
-				constants.DefragDrainingSinceAnnotation: since.Format(time.RFC3339),
+				constants.GpuPoolKey:              "pool-a",
+				constants.GpuCountAnnotation:      "1",
+				constants.TFLOPSRequestAnnotation: "10",
+				constants.VRAMRequestAnnotation:   "1Gi",
+				constants.TFLOPSLimitAnnotation:   "10",
+				constants.VRAMLimitAnnotation:     "1Gi",
+				constants.GPUDeviceIDsAnnotation:  fmt.Sprintf("%s-gpu-0", nodeName),
 			},
 		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{{
+				Name:  "main",
+				Image: "worker:test",
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 }
 
-func newDefragDrainingNodeWithoutPoolLabel(name string, since time.Time) *corev1.Node {
-	return &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				constants.DefragDrainingLabel: constants.TrueStringValue,
-			},
-			Annotations: map[string]string{
-				constants.DefragDrainingSinceAnnotation: since.Format(time.RFC3339),
-			},
-		},
+func newDefragNodeGPUs(nodeName, poolName string) []ctrlclient.Object {
+	out := make([]ctrlclient.Object, 0, 4)
+	for i := 0; i < 4; i++ {
+		availableTflops := "100"
+		if i == 0 {
+			availableTflops = "50"
+		}
+		out = append(out, gpuWithUsageOnNode(
+			fmt.Sprintf("%s-gpu-%d", nodeName, i),
+			poolName,
+			nodeName,
+			availableTflops,
+			"10Gi",
+		))
 	}
+	return out
+}
+
+func gpuWithUsageOnNode(name, poolName, nodeName, avTflops, avVram string) *tfv1.GPU {
+	g := gpuWithUsage(name, poolName, avTflops, avVram, tfv1.UsedByTensorFusion)
+	g.Status.NodeSelector = map[string]string{
+		constants.KubernetesHostNameLabel: nodeName,
+	}
+	return g
 }
 
 func newDefragGPUNode(name, poolName string) *tfv1.GPUNode {
@@ -923,6 +923,9 @@ func newDefragGPUNode(name, poolName string) *tfv1.GPUNode {
 			Labels: map[string]string{
 				fmt.Sprintf(constants.GPUNodePoolIdentifierLabelFormat, poolName): constants.TrueStringValue,
 			},
+		},
+		Status: tfv1.GPUNodeStatus{
+			Phase: tfv1.TensorFusionGPUNodePhaseRunning,
 		},
 	}
 }

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -15,6 +15,7 @@ import (
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
 	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator"
+	"github.com/robfig/cron/v3"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -62,6 +63,30 @@ func TestParseDefragMaxDuration(t *testing.T) {
 				t.Fatalf("expected fallback log; got none")
 			}
 		})
+	}
+}
+
+func TestSelectDefragCampaign_StaleAnchorUsesCurrentWindow(t *testing.T) {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse("* * * * *")
+	if err != nil {
+		t.Fatalf("parse schedule: %v", err)
+	}
+	now := time.Now()
+	staleAnchor := now.Add(-24 * time.Hour)
+
+	decision := selectDefragCampaign(schedule, staleAnchor, now, 10*time.Minute)
+	if !decision.due {
+		t.Fatalf("expected a due current-window campaign, got %+v", decision)
+	}
+	if decision.skipMissed {
+		t.Fatalf("expected current-window campaign, got missed-window skip %+v", decision)
+	}
+	if decision.start.Before(now.Add(-2 * time.Minute)) {
+		t.Fatalf("campaign advanced only one stale tick, got %s from stale %s", decision.start, staleAnchor)
+	}
+	if decision.start.After(time.Now()) {
+		t.Fatalf("campaign must not advance into the future, got %s", decision.start)
 	}
 }
 
@@ -165,6 +190,11 @@ func TestSubtractGPURequest_SafelyIgnoresBadInput(t *testing.T) {
 
 // ---- evictWorkerPods with fake clientset ------------------------------
 
+const (
+	testDefragNodeA         = "node-a"
+	testEvictionSubresource = "eviction"
+)
+
 type errLogger struct{ infoCount, errCount int }
 
 func (l *errLogger) Info(_ string, _ ...any)           { l.infoCount++ }
@@ -175,7 +205,15 @@ func newPod(name string) *corev1.Pod {
 }
 
 func newReconcilerWithFake(client *clientgofake.Clientset) *GPUPoolCompactionReconciler {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: testDefragNodeA}}).
+		Build()
 	return &GPUPoolCompactionReconciler{
+		Client:     kubeClient,
+		Scheme:     scheme,
 		KubeClient: client,
 		// FakeRecorder so Eventf doesn't panic -- 16 is well over what a
 		// single test will produce, otherwise Recorder.Eventf would block.
@@ -191,7 +229,7 @@ func TestEvictWorkerPods_AllSucceed(t *testing.T) {
 	)
 	r := newReconcilerWithFake(fakeClient)
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{newPod("p1"), newPod("p2")},
 	}
 	stats := &defragRunStats{}
@@ -211,7 +249,7 @@ func TestEvictWorkerPods_MarksEvictedPodLabel(t *testing.T) {
 	p1 := newPod("p1")
 	fakeClient := clientgofake.NewSimpleClientset(p1)
 	fakeClient.PrependReactor("create", "pods", func(a k8stesting.Action) (bool, runtime.Object, error) {
-		if a.GetSubresource() != "eviction" {
+		if a.GetSubresource() != testEvictionSubresource {
 			return false, nil, nil
 		}
 		// Keep the pod object around so the controller must patch the
@@ -220,7 +258,7 @@ func TestEvictWorkerPods_MarksEvictedPodLabel(t *testing.T) {
 	})
 	r := newReconcilerWithFake(fakeClient)
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{p1},
 	}
 	stats := &defragRunStats{}
@@ -238,11 +276,43 @@ func TestEvictWorkerPods_MarksEvictedPodLabel(t *testing.T) {
 	}
 }
 
+func TestEvictWorkerPods_MarksSourceNodeBeforeEviction(t *testing.T) {
+	p1 := newPod("p1")
+	fakeClient := clientgofake.NewSimpleClientset(p1)
+	fakeClient.PrependReactor("create", "pods", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if a.GetSubresource() != testEvictionSubresource {
+			return false, nil, nil
+		}
+		return true, nil, nil
+	})
+	pool := newDefragTestPool()
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: testDefragNodeA}}
+	r, kubeClient := newDefragControllerTestReconciler(t, pool, node)
+	r.KubeClient = fakeClient
+	cand := &defragCandidate{
+		nodeName:   testDefragNodeA,
+		workerPods: []*corev1.Pod{p1},
+	}
+	stats := &defragRunStats{}
+
+	if !r.evictWorkerPods(context.Background(), pool, cand, stats, &errLogger{}) {
+		t.Fatalf("expected eviction to succeed")
+	}
+
+	updated := &corev1.Node{}
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: testDefragNodeA}, updated); err != nil {
+		t.Fatalf("get source node: %v", err)
+	}
+	if updated.Labels[constants.DefragSourceNodeLabel] != constants.TrueStringValue {
+		t.Fatalf("expected source node defrag label, labels=%v", updated.Labels)
+	}
+}
+
 func TestEvictWorkerPods_LabelPatchFailureAborts(t *testing.T) {
 	p1 := newPod("p1")
 	fakeClient := clientgofake.NewSimpleClientset(p1)
 	fakeClient.PrependReactor("create", "pods", func(a k8stesting.Action) (bool, runtime.Object, error) {
-		if a.GetSubresource() != "eviction" {
+		if a.GetSubresource() != testEvictionSubresource {
 			return false, nil, nil
 		}
 		return true, nil, nil
@@ -252,7 +322,7 @@ func TestEvictWorkerPods_LabelPatchFailureAborts(t *testing.T) {
 	})
 	r := newReconcilerWithFake(fakeClient)
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{p1},
 	}
 	stats := &defragRunStats{}
@@ -275,7 +345,7 @@ func TestEvictWorkerPods_AbortsOnFirstFailure(t *testing.T) {
 	// evictWorkerPods is supposed to abort the entire node.
 	attempts := 0
 	fakeClient.PrependReactor("create", "pods", func(a k8stesting.Action) (bool, runtime.Object, error) {
-		if a.GetSubresource() != "eviction" {
+		if a.GetSubresource() != testEvictionSubresource {
 			return false, nil, nil
 		}
 		attempts++
@@ -283,7 +353,7 @@ func TestEvictWorkerPods_AbortsOnFirstFailure(t *testing.T) {
 	})
 	r := newReconcilerWithFake(fakeClient)
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{newPod("p1"), newPod("p2")},
 	}
 	stats := &defragRunStats{}
@@ -332,7 +402,7 @@ func TestCheckDefragPDBPreflight_BlockedPDBSkipsWholeNode(t *testing.T) {
 	fakeClient := clientgofake.NewSimpleClientset(p1, p2, pdb)
 	r := newReconcilerWithFake(fakeClient)
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{p1, p2},
 	}
 
@@ -369,7 +439,7 @@ func TestCheckDefragPDBPreflight_AllowsNodeWhenDisruptionsAvailable(t *testing.T
 	fakeClient := clientgofake.NewSimpleClientset(p1, pdb)
 	r := newReconcilerWithFake(fakeClient)
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{p1},
 	}
 
@@ -405,7 +475,7 @@ func TestCheckDefragPDBPreflight_ListsPDBsOncePerNamespace(t *testing.T) {
 	directClient := clientgofake.NewSimpleClientset(p1, p2, pdb)
 	r := newReconcilerWithFake(directClient)
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{p1, p2},
 	}
 
@@ -434,14 +504,14 @@ func TestEvictWorkerPods_NotFoundCountsAsSuccess(t *testing.T) {
 	// short-circuits in the fake to a plain action Invoke; inject NotFound
 	// explicitly to match the path we actually hit in production.
 	fakeClient.PrependReactor("create", "pods", func(a k8stesting.Action) (bool, runtime.Object, error) {
-		if a.GetSubresource() != "eviction" {
+		if a.GetSubresource() != testEvictionSubresource {
 			return false, nil, nil
 		}
 		return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "gone")
 	})
 	r := newReconcilerWithFake(fakeClient)
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{newPod("gone")},
 	}
 	stats := &defragRunStats{}
@@ -460,7 +530,7 @@ func TestEvictWorkerPods_HonorsCtxDeadline(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	cand := &defragCandidate{
-		nodeName:   "node-a",
+		nodeName:   testDefragNodeA,
 		workerPods: []*corev1.Pod{newPod("p1")},
 	}
 	stats := &defragRunStats{}
@@ -502,11 +572,11 @@ func TestGetDefragConfig(t *testing.T) {
 func TestCollectDefragCandidates_SkipsFreshWorkerPods(t *testing.T) {
 	now := time.Now()
 	pool := newDefragTestPool()
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
-	gpuNode := newDefragGPUNode("node-a", "pool-a")
-	freshWorker := newDefragWorkerPod("worker-fresh", "node-a", now.Add(-10*time.Minute))
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: testDefragNodeA}}
+	gpuNode := newDefragGPUNode(testDefragNodeA, "pool-a")
+	freshWorker := newDefragWorkerPod("worker-fresh", testDefragNodeA, now.Add(-10*time.Minute))
 	objects := []ctrlclient.Object{pool, node, gpuNode, freshWorker}
-	objects = append(objects, newDefragNodeGPUs("node-a", "pool-a")...)
+	objects = append(objects, newDefragNodeGPUs(testDefragNodeA, "pool-a")...)
 
 	r, _ := newDefragControllerTestReconciler(t, objects...)
 	if err := r.Allocator.InitGPUAndQuotaStore(); err != nil {
@@ -526,11 +596,11 @@ func TestCollectDefragCandidates_SkipsFreshWorkerPods(t *testing.T) {
 func TestCollectDefragCandidates_IncludesOldWorkerPods(t *testing.T) {
 	now := time.Now()
 	pool := newDefragTestPool()
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
-	gpuNode := newDefragGPUNode("node-a", "pool-a")
-	oldWorker := newDefragWorkerPod("worker-old", "node-a", now.Add(-31*time.Minute))
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: testDefragNodeA}}
+	gpuNode := newDefragGPUNode(testDefragNodeA, "pool-a")
+	oldWorker := newDefragWorkerPod("worker-old", testDefragNodeA, now.Add(-31*time.Minute))
 	objects := []ctrlclient.Object{pool, node, gpuNode, oldWorker}
-	objects = append(objects, newDefragNodeGPUs("node-a", "pool-a")...)
+	objects = append(objects, newDefragNodeGPUs(testDefragNodeA, "pool-a")...)
 
 	r, _ := newDefragControllerTestReconciler(t, objects...)
 	if err := r.Allocator.InitGPUAndQuotaStore(); err != nil {
@@ -545,7 +615,7 @@ func TestCollectDefragCandidates_IncludesOldWorkerPods(t *testing.T) {
 	if len(candidates) != 1 {
 		t.Fatalf("old worker pod should be eligible, got %d candidates", len(candidates))
 	}
-	if candidates[0].nodeName != "node-a" {
+	if candidates[0].nodeName != testDefragNodeA {
 		t.Fatalf("candidate node=%q want node-a", candidates[0].nodeName)
 	}
 }
@@ -814,7 +884,7 @@ func TestDefragRequeueAfter_ContinuesActiveCampaignQuickly(t *testing.T) {
 
 func TestRunDefragCandidateLoop_StopsAfterFirstEvictedNode(t *testing.T) {
 	candidates := []*defragCandidate{
-		{nodeName: "node-a"},
+		{nodeName: testDefragNodeA},
 		{nodeName: "node-b"},
 	}
 	stats := &defragRunStats{}
@@ -834,14 +904,14 @@ func TestRunDefragCandidateLoop_StopsAfterFirstEvictedNode(t *testing.T) {
 	if stats.ProcessedNodes != 1 {
 		t.Fatalf("processedNodes=%d want 1", stats.ProcessedNodes)
 	}
-	if len(visited) != 1 || visited[0] != "node-a" {
+	if len(visited) != 1 || visited[0] != testDefragNodeA {
 		t.Fatalf("visited=%v want only node-a", visited)
 	}
 }
 
 func TestRunDefragCandidateLoop_SkipsAndContinuesToNextCandidate(t *testing.T) {
 	candidates := []*defragCandidate{
-		{nodeName: "node-a"},
+		{nodeName: testDefragNodeA},
 		{nodeName: "node-b"},
 	}
 	stats := &defragRunStats{}
@@ -849,7 +919,7 @@ func TestRunDefragCandidateLoop_SkipsAndContinuesToNextCandidate(t *testing.T) {
 
 	result := runDefragCandidateLoop(context.Background(), candidates, stats, func(cand *defragCandidate) defragCandidateOutcome {
 		visited = append(visited, cand.nodeName)
-		if cand.nodeName == "node-a" {
+		if cand.nodeName == testDefragNodeA {
 			return defragCandidateSkipped
 		}
 		return defragCandidateEvicted

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -338,12 +338,6 @@ func (s *GPUFit) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, 
 		return fwk.NewStatus(fwk.Success, "skip for non tensor-fusion mode")
 	}
 
-	// Keep TF workers off nodes that defrag is draining.
-	if node := nodeInfo.Node(); node != nil &&
-		node.Labels[constants.DefragDrainingLabel] == constants.TrueStringValue {
-		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "node is draining for defrag")
-	}
-
 	// Fast-path rejection: every TF worker pod has tensor-fusion.ai/index injected
 	// by the webhook (pod_webhook.go), so a node that does not expose a positive
 	// allocatable for this resource cannot host the pod. Two cases:

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -358,6 +358,13 @@ func (s *GPUFit) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, 
 		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable,
 			"node tensor-fusion.ai/index allocatable is <= 0, hypervisor likely unhealthy")
 	}
+	node := nodeInfo.Node()
+	if node == nil {
+		return fwk.NewStatus(fwk.Unschedulable, "not valid node")
+	}
+	if node.Labels[constants.DefragSourceNodeLabel] == constants.TrueStringValue {
+		return fwk.NewStatus(fwk.Unschedulable, "node is being emptied by defrag")
+	}
 
 	filterResult, err := state.Read(CycleStateGPUSchedulingResult)
 	if err != nil {
@@ -372,7 +379,7 @@ func (s *GPUFit) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, 
 		return s.validatePreemption(state, pod, nodeInfo)
 	}
 
-	nodeName := nodeInfo.Node().Name
+	nodeName := node.Name
 
 	// Check if there are higher priority nominated pods waiting for this node's GPU resources
 	// This ensures that low priority pods don't steal GPU resources from pods that have already

--- a/internal/scheduler/gpuresources/gpuresources_test.go
+++ b/internal/scheduler/gpuresources/gpuresources_test.go
@@ -451,63 +451,6 @@ func (s *GPUResourcesSuite) TestFilter() {
 	}
 }
 
-// A node that the GPUPool defrag controller has labeled for draining
-// must be rejected by Filter before any other check. This prevents
-// evicted TF worker pods from bouncing back onto the still-occupied
-// source node, which would defeat the defrag run. The rejection must
-// be UnschedulableAndUnresolvable so the preemption machinery does not
-// speculatively retry the same node.
-func (s *GPUResourcesSuite) TestFilter_DefragDrainingLabelRejectsNode() {
-	log.FromContext(s.ctx).Info("Running TestFilter_DefragDrainingLabelRejectsNode")
-	state := framework.NewCycleState()
-	pod := s.makePod("p-drain-guard",
-		map[string]string{
-			constants.GpuCountAnnotation:      "1",
-			constants.TFLOPSRequestAnnotation: "100",
-			constants.VRAMRequestAnnotation:   "10Gi",
-			constants.TFLOPSLimitAnnotation:   "100",
-			constants.VRAMLimitAnnotation:     "40Gi",
-		})
-	_, preFilterStatus := s.plugin.PreFilter(s.ctx, state, pod, []fwk.NodeInfo{})
-	s.Require().True(preFilterStatus.IsSuccess())
-
-	tests := []struct {
-		name           string
-		labels         map[string]string
-		expectedStatus fwk.Code
-	}{
-		{
-			name:           "node with draining label is rejected",
-			labels:         map[string]string{constants.DefragDrainingLabel: constants.TrueStringValue},
-			expectedStatus: fwk.UnschedulableAndUnresolvable,
-		},
-		{
-			name:           "node without draining label proceeds through Filter",
-			labels:         map[string]string{},
-			expectedStatus: fwk.Success,
-		},
-	}
-
-	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			nodeInfo := &framework.NodeInfo{}
-			nodeInfo.SetNode(&v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "node-a",
-					Labels: tt.labels,
-				},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceName(constants.PodIndexAnnotation): resource.MustParse("512"),
-					},
-				},
-			})
-			status := s.plugin.Filter(s.ctx, state, pod, nodeInfo)
-			s.Equal(tt.expectedStatus, status.Code(), status.Message())
-		})
-	}
-}
-
 // Every TF worker pod has tensor-fusion.ai/index injected by the webhook, so the
 // node must expose a positive allocatable for that resource. Filter must reject
 // with UnschedulableAndUnresolvable on both a zeroed value (hypervisor just died

--- a/internal/scheduler/gpuresources/gpuresources_test.go
+++ b/internal/scheduler/gpuresources/gpuresources_test.go
@@ -451,6 +451,36 @@ func (s *GPUResourcesSuite) TestFilter() {
 	}
 }
 
+func (s *GPUResourcesSuite) TestFilter_DefragDrainingLabelDoesNotRejectNode() {
+	log.FromContext(s.ctx).Info("Running TestFilter_DefragDrainingLabelDoesNotRejectNode")
+	state := framework.NewCycleState()
+	pod := s.makePod("p-drain-guard",
+		map[string]string{
+			constants.GpuCountAnnotation:      "1",
+			constants.TFLOPSRequestAnnotation: "100",
+			constants.VRAMRequestAnnotation:   "10Gi",
+			constants.TFLOPSLimitAnnotation:   "100",
+			constants.VRAMLimitAnnotation:     "40Gi",
+		})
+	_, preFilterStatus := s.plugin.PreFilter(s.ctx, state, pod, []fwk.NodeInfo{})
+	s.Require().True(preFilterStatus.IsSuccess())
+
+	nodeInfo := &framework.NodeInfo{}
+	nodeInfo.SetNode(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{constants.Domain + "/defrag-draining": constants.TrueStringValue},
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceName(constants.PodIndexAnnotation): resource.MustParse("512"),
+			},
+		},
+	})
+	status := s.plugin.Filter(s.ctx, state, pod, nodeInfo)
+	s.Equal(fwk.Success, status.Code(), status.Message())
+}
+
 // Every TF worker pod has tensor-fusion.ai/index injected by the webhook, so the
 // node must expose a positive allocatable for that resource. Filter must reject
 // with UnschedulableAndUnresolvable on both a zeroed value (hypervisor just died

--- a/internal/scheduler/gpuresources/gpuresources_test.go
+++ b/internal/scheduler/gpuresources/gpuresources_test.go
@@ -481,6 +481,36 @@ func (s *GPUResourcesSuite) TestFilter_DefragDrainingLabelDoesNotRejectNode() {
 	s.Equal(fwk.Success, status.Code(), status.Message())
 }
 
+func (s *GPUResourcesSuite) TestFilter_DefragSourceLabelRejectsWorker() {
+	log.FromContext(s.ctx).Info("Running TestFilter_DefragSourceLabelRejectsWorker")
+	state := framework.NewCycleState()
+	pod := s.makePod("p-defrag-source",
+		map[string]string{
+			constants.GpuCountAnnotation:      "1",
+			constants.TFLOPSRequestAnnotation: "100",
+			constants.VRAMRequestAnnotation:   "10Gi",
+			constants.TFLOPSLimitAnnotation:   "100",
+			constants.VRAMLimitAnnotation:     "40Gi",
+		})
+	_, preFilterStatus := s.plugin.PreFilter(s.ctx, state, pod, []fwk.NodeInfo{})
+	s.Require().True(preFilterStatus.IsSuccess())
+
+	nodeInfo := &framework.NodeInfo{}
+	nodeInfo.SetNode(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-a",
+			Labels: map[string]string{constants.DefragSourceNodeLabel: constants.TrueStringValue},
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceName(constants.PodIndexAnnotation): resource.MustParse("512"),
+			},
+		},
+	})
+	status := s.plugin.Filter(s.ctx, state, pod, nodeInfo)
+	s.Equal(fwk.Unschedulable, status.Code(), status.Message())
+}
+
 // Every TF worker pod has tensor-fusion.ai/index injected by the webhook, so the
 // node must expose a positive allocatable for that resource. Filter must reject
 // with UnschedulableAndUnresolvable on both a zeroed value (hypervisor just died


### PR DESCRIPTION
- Removed deprecated defrag draining labels and annotations from constants.
- Updated GPUPoolCompactionReconciler to streamline defrag processes, replacing the defrag run initiation with a more focused defrag step.
- Added tests to ensure proper labeling of evicted pods and handling of defrag candidates.
- Enhanced the logic to prevent evictions from being blocked by evicted pod labels.