### PR TITLE
fix: harden autoscaler / gpuallocator / scheduler   against races, lost writes, and leaks

### DIFF
--- a/internal/autoscaler/autoscaler.go
+++ b/internal/autoscaler/autoscaler.go
@@ -153,6 +153,22 @@ func (s *Autoscaler) loadWorkloads(ctx context.Context) {
 			continue
 		}
 
+		// Detect same-name-different-UID recreation: between two ticks the
+		// previous workload may have been deleted and a fresh one created
+		// with the same namespace/name. Drop the stale State (and its
+		// metrics-loader goroutine) so the fresh CR seeds a clean Status —
+		// otherwise the new workload would inherit the old workload's
+		// Recommendation / ActiveCronScalingRule / Conditions /
+		// AppliedRecommendedReplicas through the seed-once cache.
+		if existing, ok := s.findWorkloadState(workloadID.Namespace, workloadID.Name); ok {
+			if !existing.MatchesUID(string(workload.UID)) {
+				log.Info("workload recreated with same namespace/name, dropping stale state",
+					"workload", workloadID)
+				s.metricsLoader.removeWorkload(workloadID)
+				delete(s.workloads, workloadID)
+			}
+		}
+
 		activeWorkloads[workloadID] = true
 		workloadState := s.findOrCreateWorkloadState(workloadID.Namespace, workloadID.Name)
 		if err := s.workloadHandler.UpdateWorkloadState(ctx, workloadState, &workload); err != nil {
@@ -176,20 +192,32 @@ func (s *Autoscaler) loadWorkloads(ctx context.Context) {
 
 func (s *Autoscaler) processSingleWorkload(ctx context.Context, workload *workload.State) {
 	log := log.FromContext(ctx)
+	_, workloadName := workload.Coordinates()
 	recommendation, err := recommender.GetRecommendation(ctx, workload, s.recommenders)
 	if err != nil {
-		log.Error(err, "failed to get recommendation", "workload", workload.Name)
+		log.Error(err, "failed to get recommendation", "workload", workloadName)
 		return
+	}
+
+	// Mirror the newly computed recommendation into State.Status before Apply
+	// runs. Subsequent reads through GetCurrentResourcesSpec (used by the
+	// recommender for incremental scaling), LatestRecommendation (retry on
+	// partial failure), and IsRecommendationAppliedToAllWorkers all consume
+	// State.Status.Recommendation, which seed-once UpdateWorkloadState no
+	// longer refreshes from the API. Only update on a non-nil result so a
+	// no-op round does not erase the in-flight recommendation.
+	if recommendation != nil {
+		workload.SetRecommendation(recommendation)
 	}
 
 	if workload.IsAutoSetResourcesEnabled() {
 		if err := s.workloadHandler.ApplyRecommendationToWorkload(ctx, workload, recommendation); err != nil {
-			log.Error(err, "failed to apply recommendation to workload", "workload", workload.Name)
+			log.Error(err, "failed to apply recommendation to workload", "workload", workloadName)
 		}
 	}
 
 	if err := s.workloadHandler.UpdateWorkloadStatus(ctx, workload, recommendation); err != nil {
-		log.Error(err, "failed to update workload status", "workload", workload.Name)
+		log.Error(err, "failed to update workload status", "workload", workloadName)
 	}
 }
 

--- a/internal/autoscaler/recommender/cron_recommender.go
+++ b/internal/autoscaler/recommender/cron_recommender.go
@@ -9,7 +9,6 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/workload"
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	"github.com/robfig/cron/v3"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -31,12 +30,16 @@ func (c *CronRecommender) Name() string {
 }
 
 func (c *CronRecommender) Recommend(ctx context.Context, w *workload.State) (*RecResult, error) {
-	activeRule, err := c.getActiveCronScalingRule(&w.Spec.AutoScalingConfig)
+	// Snapshot all Spec/Status reads up front so we don't hold State.Mu across
+	// recommendationProcessor.Apply (which itself locks via State accessors).
+	cfg := w.AutoScalingConfigSnapshot()
+	currentRule := w.ActiveCronScalingRuleSnapshot()
+	_, name := w.Coordinates()
+
+	activeRule, err := c.getActiveCronScalingRule(&cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get active cron scaling rule %w", err)
 	}
-
-	currentRule := w.Status.ActiveCronScalingRule
 
 	if activeRule == nil && currentRule == nil {
 		return nil, nil
@@ -50,14 +53,14 @@ func (c *CronRecommender) Recommend(ctx context.Context, w *workload.State) (*Re
 		reason = "RuleInactive"
 		message = fmt.Sprintf("Cron scaling rule %q is inactive", currentRule.Name)
 		log.FromContext(ctx).Info("cron scaling rule inactive",
-			"rule", currentRule.Name, "workload", w.Name, "resources", recommendation)
+			"rule", currentRule.Name, "workload", name, "resources", recommendation)
 	} else {
 		recommendation = activeRule.DesiredResources
 		if currentRule == nil || !recommendation.Equal(&currentRule.DesiredResources) {
 			reason = "RuleActive"
 			message = fmt.Sprintf("Cron scaling rule %q is active", activeRule.Name)
 			log.FromContext(ctx).Info("cron scaling rule active",
-				"rule", activeRule.Name, "workload", w.Name, "resources", recommendation)
+				"rule", activeRule.Name, "workload", name, "resources", recommendation)
 			if c.recommendationProcessor != nil {
 				var err error
 				var msg string
@@ -74,8 +77,8 @@ func (c *CronRecommender) Recommend(ctx context.Context, w *workload.State) (*Re
 	}
 
 	if len(reason) > 0 {
-		w.Status.ActiveCronScalingRule = activeRule.DeepCopy()
-		meta.SetStatusCondition(&w.Status.Conditions, metav1.Condition{
+		w.SetActiveCronScalingRule(activeRule.DeepCopy())
+		w.UpsertStatusCondition(metav1.Condition{
 			Type:               constants.ConditionStatusTypeRecommendationProvided,
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),

--- a/internal/autoscaler/recommender/external_recommender.go
+++ b/internal/autoscaler/recommender/external_recommender.go
@@ -13,7 +13,6 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/workload"
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,7 +38,10 @@ func (e *ExternalRecommender) Name() string {
 
 func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *workload.State) (*RecResult, error) {
 	log := log.FromContext(ctx)
-	config := workloadState.Spec.AutoScalingConfig.ExternalScaler
+	// Snapshot up front; HTTP work below must run without holding State.Mu.
+	config := workloadState.ExternalScalerConfig()
+	namespace, name := workloadState.Coordinates()
+	creationTime := workloadState.CreationTime()
 
 	if config == nil || !config.Enable {
 		return nil, nil
@@ -55,9 +57,9 @@ func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *work
 		}
 	}
 
-	timeSinceCreation := time.Since(workloadState.CreationTimestamp.Time)
+	timeSinceCreation := time.Since(creationTime)
 	if timeSinceCreation < initialDelay {
-		meta.SetStatusCondition(&workloadState.Status.Conditions, metav1.Condition{
+		workloadState.UpsertStatusCondition(metav1.Condition{
 			Type:               constants.ConditionStatusTypeResourceUpdate,
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
@@ -74,8 +76,8 @@ func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *work
 	// Prepare request
 	curRes := workloadState.GetCurrentResourcesSpec()
 	request := tfv1.ExternalScalerRequest{
-		WorkloadName:     workloadState.Name,
-		Namespace:        workloadState.Namespace,
+		WorkloadName:     name,
+		Namespace:        namespace,
 		CurrentResources: *curRes,
 	}
 
@@ -124,7 +126,7 @@ func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *work
 
 	// If no scaling needed, return nil
 	if !response.NeedScaleUp && !response.NeedScaleDown {
-		meta.SetStatusCondition(&workloadState.Status.Conditions, metav1.Condition{
+		workloadState.UpsertStatusCondition(metav1.Condition{
 			Type:               constants.ConditionStatusTypeResourceUpdate,
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
@@ -162,7 +164,7 @@ func (e *ExternalRecommender) Recommend(ctx context.Context, workloadState *work
 		if response.Reason != "" {
 			reason = response.Reason
 		}
-		meta.SetStatusCondition(&workloadState.Status.Conditions, metav1.Condition{
+		workloadState.UpsertStatusCondition(metav1.Condition{
 			Type:               constants.ConditionStatusTypeResourceUpdate,
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),

--- a/internal/autoscaler/recommender/percentile_recommender.go
+++ b/internal/autoscaler/recommender/percentile_recommender.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/metrics"
 	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/workload"
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -102,7 +102,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 	log := log.FromContext(ctx)
 
 	// Check InitialDelayPeriod
-	asr := workload.Spec.AutoScalingConfig.AutoSetResources
+	asr := workload.AutoSetResources()
 	if asr == nil {
 		return nil, nil
 	}
@@ -113,15 +113,17 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 		initialDelay = 30 * time.Minute
 	}
 
-	workloadCreationTime := workload.CreationTimestamp.Time
+	workloadCreationTime := workload.CreationTime()
 	if workloadCreationTime.IsZero() {
 		// Fallback: use current time if creation timestamp is not set
 		workloadCreationTime = time.Now()
 	}
+	_, name := workload.Coordinates()
+	qos := workload.Qos()
 
 	timeSinceCreation := time.Since(workloadCreationTime)
 	if timeSinceCreation < initialDelay {
-		meta.SetStatusCondition(&workload.Status.Conditions, metav1.Condition{
+		workload.UpsertStatusCondition(metav1.Condition{
 			Type:               constants.ConditionStatusTypeResourceUpdate,
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
@@ -140,7 +142,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 		return nil, nil
 	}
 
-	log.V(4).Info("estimated resources", "workload", workload.Name, "estimations", estimations)
+	log.V(4).Info("estimated resources", "workload", name, "estimations", estimations)
 
 	curRes := workload.GetCurrentResourcesSpec()
 	originalRes := workload.GetOriginalResourcesSpec()
@@ -158,7 +160,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 		&originalRes.Requests.Tflops,
 		&originalRes.Limits.Tflops,
 		config,
-		workload.Spec.Qos,
+		qos,
 	); result != nil {
 		message = result.message
 		recommendation.Requests.Tflops = result.targetRequest
@@ -179,7 +181,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 		&originalRes.Requests.Vram,
 		&originalRes.Limits.Vram,
 		config,
-		workload.Spec.Qos,
+		qos,
 	); result != nil {
 		if len(message) > 0 {
 			message += fmt.Sprintf(", %s", result.message)
@@ -222,7 +224,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 
 		// Avoid fluctuation when scale up/down is too small
 		if !shouldUpdate && thresholdMessage != "" {
-			meta.SetStatusCondition(&workload.Status.Conditions, metav1.Condition{
+			workload.UpsertStatusCondition(metav1.Condition{
 				Type:               constants.ConditionStatusTypeResourceUpdate,
 				Status:             metav1.ConditionTrue,
 				LastTransitionTime: metav1.Now(),
@@ -257,7 +259,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 
 	hasApplied := recommendation.Equal(curRes)
 	if !hasApplied {
-		meta.SetStatusCondition(&workload.Status.Conditions, metav1.Condition{
+		workload.UpsertStatusCondition(metav1.Condition{
 			Type:               constants.ConditionStatusTypeResourceUpdate,
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
@@ -391,7 +393,14 @@ type EstimatedResources struct {
 	UpperBoundVram   resource.Quantity
 }
 
-type resourcesEstimator struct {
+// resourcesEstimator is stateless. It holds no per-call data; estimators are
+// constructed locally per GetResourcesEstimation call so concurrent invocations
+// for different workloads cannot stomp on each other's percentile / margin
+// configuration (the previous "*r = resourcesEstimator{...}" pattern was a
+// data race across workloads sharing the same PercentileRecommender).
+type resourcesEstimator struct{}
+
+type percentileEstimators struct {
 	lowerBoundTflops TflopsEstimator
 	targetTflops     TflopsEstimator
 	upperBoundTflops TflopsEstimator
@@ -400,28 +409,31 @@ type resourcesEstimator struct {
 	upperBoundVram   VramEstimator
 }
 
-func (r *resourcesEstimator) GetResourcesEstimation(workload *workload.State) *EstimatedResources {
-	aggregator := workload.WorkerUsageAggregator
-	if aggregator.IsEmpty() {
-		return nil
-	}
-	// TODO: cache config
-	asr := workload.Spec.AutoScalingConfig.AutoSetResources
+func (r *resourcesEstimator) GetResourcesEstimation(wl *workload.State) *EstimatedResources {
+	asr := wl.AutoSetResources()
 	if asr == nil {
 		return nil
 	}
-	r.createEstimatorsFromConfig(getPercentileConfig(asr))
-	return &EstimatedResources{
-		LowerBoundTflops: QuantityFromAmount(r.lowerBoundTflops.GetTflopsEstimation(aggregator), resource.DecimalSI),
-		TargetTflops:     QuantityFromAmount(r.targetTflops.GetTflopsEstimation(aggregator), resource.DecimalSI),
-		UpperBoundTflops: QuantityFromAmount(r.upperBoundTflops.GetTflopsEstimation(aggregator), resource.DecimalSI),
-		LowerBoundVram:   QuantityFromAmount(r.lowerBoundVram.GetVramEstimation(aggregator), resource.BinarySI),
-		TargetVram:       QuantityFromAmount(r.targetVram.GetVramEstimation(aggregator), resource.BinarySI),
-		UpperBoundVram:   QuantityFromAmount(r.upperBoundVram.GetVramEstimation(aggregator), resource.BinarySI),
-	}
+	est := buildPercentileEstimators(getPercentileConfig(asr))
+
+	var result *EstimatedResources
+	wl.ConsumeAggregator(func(aggregator *metrics.WorkerUsageAggregator) {
+		if aggregator == nil || aggregator.IsEmpty() {
+			return
+		}
+		result = &EstimatedResources{
+			LowerBoundTflops: QuantityFromAmount(est.lowerBoundTflops.GetTflopsEstimation(aggregator), resource.DecimalSI),
+			TargetTflops:     QuantityFromAmount(est.targetTflops.GetTflopsEstimation(aggregator), resource.DecimalSI),
+			UpperBoundTflops: QuantityFromAmount(est.upperBoundTflops.GetTflopsEstimation(aggregator), resource.DecimalSI),
+			LowerBoundVram:   QuantityFromAmount(est.lowerBoundVram.GetVramEstimation(aggregator), resource.BinarySI),
+			TargetVram:       QuantityFromAmount(est.targetVram.GetVramEstimation(aggregator), resource.BinarySI),
+			UpperBoundVram:   QuantityFromAmount(est.upperBoundVram.GetVramEstimation(aggregator), resource.BinarySI),
+		}
+	})
+	return result
 }
 
-func (r *resourcesEstimator) createEstimatorsFromConfig(config *PercentileConfig) {
+func buildPercentileEstimators(config *PercentileConfig) percentileEstimators {
 	// Simplified: no confidence multiplier, just percentile + margin
 	targetTflops := NewPercentileTflopsEstimator(config.TargetTflopsPercentile)
 	lowerBoundTflops := NewPercentileTflopsEstimator(config.LowerBoundTflopsPercentile)
@@ -439,7 +451,7 @@ func (r *resourcesEstimator) createEstimatorsFromConfig(config *PercentileConfig
 	lowerBoundVram = WithVramMargin(config.RequestMarginFraction, lowerBoundVram)
 	upperBoundVram = WithVramMargin(config.RequestMarginFraction, upperBoundVram)
 
-	*r = resourcesEstimator{
+	return percentileEstimators{
 		lowerBoundTflops: lowerBoundTflops,
 		targetTflops:     targetTflops,
 		upperBoundTflops: upperBoundTflops,

--- a/internal/autoscaler/recommender/percentile_recommender_race_test.go
+++ b/internal/autoscaler/recommender/percentile_recommender_race_test.go
@@ -1,0 +1,71 @@
+package recommender
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/metrics"
+	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/workload"
+)
+
+// TestPercentileRecommender_ConcurrentDifferentConfigs guards against a
+// shared-mutable-state regression in the percentile estimator. Previously
+// resourcesEstimator stored the configured estimators on the embedded struct
+// (`*r = resourcesEstimator{...}`), so two workloads with different
+// AutoSetResources percentile settings would stomp on each other when running
+// concurrently in their per-workload metrics-loader goroutines. The fix builds
+// the percentileEstimators as a local value per call. Run with -race.
+func TestPercentileRecommender_ConcurrentDifferentConfigs(t *testing.T) {
+	rec := NewPercentileRecommender(nil)
+
+	mkWorkload := func(percentile, margin string) *workload.State {
+		ws := workload.NewWorkloadState()
+		ws.Namespace = "ns"
+		ws.Name = "wl-" + percentile
+		ws.Spec.AutoScalingConfig.AutoSetResources = &tfv1.AutoSetResources{
+			Enable:                      true,
+			TargetResource:              tfv1.ScalingTargetResourceAll,
+			TargetComputePercentile:     percentile,
+			LowerBoundComputePercentile: "0.5",
+			UpperBoundComputePercentile: "0.99",
+			TargetVRAMPercentile:        percentile,
+			LowerBoundVRAMPercentile:    "0.5",
+			UpperBoundVRAMPercentile:    "0.99",
+			MarginFraction:              margin,
+		}
+		// Seed a sample so the aggregator is non-empty; this forces the
+		// estimator read path to actually execute.
+		ws.AddSample(&metrics.WorkerUsage{
+			WorkerName:  "w",
+			TflopsUsage: 10,
+			VramUsage:   1 << 20,
+			Timestamp:   time.Now(),
+		})
+		return ws
+	}
+
+	workloads := []*workload.State{
+		mkWorkload("0.95", "0.15"),
+		mkWorkload("0.50", "0.30"),
+		mkWorkload("0.99", "0.05"),
+		mkWorkload("0.75", "0.20"),
+	}
+
+	// Drive the estimator path directly: skip the Recommend wrapper so the test
+	// doesn't depend on InitialDelayPeriod / curRes plumbing. This is the
+	// specific function that previously stomped on *r.
+	const iterations = 200
+	var wg sync.WaitGroup
+	for _, w := range workloads {
+		wg.Add(1)
+		go func(w *workload.State) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_ = rec.GetResourcesEstimation(w)
+			}
+		}(w)
+	}
+	wg.Wait()
+}

--- a/internal/autoscaler/recommender/recommendation.go
+++ b/internal/autoscaler/recommender/recommendation.go
@@ -40,7 +40,8 @@ func (r *recommendationProcessor) Apply(
 	if err != nil || allowedRes == nil {
 		return result, msg, err
 	}
-	log.FromContext(ctx).V(4).Info("fetched max allowed resources", "workload", workload.Name, "resources", allowedRes)
+	_, workloadName := workload.Coordinates()
+	log.FromContext(ctx).V(4).Info("fetched max allowed resources", "workload", workloadName, "resources", allowedRes)
 
 	if isScaleUpTflops && rec.Requests.Tflops.Cmp(allowedRes.Tflops) > 0 {
 		result.Requests.Tflops = allowedRes.Tflops

--- a/internal/autoscaler/workload/handler.go
+++ b/internal/autoscaler/workload/handler.go
@@ -57,22 +57,34 @@ func (h *handler) SetEventRecorder(recorder events.EventRecorder, scheme *runtim
 }
 
 func (h *handler) UpdateWorkloadState(ctx context.Context, workloadState *State, workload *tfv1.TensorFusionWorkload) error {
+	workerList := &corev1.PodList{}
+	if err := h.List(ctx, workerList,
+		client.InNamespace(workload.Namespace),
+		client.MatchingLabels{constants.WorkloadKey: workload.Name}); err != nil {
+		return err
+	}
+
+	workloadState.Mu.Lock()
+	defer workloadState.Mu.Unlock()
 	workloadState.Namespace = workload.Namespace
 	workloadState.Name = workload.Name
+	workloadState.uid = string(workload.UID)
 	workloadState.Spec = workload.Spec
-	workloadState.Status = *workload.Status.DeepCopy()
+	// Status is autoscaler-owned in memory after seeding. Overwriting it on
+	// every load would race with recommender writes that have not yet been
+	// persisted by UpdateWorkloadStatus, dropping ActiveCronScalingRule /
+	// Recommendation / AppliedRecommendedReplicas / conditions silently.
+	// Seed once (operator startup / first observation), then leave it alone.
+	if !workloadState.statusSeeded {
+		workloadState.Status = *workload.Status.DeepCopy()
+		workloadState.statusSeeded = true
+	}
 	workloadState.CreationTimestamp = workload.CreationTimestamp
 
 	if workload.Spec.AutoScalingConfig.AutoSetResources != nil {
 		workloadState.updateHistoryPeriod(workload.Spec.AutoScalingConfig.AutoSetResources.HistoryDataPeriod)
 	}
 
-	workerList := &corev1.PodList{}
-	if err := h.List(ctx, workerList,
-		client.InNamespace(workloadState.Namespace),
-		client.MatchingLabels{constants.WorkloadKey: workloadState.Name}); err != nil {
-		return err
-	}
 	workloadState.updateCurrentActiveWorkers(workerList)
 	return nil
 }
@@ -81,12 +93,14 @@ func (h *handler) ApplyRecommendationToWorkload(ctx context.Context, workload *S
 	// If the latest recommendation has not been applied to all workers,
 	// we need to retry the update
 	if recommendation == nil && !workload.IsRecommendationAppliedToAllWorkers() {
-		recommendation = workload.Status.Recommendation
+		recommendation = workload.LatestRecommendation()
 	}
 
 	if recommendation != nil {
-		workload.Status.AppliedRecommendedReplicas = 0
-		for _, worker := range workload.CurrentActiveWorkers {
+		// Count successfully-applied workers locally and write once at the end
+		// to avoid lock churn (Reset + Inc-per-iteration was O(N) lock acquisitions).
+		var applied int32
+		for _, worker := range workload.ActiveWorkersSnapshot() {
 			if isWorkerHasDedicatedGPU(worker) {
 				continue
 			}
@@ -95,16 +109,18 @@ func (h *handler) ApplyRecommendationToWorkload(ctx context.Context, workload *S
 				log.FromContext(ctx).Error(err, "failed to update worker resources", "worker", worker.Name)
 				continue
 			}
-			workload.Status.AppliedRecommendedReplicas++
+			applied++
 		}
+		workload.SetAppliedRecommendedReplicas(applied)
 	}
 
 	return nil
 }
 
 func (h *handler) UpdateWorkloadStatus(ctx context.Context, state *State, recommendation *tfv1.Resources) error {
+	namespace, name, stateStatus := state.StatusSnapshot()
 	workload := &tfv1.TensorFusionWorkload{}
-	if err := h.Get(ctx, client.ObjectKey{Namespace: state.Namespace, Name: state.Name}, workload); err != nil {
+	if err := h.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, workload); err != nil {
 		return fmt.Errorf("failed to get workload: %v", err)
 	}
 
@@ -113,18 +129,18 @@ func (h *handler) UpdateWorkloadStatus(ctx context.Context, state *State, recomm
 
 	if isRecommendationChanged(&workload.Status, recommendation) {
 		workload.Status.Recommendation = recommendation
-		workload.Status.ActiveCronScalingRule = state.Status.ActiveCronScalingRule.DeepCopy()
+		workload.Status.ActiveCronScalingRule = stateStatus.ActiveCronScalingRule.DeepCopy()
 		hasChanges = true
 	}
 
-	if workload.Status.AppliedRecommendedReplicas != state.Status.AppliedRecommendedReplicas {
-		workload.Status.AppliedRecommendedReplicas = state.Status.AppliedRecommendedReplicas
+	if workload.Status.AppliedRecommendedReplicas != stateStatus.AppliedRecommendedReplicas {
+		workload.Status.AppliedRecommendedReplicas = stateStatus.AppliedRecommendedReplicas
 		hasChanges = true
 	}
 
 	// Update condition - check for both old and new condition types
 	// Always check conditions even if recommendation is nil, as conditions may need to be updated
-	if condition := meta.FindStatusCondition(state.Status.Conditions,
+	if condition := meta.FindStatusCondition(stateStatus.Conditions,
 		constants.ConditionStatusTypeResourceUpdate); condition != nil {
 		oldCondition := meta.FindStatusCondition(workload.Status.Conditions,
 			constants.ConditionStatusTypeResourceUpdate)
@@ -132,7 +148,7 @@ func (h *handler) UpdateWorkloadStatus(ctx context.Context, state *State, recomm
 			meta.SetStatusCondition(&workload.Status.Conditions, *condition)
 			hasChanges = true
 		}
-	} else if condition := meta.FindStatusCondition(state.Status.Conditions,
+	} else if condition := meta.FindStatusCondition(stateStatus.Conditions,
 		constants.ConditionStatusTypeRecommendationProvided); condition != nil {
 		// Migrate old condition to new type
 		oldCondition := meta.FindStatusCondition(workload.Status.Conditions,
@@ -170,7 +186,8 @@ func isRecommendationChanged(status *tfv1.TensorFusionWorkloadStatus, recommenda
 }
 
 func isAppliedRecommendedReplicasChanged(workload *tfv1.TensorFusionWorkload, state *State) bool {
-	return workload.Status.AppliedRecommendedReplicas != state.Status.AppliedRecommendedReplicas
+	_, _, stateStatus := state.StatusSnapshot()
+	return workload.Status.AppliedRecommendedReplicas != stateStatus.AppliedRecommendedReplicas
 }
 
 func isConditionEqual(c1, c2 *metav1.Condition) bool {
@@ -200,9 +217,10 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 
 	// Record event when scaling happens
 	if h.eventRecorder != nil && h.scheme != nil {
+		namespace, name := workload.Coordinates()
 		workloadObj := &tfv1.TensorFusionWorkload{}
-		workloadObj.Namespace = workload.Namespace
-		workloadObj.Name = workload.Name
+		workloadObj.Namespace = namespace
+		workloadObj.Name = name
 		workloadObj.Kind = "TensorFusionWorkload"
 		workloadObj.APIVersion = tfv1.GroupVersion.String()
 
@@ -253,6 +271,13 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 		return fmt.Errorf("failed to adjust allocation: %v", err)
 	}
 
+	if worker.Annotations == nil {
+		// maps.Copy panics on a nil destination. Pods admitted through the
+		// TF webhook always have GPU resource annotations, but a manual
+		// `kubectl annotate ...-` or an out-of-band controller could leave
+		// the map nil; initialize defensively before the in-place merge.
+		worker.Annotations = make(map[string]string, len(annotationsToUpdate))
+	}
 	patch := client.MergeFrom(worker.DeepCopy())
 	maps.Copy(worker.Annotations, annotationsToUpdate)
 	if err := h.Patch(ctx, worker, patch); err != nil {
@@ -288,6 +313,11 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 		return fmt.Errorf("failed to patch worker %s: %v", worker.Name, err)
 	}
 
+	// Patch landed; mirror the new annotations into the in-memory State so the
+	// next ActiveWorkersSnapshot (now returning deep copies, not shared pointers)
+	// reflects the latest applied resources instead of replaying a stale curRes.
+	workload.UpdateWorkerAnnotations(worker.Name, annotationsToUpdate)
+
 	log.Info("apply recommendation to worker successfully",
 		"worker", worker.Name, "recommendation", recommendation, "currentResources", curRes)
 
@@ -295,13 +325,14 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 }
 
 func (h *handler) GetMaxAllowedResourcesSpec(workload *State) (*tfv1.Resource, error) {
-	if len(workload.CurrentActiveWorkers) <= 0 {
+	workers := workload.ActiveWorkersSnapshot()
+	if len(workers) <= 0 {
 		return nil, nil
 	}
 
 	gpuStore, _, allocRequests := h.allocator.GetAllocationInfo()
 	gpuToWorkers := map[*tfv1.GPU][]*corev1.Pod{}
-	for _, worker := range workload.CurrentActiveWorkers {
+	for _, worker := range workers {
 		allocated, exists := allocRequests[string(worker.UID)]
 		if !exists || allocated == nil {
 			return nil, fmt.Errorf("worker %s has not allocated GPUs", worker.Name)

--- a/internal/autoscaler/workload/workload.go
+++ b/internal/autoscaler/workload/workload.go
@@ -2,6 +2,7 @@ package workload
 
 import (
 	"strings"
+	"sync"
 	"time"
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
@@ -9,19 +10,45 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/utils"
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type State struct {
-	Namespace             string
-	Name                  string
-	Spec                  tfv1.WorkloadProfileSpec
+	Namespace string
+	Name      string
+	Spec      tfv1.WorkloadProfileSpec
+	// Status holds the autoscaler's authoritative view of the recommendation /
+	// applied-replicas / active-cron-rule / conditions fields. It is seeded
+	// from the API CR on the first UpdateWorkloadState call and then owned
+	// in-memory by the autoscaler — subsequent UpdateWorkloadState calls do
+	// NOT overwrite Status, otherwise concurrent loadWorkloads ticks would
+	// blow away pending recommender writes between Recommend and
+	// UpdateWorkloadStatus (lost-write transaction race).
 	Status                tfv1.TensorFusionWorkloadStatus
 	CreationTimestamp     metav1.Time
 	CurrentActiveWorkers  map[string]*corev1.Pod
 	WorkerUsageSamplers   map[string]*metrics.WorkerUsageSampler
 	WorkerUsageAggregator *metrics.WorkerUsageAggregator
 	HistoryPeriod         time.Duration
+	Mu                    sync.RWMutex
+	// statusSeeded marks whether Status has been populated from the API CR.
+	// Toggled true the first time UpdateWorkloadState observes this workload.
+	statusSeeded bool
+	// uid is the API UID of the workload this State is bound to. Used by
+	// loadWorkloads to detect same-namespace/name-but-recreated workloads and
+	// drop the stale State so its Recommendation / ActiveCronScalingRule /
+	// AppliedRecommendedReplicas / conditions don't pollute the new workload.
+	uid string
+}
+
+// MatchesUID reports whether this State is currently bound to the given API
+// UID. A fresh State (uid == "") matches any UID, so the first
+// UpdateWorkloadState call gets to claim it.
+func (w *State) MatchesUID(uid string) bool {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return w.uid == "" || w.uid == uid
 }
 
 func NewWorkloadState() *State {
@@ -34,22 +61,34 @@ func NewWorkloadState() *State {
 }
 
 func (w *State) GetOriginalResourcesSpec() *tfv1.Resources {
-	return &w.Spec.Resources
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return w.Spec.Resources.DeepCopy()
 }
 
 func (w *State) GetCurrentResourcesSpec() *tfv1.Resources {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
 	if w.Status.Recommendation != nil {
-		return w.Status.Recommendation
+		return w.Status.Recommendation.DeepCopy()
 	}
-	return w.GetOriginalResourcesSpec()
+	return w.Spec.Resources.DeepCopy()
 }
 
 func (w *State) IsAutoSetResourcesEnabled() bool {
-	return w.Spec.AutoScalingConfig.AutoSetResources.Enable &&
-		w.Spec.AutoScalingConfig.AutoSetResources.TargetResource != ""
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	asr := w.Spec.AutoScalingConfig.AutoSetResources
+	return asr != nil && asr.Enable && asr.TargetResource != ""
 }
 
 func (w *State) ShouldScaleResource(name tfv1.ResourceName) bool {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return w.shouldScaleResourceLocked(name)
+}
+
+func (w *State) shouldScaleResourceLocked(name tfv1.ResourceName) bool {
 	asr := w.Spec.AutoScalingConfig.AutoSetResources
 	if asr == nil {
 		return false
@@ -71,15 +110,26 @@ func (w *State) ShouldScaleResource(name tfv1.ResourceName) bool {
 }
 
 func (w *State) IsRecommendationAppliedToAllWorkers() bool {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
 	if w.Status.Recommendation == nil {
 		return true
 	}
 
-	if int32(len(w.CurrentActiveWorkers)) != w.Status.AppliedRecommendedReplicas {
+	// Only non-dedicated-GPU workers receive recommendations, so the denominator
+	// must exclude dedicated workers — otherwise AppliedRecommendedReplicas can
+	// never reach len(CurrentActiveWorkers) and we'd retry forever.
+	scalable := int32(0)
+	for _, worker := range w.CurrentActiveWorkers {
+		if !isWorkerHasDedicatedGPU(worker) {
+			scalable++
+		}
+	}
+	if scalable != w.Status.AppliedRecommendedReplicas {
 		return false
 	}
 
-	curRes := w.GetCurrentResourcesSpec()
+	curRes := w.Status.Recommendation
 	for _, worker := range w.CurrentActiveWorkers {
 		if isWorkerHasDedicatedGPU(worker) {
 			continue
@@ -91,6 +141,20 @@ func (w *State) IsRecommendationAppliedToAllWorkers() bool {
 	}
 
 	return true
+}
+
+// ScalableWorkerCount returns the number of current active workers that are
+// eligible to receive recommendations (i.e. excluding dedicated-GPU workers).
+func (w *State) ScalableWorkerCount() int32 {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	var n int32
+	for _, worker := range w.CurrentActiveWorkers {
+		if !isWorkerHasDedicatedGPU(worker) {
+			n++
+		}
+	}
+	return n
 }
 
 func (w *State) updateHistoryPeriod(historyDataPeriod string) {
@@ -110,14 +174,15 @@ func (w *State) updateHistoryPeriod(historyDataPeriod string) {
 
 func (w *State) updateCurrentActiveWorkers(podList *corev1.PodList) {
 	w.CurrentActiveWorkers = map[string]*corev1.Pod{}
-	for _, worker := range podList.Items {
+	for i := range podList.Items {
+		worker := &podList.Items[i]
 		if !worker.DeletionTimestamp.IsZero() {
 			continue
 		}
 		if _, exists := w.WorkerUsageSamplers[worker.Name]; !exists {
 			w.WorkerUsageSamplers[worker.Name] = metrics.NewWorkerUsageSampler()
 		}
-		w.CurrentActiveWorkers[worker.Name] = &worker
+		w.CurrentActiveWorkers[worker.Name] = worker.DeepCopy()
 	}
 
 	for key := range w.WorkerUsageSamplers {
@@ -128,6 +193,8 @@ func (w *State) updateCurrentActiveWorkers(podList *corev1.PodList) {
 }
 
 func (w *State) AddSample(sample *metrics.WorkerUsage) {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
 	sampler, exists := w.WorkerUsageSamplers[sample.WorkerName]
 	if !exists {
 		sampler = metrics.NewWorkerUsageSampler()
@@ -136,6 +203,177 @@ func (w *State) AddSample(sample *metrics.WorkerUsage) {
 	sampler.AddSample(w.WorkerUsageAggregator, sample)
 }
 
+func (w *State) LatestRecommendation() *tfv1.Resources {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	if w.Status.Recommendation == nil {
+		return nil
+	}
+	return w.Status.Recommendation.DeepCopy()
+}
+
+// SetRecommendation stores the latest computed recommendation in the
+// autoscaler-owned in-memory Status so subsequent reads observe it across
+// reconcile cycles. Must be called after every successful GetRecommendation
+// that returns a non-nil value — otherwise GetCurrentResourcesSpec falls back
+// to the original spec, LatestRecommendation cannot service retries, and
+// IsRecommendationAppliedToAllWorkers short-circuits to true.
+//
+// The deep copy keeps callers' references independent of State internals.
+// Pass nil to clear (e.g., when reverting to original spec).
+func (w *State) SetRecommendation(rec *tfv1.Resources) {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	if rec == nil {
+		w.Status.Recommendation = nil
+		return
+	}
+	w.Status.Recommendation = rec.DeepCopy()
+}
+
+// SetAppliedRecommendedReplicas overwrites AppliedRecommendedReplicas in one locked
+// section. Prefer this over Reset+Inc-per-iteration to avoid lock churn in
+// hot apply loops.
+func (w *State) SetAppliedRecommendedReplicas(n int32) {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	w.Status.AppliedRecommendedReplicas = n
+}
+
+func (w *State) ActiveWorkersSnapshot() []*corev1.Pod {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	workers := make([]*corev1.Pod, 0, len(w.CurrentActiveWorkers))
+	for _, worker := range w.CurrentActiveWorkers {
+		if worker == nil {
+			continue
+		}
+		workers = append(workers, worker.DeepCopy())
+	}
+	return workers
+}
+
+func (w *State) StatusSnapshot() (string, string, tfv1.TensorFusionWorkloadStatus) {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return w.Namespace, w.Name, *w.Status.DeepCopy()
+}
+
 func isWorkerHasDedicatedGPU(worker *corev1.Pod) bool {
 	return worker.Annotations[constants.DedicatedGPUAnnotation] == constants.TrueStringValue
+}
+
+// Coordinates returns the workload (namespace, name). Both are immutable
+// after the first UpdateWorkloadState but locked for completeness so external
+// callers don't reach into the struct directly.
+func (w *State) Coordinates() (string, string) {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return w.Namespace, w.Name
+}
+
+// CreationTime returns a copy of CreationTimestamp.Time under lock.
+func (w *State) CreationTime() time.Time {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return w.CreationTimestamp.Time
+}
+
+// SpecSnapshot returns a deep copy of the WorkloadProfileSpec.
+func (w *State) SpecSnapshot() tfv1.WorkloadProfileSpec {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return *w.Spec.DeepCopy()
+}
+
+// AutoScalingConfigSnapshot returns a deep copy of the auto-scaling config.
+func (w *State) AutoScalingConfigSnapshot() tfv1.AutoScalingConfig {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return *w.Spec.AutoScalingConfig.DeepCopy()
+}
+
+// AutoSetResources returns a deep copy of the AutoSetResources config, or nil
+// when unset. Callers checking ".Enable" or ".TargetResource" must handle nil.
+func (w *State) AutoSetResources() *tfv1.AutoSetResources {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	if w.Spec.AutoScalingConfig.AutoSetResources == nil {
+		return nil
+	}
+	return w.Spec.AutoScalingConfig.AutoSetResources.DeepCopy()
+}
+
+// ExternalScalerConfig returns a deep copy of the ExternalScaler config, or nil.
+func (w *State) ExternalScalerConfig() *tfv1.ExternalScalerConfig {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	if w.Spec.AutoScalingConfig.ExternalScaler == nil {
+		return nil
+	}
+	return w.Spec.AutoScalingConfig.ExternalScaler.DeepCopy()
+}
+
+// Qos returns the QoS level (immutable copy).
+func (w *State) Qos() tfv1.QoSLevel {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	return w.Spec.Qos
+}
+
+// ActiveCronScalingRuleSnapshot returns a deep copy of the rule, or nil when unset.
+func (w *State) ActiveCronScalingRuleSnapshot() *tfv1.CronScalingRule {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	if w.Status.ActiveCronScalingRule == nil {
+		return nil
+	}
+	return w.Status.ActiveCronScalingRule.DeepCopy()
+}
+
+// SetActiveCronScalingRule replaces Status.ActiveCronScalingRule under lock.
+// Pass a deep copy if the caller wants to retain its own reference.
+func (w *State) SetActiveCronScalingRule(rule *tfv1.CronScalingRule) {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	w.Status.ActiveCronScalingRule = rule
+}
+
+// UpsertStatusCondition runs meta.SetStatusCondition on Status.Conditions
+// under the write lock.
+func (w *State) UpsertStatusCondition(cond metav1.Condition) {
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	meta.SetStatusCondition(&w.Status.Conditions, cond)
+}
+
+// ConsumeAggregator runs fn while holding the State read lock so callers can
+// safely query the WorkerUsageAggregator without exposing the pointer outside
+// the lock window. The aggregator MUST NOT be retained after fn returns.
+func (w *State) ConsumeAggregator(fn func(*metrics.WorkerUsageAggregator)) {
+	w.Mu.RLock()
+	defer w.Mu.RUnlock()
+	fn(w.WorkerUsageAggregator)
+}
+
+// UpdateWorkerAnnotations merges the given annotations into the tracked
+// worker's in-memory annotations under the State write lock. Call this after a
+// successful API Patch so subsequent ActiveWorkersSnapshot reads see the new
+// state without requiring a re-list. No-op when the worker is not tracked.
+func (w *State) UpdateWorkerAnnotations(workerName string, annotations map[string]string) {
+	if len(annotations) == 0 {
+		return
+	}
+	w.Mu.Lock()
+	defer w.Mu.Unlock()
+	worker, ok := w.CurrentActiveWorkers[workerName]
+	if !ok || worker == nil {
+		return
+	}
+	if worker.Annotations == nil {
+		worker.Annotations = make(map[string]string, len(annotations))
+	}
+	for k, v := range annotations {
+		worker.Annotations[k] = v
+	}
 }

--- a/internal/autoscaler/workload/workload_concurrency_test.go
+++ b/internal/autoscaler/workload/workload_concurrency_test.go
@@ -1,0 +1,95 @@
+package workload
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestState_ConcurrentAddSampleAndSnapshots runs concurrent writers and readers
+// on the same State to ensure Mu (now RWMutex) protects WorkerUsageSamplers
+// against the data race that v1 PR #669 (workload.State locking) addressed.
+//
+// Run with `-race` for the real check; without -race we at least verify no
+// panic and that the returned snapshots remain self-consistent.
+func TestState_ConcurrentAddSampleAndSnapshots(t *testing.T) {
+	ws := NewWorkloadState()
+	ws.Namespace = "ns"
+	ws.Name = "wl"
+
+	const workers = 4
+	const samplesPerWorker = 200
+
+	var wg sync.WaitGroup
+
+	// Writers: AddSample (Lock path).
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		workerName := workerNameFor(w)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < samplesPerWorker; i++ {
+				ws.AddSample(&metrics.WorkerUsage{
+					WorkerName:  workerName,
+					TflopsUsage: float64(i),
+					VramUsage:   uint64(i),
+					Timestamp:   time.Now(),
+				})
+			}
+		}()
+	}
+
+	// Readers: concurrent RLock paths.
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < samplesPerWorker; i++ {
+			ws.StatusSnapshot()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < samplesPerWorker; i++ {
+			_ = ws.IsAutoSetResourcesEnabled()
+			_ = ws.ShouldScaleResource(tfv1.ResourceTflops)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < samplesPerWorker; i++ {
+			_ = ws.ActiveWorkersSnapshot()
+		}
+	}()
+
+	wg.Wait()
+
+	// Sanity: every worker we wrote ended up with a sampler.
+	ws.Mu.RLock()
+	defer ws.Mu.RUnlock()
+	for w := 0; w < workers; w++ {
+		_, ok := ws.WorkerUsageSamplers[workerNameFor(w)]
+		assert.True(t, ok, "expected sampler for %s", workerNameFor(w))
+	}
+}
+
+// TestState_SetAppliedRecommendedReplicas exercises the batched setter that
+// replaced the per-iteration Reset+Inc pattern.
+func TestState_SetAppliedRecommendedReplicas(t *testing.T) {
+	ws := NewWorkloadState()
+	ws.SetAppliedRecommendedReplicas(7)
+
+	_, _, status := ws.StatusSnapshot()
+	assert.Equal(t, int32(7), status.AppliedRecommendedReplicas)
+
+	ws.SetAppliedRecommendedReplicas(0)
+	_, _, status = ws.StatusSnapshot()
+	assert.Equal(t, int32(0), status.AppliedRecommendedReplicas)
+}
+
+func workerNameFor(i int) string {
+	return "worker-" + string(rune('a'+i))
+}

--- a/internal/autoscaler/workload/workload_status_seed_test.go
+++ b/internal/autoscaler/workload/workload_status_seed_test.go
@@ -1,0 +1,197 @@
+package workload
+
+import (
+	"context"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestUpdateWorkloadState_DoesNotClobberRecommenderStatusWrites guards against
+// the lost-write transaction race: while processSingleWorkload is mid-cycle
+// (recommender already wrote Status.ActiveCronScalingRule / Recommendation /
+// AppliedRecommendedReplicas / conditions into State, but UpdateWorkloadStatus
+// has not yet patched the CR), a concurrent loadWorkloads tick must NOT
+// overwrite the in-memory Status with the stale API view.
+func TestUpdateWorkloadState_DoesNotClobberRecommenderStatusWrites(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, tfv1.AddToScheme(scheme))
+
+	apiStatus := tfv1.TensorFusionWorkloadStatus{
+		WorkerCount:                3,
+		ReadyWorkers:               3,
+		Phase:                      tfv1.TensorFusionWorkloadPhaseRunning,
+		PodTemplateHash:            "abc",
+		Recommendation:             nil, // CR has no recommendation persisted yet
+		AppliedRecommendedReplicas: 0,
+		ActiveCronScalingRule:      nil,
+	}
+	wl := &tfv1.TensorFusionWorkload{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "wl"},
+		Spec: tfv1.WorkloadProfileSpec{
+			Resources: tfv1.Resources{
+				Requests: tfv1.Resource{Tflops: resource.MustParse("10"), Vram: resource.MustParse("1Gi")},
+				Limits:   tfv1.Resource{Tflops: resource.MustParse("20"), Vram: resource.MustParse("2Gi")},
+			},
+		},
+		Status: apiStatus,
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wl).WithStatusSubresource(wl).Build()
+	h := NewHandler(c, nil)
+
+	ws := NewWorkloadState()
+
+	// First seed: state.Status is populated from the API CR.
+	assert.NoError(t, h.UpdateWorkloadState(context.Background(), ws, wl))
+	_, _, statusAfterSeed := ws.StatusSnapshot()
+	assert.Equal(t, int32(3), statusAfterSeed.WorkerCount, "first load should seed Status from CR")
+	assert.True(t, ws.statusSeeded, "statusSeeded flag should be flipped")
+
+	// Recommender writes happen in-memory between Recommend and
+	// UpdateWorkloadStatus. Simulate that.
+	rec := &tfv1.Resources{
+		Requests: tfv1.Resource{Tflops: resource.MustParse("99"), Vram: resource.MustParse("9Gi")},
+		Limits:   tfv1.Resource{Tflops: resource.MustParse("99"), Vram: resource.MustParse("9Gi")},
+	}
+	cronRule := &tfv1.CronScalingRule{Name: "active-rule", Enable: true}
+	ws.Mu.Lock()
+	ws.Status.Recommendation = rec.DeepCopy()
+	ws.Status.AppliedRecommendedReplicas = 2
+	ws.Mu.Unlock()
+	ws.SetActiveCronScalingRule(cronRule.DeepCopy())
+	ws.UpsertStatusCondition(metav1.Condition{
+		Type:    "ResourceUpdate",
+		Status:  metav1.ConditionTrue,
+		Reason:  "Updated",
+		Message: "scaled up",
+	})
+
+	// loadWorkloads ticks concurrently — UpdateWorkloadState fires again with
+	// the SAME stale API status (CR hasn't been patched yet). The fix must
+	// preserve the in-memory writes above.
+	assert.NoError(t, h.UpdateWorkloadState(context.Background(), ws, wl))
+
+	_, _, statusAfter := ws.StatusSnapshot()
+	assert.NotNil(t, statusAfter.Recommendation, "Recommendation must survive concurrent UpdateWorkloadState")
+	assert.True(t, statusAfter.Recommendation.Equal(rec),
+		"Recommendation value must match what recommender wrote")
+	assert.Equal(t, int32(2), statusAfter.AppliedRecommendedReplicas,
+		"AppliedRecommendedReplicas must survive")
+	assert.NotNil(t, statusAfter.ActiveCronScalingRule, "ActiveCronScalingRule must survive")
+	assert.Equal(t, "active-rule", statusAfter.ActiveCronScalingRule.Name)
+
+	cond := findCondition(statusAfter.Conditions, "ResourceUpdate")
+	assert.NotNil(t, cond, "Conditions written by recommender must survive")
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+}
+
+func findCondition(conds []metav1.Condition, t string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == t {
+			return &conds[i]
+		}
+	}
+	return nil
+}
+
+// TestSetRecommendation_VisibleToReaders guards that SetRecommendation makes
+// the recommendation visible to GetCurrentResourcesSpec / LatestRecommendation
+// / IsRecommendationAppliedToAllWorkers across reconcile rounds. The
+// production path must call this after every successful GetRecommendation
+// returning non-nil, otherwise (after the seed-once Status refactor)
+// State.Status.Recommendation stays at its seeded value forever and:
+//   - GetCurrentResourcesSpec falls back to original Spec.Resources, breaking
+//     incremental scaling
+//   - LatestRecommendation returns nil so the Apply retry path never recovers
+//     a partially-applied recommendation
+//   - IsRecommendationAppliedToAllWorkers short-circuits to true even when no
+//     recommendation has been applied to any worker
+func TestSetRecommendation_VisibleToReaders(t *testing.T) {
+	ws := NewWorkloadState()
+	ws.Spec.Resources = tfv1.Resources{
+		Requests: tfv1.Resource{Tflops: resource.MustParse("10"), Vram: resource.MustParse("1Gi")},
+		Limits:   tfv1.Resource{Tflops: resource.MustParse("20"), Vram: resource.MustParse("2Gi")},
+	}
+
+	// Fresh state: no recommendation, readers fall back to Spec.Resources.
+	assert.Nil(t, ws.LatestRecommendation())
+	assert.True(t, ws.GetCurrentResourcesSpec().Equal(&ws.Spec.Resources))
+
+	rec := &tfv1.Resources{
+		Requests: tfv1.Resource{Tflops: resource.MustParse("80"), Vram: resource.MustParse("8Gi")},
+		Limits:   tfv1.Resource{Tflops: resource.MustParse("100"), Vram: resource.MustParse("10Gi")},
+	}
+	ws.SetRecommendation(rec)
+
+	assert.NotNil(t, ws.LatestRecommendation())
+	assert.True(t, ws.LatestRecommendation().Equal(rec),
+		"LatestRecommendation must reflect the value set via SetRecommendation")
+	assert.True(t, ws.GetCurrentResourcesSpec().Equal(rec),
+		"GetCurrentResourcesSpec must prefer the in-memory recommendation over Spec.Resources "+
+			"so the next reconcile round uses an incrementally correct baseline")
+
+	// Mutating the caller's copy must not bleed into State (deep copy contract).
+	rec.Requests.Tflops = resource.MustParse("999")
+	stored := ws.LatestRecommendation()
+	assert.NotEqual(t, "999", stored.Requests.Tflops.String(),
+		"SetRecommendation must deep-copy to insulate State from caller mutations")
+
+	// Clearing via nil resets to fallback behavior.
+	ws.SetRecommendation(nil)
+	assert.Nil(t, ws.LatestRecommendation())
+	assert.True(t, ws.GetCurrentResourcesSpec().Equal(&ws.Spec.Resources))
+}
+
+// TestMatchesUID_FreshAndBoundStates documents the UID-tracking contract used
+// by loadWorkloads to detect same-namespace/name workload recreation.
+func TestMatchesUID_FreshAndBoundStates(t *testing.T) {
+	ws := NewWorkloadState()
+	// Fresh state: any UID matches so the first UpdateWorkloadState can claim it.
+	assert.True(t, ws.MatchesUID("uid-A"))
+	assert.True(t, ws.MatchesUID("uid-B"))
+	assert.True(t, ws.MatchesUID(""))
+
+	ws.Mu.Lock()
+	ws.uid = "uid-A"
+	ws.Mu.Unlock()
+
+	// Bound state: only its own UID matches.
+	assert.True(t, ws.MatchesUID("uid-A"))
+	assert.False(t, ws.MatchesUID("uid-B"))
+	assert.False(t, ws.MatchesUID(""))
+}
+
+// TestUpdateWorkloadState_RecordsUID guards that UpdateWorkloadState stores
+// the workload UID on the State so loadWorkloads can detect recreation.
+func TestUpdateWorkloadState_RecordsUID(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, tfv1.AddToScheme(scheme))
+
+	wl := &tfv1.TensorFusionWorkload{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "wl", UID: "uid-A"},
+		Spec: tfv1.WorkloadProfileSpec{
+			Resources: tfv1.Resources{
+				Requests: tfv1.Resource{Tflops: resource.MustParse("10"), Vram: resource.MustParse("1Gi")},
+				Limits:   tfv1.Resource{Tflops: resource.MustParse("20"), Vram: resource.MustParse("2Gi")},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wl).WithStatusSubresource(wl).Build()
+	h := NewHandler(c, nil)
+
+	ws := NewWorkloadState()
+	assert.NoError(t, h.UpdateWorkloadState(context.Background(), ws, wl))
+
+	assert.True(t, ws.MatchesUID("uid-A"))
+	assert.False(t, ws.MatchesUID("uid-B"),
+		"after seeding with workload UID 'uid-A', a different UID must NOT match — "+
+			"loadWorkloads relies on this to detect same-name workload recreation")
+}

--- a/internal/autoscaler/workload_metrics_loader.go
+++ b/internal/autoscaler/workload_metrics_loader.go
@@ -60,8 +60,9 @@ func (l *workloadMetricsLoader) addWorkload(ctx context.Context, workloadID Work
 		return
 	}
 
-	// Get configuration
-	asr := state.Spec.AutoScalingConfig.AutoSetResources
+	// Get configuration (deep copy under State's read lock so we don't race with
+	// loadWorkloads/UpdateWorkloadState rewriting Spec on a separate goroutine).
+	asr := state.AutoSetResources()
 	if asr == nil || !asr.Enable {
 		return
 	}
@@ -100,7 +101,7 @@ func (l *workloadMetricsLoader) addWorkload(ctx context.Context, workloadID Work
 	}
 
 	// Set timer for initial delay
-	timeSinceCreation := time.Since(state.CreationTimestamp.Time)
+	timeSinceCreation := time.Since(state.CreationTime())
 	if timeSinceCreation < initialDelay {
 		remainingDelay := initialDelay - timeSinceCreation
 		loaderState.initialDelayTimer = time.AfterFunc(remainingDelay, func() {
@@ -132,11 +133,18 @@ func (l *workloadMetricsLoader) removeWorkload(workloadID WorkloadID) {
 
 func (l *workloadMetricsLoader) startWorkloadMetricsLoading(loaderState *workloadMetricsState) {
 	logger := log.FromContext(loaderState.ctx)
+
+	// Bail before logging / history-load if removeWorkload already cancelled.
+	if loaderState.ctx.Err() != nil {
+		return
+	}
+
 	logger.Info("Starting metrics loading for workload",
 		"workload", loaderState.workloadID.Name,
 		"firstLoad", loaderState.firstLoad)
 
-	// First load: load history
+	// First load: load history. This call can be slow (up to 60s timeout)
+	// and runs without holding l.mu, so removeWorkload may cancel us mid-way.
 	if loaderState.firstLoad {
 		if err := l.loadHistoryMetricsForWorkload(loaderState); err != nil {
 			logger.Error(err, "failed to load history metrics", "workload", loaderState.workloadID.Name)
@@ -144,12 +152,33 @@ func (l *workloadMetricsLoader) startWorkloadMetricsLoading(loaderState *workloa
 		loaderState.firstLoad = false
 	}
 
-	// Set up ticker for periodic realtime metrics
-	loaderState.ticker = time.NewTicker(loaderState.evaluationInterval)
+	// Re-check post-history-load: if removeWorkload fired during the load,
+	// do NOT create a fresh ticker — that would leak (removeWorkload already
+	// observed ticker == nil and only cancelled ctx).
+	if loaderState.ctx.Err() != nil {
+		return
+	}
+
+	// Assigning loaderState.ticker is a write that removeWorkload reads under
+	// l.mu (line ~126). Take l.mu here so the publish/observe happens under
+	// the same mutex, and re-check ctx once more in case removeWorkload was
+	// waiting on the lock with intent to cancel.
+	l.mu.Lock()
+	if loaderState.ctx.Err() != nil {
+		l.mu.Unlock()
+		return
+	}
+	ticker := time.NewTicker(loaderState.evaluationInterval)
+	loaderState.ticker = ticker
+	l.mu.Unlock()
+
 	go func() {
+		// Stop the ticker on goroutine exit unconditionally. ticker.Stop is
+		// idempotent so this is safe even if removeWorkload already stopped it.
+		defer ticker.Stop()
 		for {
 			select {
-			case <-loaderState.ticker.C:
+			case <-ticker.C:
 				if err := l.loadRealtimeMetricsForWorkload(loaderState); err != nil {
 					logger.Error(err, "failed to load realtime metrics", "workload", loaderState.workloadID.Name)
 				}

--- a/internal/autoscaler/workload_metrics_loader_test.go
+++ b/internal/autoscaler/workload_metrics_loader_test.go
@@ -1,0 +1,111 @@
+package autoscaler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/metrics"
+	"github.com/NexusGPU/tensor-fusion/internal/autoscaler/workload"
+	"github.com/stretchr/testify/assert"
+)
+
+// blockingMetricsProvider lets us hold a history-load call open long enough
+// to schedule removeWorkload concurrently.
+type blockingMetricsProvider struct {
+	historyStarted chan struct{}
+	historyRelease chan struct{}
+	historyCalled  int32
+}
+
+func (b *blockingMetricsProvider) GetWorkersMetrics(ctx context.Context) ([]*metrics.WorkerUsage, error) {
+	return nil, nil
+}
+func (b *blockingMetricsProvider) GetWorkloadHistoryMetrics(ctx context.Context, ns, name string, start, end time.Time) ([]*metrics.WorkerUsage, error) {
+	atomic.AddInt32(&b.historyCalled, 1)
+	select {
+	case b.historyStarted <- struct{}{}:
+	default:
+	}
+	select {
+	case <-b.historyRelease:
+	case <-ctx.Done():
+	}
+	return nil, nil
+}
+func (b *blockingMetricsProvider) GetWorkloadRealtimeMetrics(ctx context.Context, ns, name string, start, end time.Time) ([]*metrics.WorkerUsage, error) {
+	return nil, nil
+}
+
+// TestWorkloadMetricsLoader_RemoveDuringHistoryLoadDoesNotLeakTicker covers
+// the race where removeWorkload observes ticker == nil (because
+// startWorkloadMetricsLoading is still blocked in loadHistoryMetricsForWorkload),
+// only cancels ctx, and then the history-load returns — previously
+// startWorkloadMetricsLoading would proceed to create a fresh time.Ticker
+// and start a goroutine, leaking the ticker. Run with -race for the
+// ticker-field synchronization check.
+func TestWorkloadMetricsLoader_RemoveDuringHistoryLoadDoesNotLeakTicker(t *testing.T) {
+	prov := &blockingMetricsProvider{
+		historyStarted: make(chan struct{}, 1),
+		historyRelease: make(chan struct{}),
+	}
+	l := newWorkloadMetricsLoader(nil, prov)
+	l.setProcessFunc(func(ctx context.Context, state *workload.State) {})
+
+	ws := workload.NewWorkloadState()
+	ws.Namespace = "ns"
+	ws.Name = "wl"
+	ws.HistoryPeriod = time.Hour
+
+	wid := WorkloadID{"ns", "wl"}
+
+	// Manually wire a loaderState that goes into history-load right away.
+	loaderCtx, cancel := context.WithCancel(context.Background())
+	loaderState := &workloadMetricsState{
+		workloadID:         wid,
+		state:              ws,
+		initialDelay:       0,
+		evaluationInterval: 10 * time.Millisecond,
+		historyDataPeriod:  time.Hour,
+		ctx:                loaderCtx,
+		cancel:             cancel,
+		firstLoad:          true,
+	}
+	l.mu.Lock()
+	l.workloads[wid] = loaderState
+	l.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		l.startWorkloadMetricsLoading(loaderState)
+		close(done)
+	}()
+
+	// Wait until we're inside the history-load (blocked on historyRelease).
+	select {
+	case <-prov.historyStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("history load never started")
+	}
+
+	// removeWorkload runs while history load is still blocking.
+	l.removeWorkload(wid)
+
+	// Release history-load; startWorkloadMetricsLoading should now return
+	// without creating a ticker because ctx is already cancelled.
+	close(prov.historyRelease)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("startWorkloadMetricsLoading did not return after cancel")
+	}
+
+	// Ticker must NOT have been published — startWorkloadMetricsLoading bailed
+	// post-history-load on ctx.Err(). If the bug came back, ticker would be
+	// a non-nil leaked *time.Ticker.
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	assert.Nil(t, loaderState.ticker, "ticker must not be allocated after removeWorkload cancelled ctx during history load")
+}

--- a/internal/config/global_config.go
+++ b/internal/config/global_config.go
@@ -16,6 +16,10 @@ type GlobalConfig struct {
 	AutoScalingInterval       string `yaml:"autoScalingInterval"`
 	GPUOperatorNamespace      string `yaml:"gpuOperatorNamespace"`
 	PreemptClusterWideFromEnv bool   `yaml:"preemptClusterWideFromEnv"`
+
+	// HypervisorMaxCrashCount is the container RestartCount threshold that triggers
+	// a hypervisor pod recreation. Set to 0 to disable. nil uses the default.
+	HypervisorMaxCrashCount *int32 `yaml:"hypervisorMaxCrashCount"`
 }
 
 type AutoMigrationConfig struct {
@@ -61,6 +65,9 @@ const (
 
 	// Default GPU operator namespace
 	DefaultGPUOperatorNamespace = "gpu-operator"
+
+	// DefaultHypervisorMaxCrashCount is used when HypervisorMaxCrashCount is unset.
+	DefaultHypervisorMaxCrashCount int32 = 5
 )
 
 // GetGPUOperatorNamespace returns the configured GPU operator namespace or default value

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -270,7 +270,7 @@ func (r *GPUNodeReconciler) checkStatusAndUpdateVirtualCapacity(
 			metrics.SetGPUMetrics(gpuList, node.Name, poolObj.Name)
 		}
 
-		if coreNode.Labels != nil && coreNode.Labels[constants.KarpenterExpansionLabel] != "" {
+		if r.Expander != nil && coreNode.Labels != nil && coreNode.Labels[constants.KarpenterExpansionLabel] != "" {
 			r.Expander.RemoveInFlightNode(coreNode.Labels[constants.KarpenterExpansionLabel])
 		}
 		return nil
@@ -389,6 +389,22 @@ func (r *GPUNodeReconciler) reconcileHypervisorPod(
 
 	// If pod exists and prerequisites are satisfied, verify its status
 	if podExists {
+		if crashedContainer, restartCount, threshold, ok := hypervisorPodCrashExceeded(currentPod); ok {
+			log.Info("hypervisor pod crash count exceeded threshold, deleting for recreation",
+				"node", node.Name,
+				"pod", currentPod.Name,
+				"container", crashedContainer,
+				"restartCount", restartCount,
+				"threshold", threshold)
+			r.Recorder.Eventf(node, nil, corev1.EventTypeWarning, "HypervisorCrashLoopRecreate", "Recreate",
+				"Hypervisor pod %s deleted for recreation: container %s restarted %d times (threshold %d)",
+				currentPod.Name, crashedContainer, restartCount, threshold)
+			if err := r.Delete(ctx, currentPod); err != nil {
+				return "", fmt.Errorf("failed to delete crash-looping hypervisor pod: %w", err)
+			}
+			return "", nil
+		}
+
 		desiredIsolationMode := getHypervisorIsolationModeFromNodeLabel(node)
 		if !isHypervisorIsolationModeConfigured(currentPod, desiredIsolationMode) {
 			if err := r.Delete(ctx, currentPod); err != nil {
@@ -1119,6 +1135,32 @@ func (r *GPUNodeReconciler) mapDevicePluginPodToGPUNode(ctx context.Context, obj
 		"nodeName", pod.Spec.NodeName)
 
 	return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: pod.Spec.NodeName}}}
+}
+
+func hypervisorPodCrashExceeded(pod *corev1.Pod) (container string, restartCount int32, threshold int32, exceeded bool) {
+	threshold = config.DefaultHypervisorMaxCrashCount
+	if cfg := config.GetGlobalConfig(); cfg != nil && cfg.HypervisorMaxCrashCount != nil {
+		threshold = *cfg.HypervisorMaxCrashCount
+	}
+	if threshold <= 0 {
+		return "", 0, 0, false
+	}
+
+	check := func(statuses []corev1.ContainerStatus) (string, int32, bool) {
+		for _, cs := range statuses {
+			if cs.RestartCount > threshold {
+				return cs.Name, cs.RestartCount, true
+			}
+		}
+		return "", 0, false
+	}
+	if name, count, hit := check(pod.Status.InitContainerStatuses); hit {
+		return name, count, threshold, true
+	}
+	if name, count, hit := check(pod.Status.ContainerStatuses); hit {
+		return name, count, threshold, true
+	}
+	return "", 0, threshold, false
 }
 
 func getMatchedVendor(node *corev1.Node, nodeManagerConfig *tfv1.NodeManagerConfig) (string, error) {

--- a/internal/controller/gpunode_crash_recovery_unit_test.go
+++ b/internal/controller/gpunode_crash_recovery_unit_test.go
@@ -1,0 +1,82 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/NexusGPU/tensor-fusion/internal/config"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestHypervisorPodCrashExceeded(t *testing.T) {
+	defaultCfg := config.GetGlobalConfig()
+	t.Cleanup(func() { config.SetGlobalConfig(defaultCfg) })
+
+	pod := func(initRestart, mainRestart int32) *corev1.Pod {
+		return &corev1.Pod{
+			Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{Name: "init", RestartCount: initRestart},
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: "main", RestartCount: mainRestart},
+				},
+			},
+		}
+	}
+
+	t.Run("default threshold, restart count below threshold => not exceeded", func(t *testing.T) {
+		config.SetGlobalConfig(&config.GlobalConfig{})
+		_, _, threshold, exceeded := hypervisorPodCrashExceeded(pod(0, config.DefaultHypervisorMaxCrashCount))
+		assert.False(t, exceeded, "RestartCount == threshold should not trigger (strict greater-than)")
+		assert.Equal(t, config.DefaultHypervisorMaxCrashCount, threshold)
+	})
+
+	t.Run("default threshold, restart count above threshold => exceeded", func(t *testing.T) {
+		config.SetGlobalConfig(&config.GlobalConfig{})
+		name, count, threshold, exceeded := hypervisorPodCrashExceeded(pod(0, config.DefaultHypervisorMaxCrashCount+1))
+		assert.True(t, exceeded)
+		assert.Equal(t, "main", name)
+		assert.Equal(t, config.DefaultHypervisorMaxCrashCount+1, count)
+		assert.Equal(t, config.DefaultHypervisorMaxCrashCount, threshold)
+	})
+
+	t.Run("init container exceeds threshold is detected first", func(t *testing.T) {
+		config.SetGlobalConfig(&config.GlobalConfig{})
+		name, count, _, exceeded := hypervisorPodCrashExceeded(pod(config.DefaultHypervisorMaxCrashCount+1, 0))
+		assert.True(t, exceeded)
+		assert.Equal(t, "init", name)
+		assert.Equal(t, config.DefaultHypervisorMaxCrashCount+1, count)
+	})
+
+	t.Run("threshold = 0 disables the mechanism", func(t *testing.T) {
+		zero := int32(0)
+		config.SetGlobalConfig(&config.GlobalConfig{HypervisorMaxCrashCount: &zero})
+		_, _, _, exceeded := hypervisorPodCrashExceeded(pod(100, 100))
+		assert.False(t, exceeded, "threshold <= 0 must disable the check entirely")
+	})
+
+	t.Run("negative threshold disables the mechanism", func(t *testing.T) {
+		neg := int32(-1)
+		config.SetGlobalConfig(&config.GlobalConfig{HypervisorMaxCrashCount: &neg})
+		_, _, _, exceeded := hypervisorPodCrashExceeded(pod(50, 50))
+		assert.False(t, exceeded)
+	})
+
+	t.Run("custom threshold from config is honored", func(t *testing.T) {
+		custom := int32(2)
+		config.SetGlobalConfig(&config.GlobalConfig{HypervisorMaxCrashCount: &custom})
+		_, _, threshold, exceeded := hypervisorPodCrashExceeded(pod(0, 2))
+		assert.False(t, exceeded)
+		assert.Equal(t, int32(2), threshold)
+
+		_, _, _, exceeded = hypervisorPodCrashExceeded(pod(0, 3))
+		assert.True(t, exceeded, "RestartCount 3 > threshold 2 should trigger")
+	})
+
+	t.Run("nil GlobalConfig falls back to default", func(t *testing.T) {
+		config.SetGlobalConfig(nil)
+		_, _, threshold, _ := hypervisorPodCrashExceeded(pod(0, 0))
+		assert.Equal(t, config.DefaultHypervisorMaxCrashCount, threshold)
+	})
+}

--- a/internal/controller/gpunodeclaim_controller.go
+++ b/internal/controller/gpunodeclaim_controller.go
@@ -77,7 +77,7 @@ func (r *GPUNodeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// When node really created, remove from in flight nodes
-	if claim.Labels != nil && claim.Status.Phase == tfv1.GPUNodeClaimBound {
+	if r.Expander != nil && claim.Labels != nil && claim.Status.Phase == tfv1.GPUNodeClaimBound {
 		r.Expander.RemoveInFlightNode(claim.Labels[constants.KarpenterExpansionLabel])
 	}
 
@@ -90,7 +90,9 @@ func (r *GPUNodeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	needRequeueCheckDeletion := false
 	shouldReturn, err := utils.HandleFinalizer(ctx, claim, r.Client, func(ctx context.Context, claim *tfv1.GPUNodeClaim) (bool, error) {
 		nodeList := &corev1.NodeList{}
-		r.Expander.RemoveInFlightNode(claim.Name)
+		if r.Expander != nil {
+			r.Expander.RemoveInFlightNode(claim.Name)
+		}
 		if err := r.List(ctx, nodeList, client.MatchingLabels{constants.ProvisionerLabelKey: claim.Name}); err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -83,7 +83,9 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	pod := &corev1.Pod{}
 	if err := r.Get(ctx, req.NamespacedName, pod); err != nil {
 		if errors.IsNotFound(err) {
-			_ = r.Expander.RemovePreSchedulePod(req.Name, true)
+			if r.Expander != nil {
+				_ = r.Expander.RemovePreSchedulePod(req.Name, true)
+			}
 			r.Allocator.DeallocByPodIdentifier(ctx, req.NamespacedName)
 			metrics.RemoveWorkerMetrics(req.Name, time.Now())
 			metrics.RemoveGPUAllocationMetrics(req.Name)
@@ -104,7 +106,9 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// Release GPU resources when pod is in Failed or Succeeded (Complete) state
 	// Only for worker pods that have allocated GPU resources
 	if pod.Labels[constants.LabelComponent] == constants.ComponentWorker && utils.IsPodStopped(pod) {
-		_ = r.Expander.RemovePreSchedulePod(pod.Name, true)
+		if r.Expander != nil {
+			_ = r.Expander.RemovePreSchedulePod(pod.Name, true)
+		}
 		r.Allocator.DeallocByPodIdentifier(ctx, req.NamespacedName)
 		metrics.RemoveWorkerMetrics(pod.Name, time.Now())
 		metrics.RemoveGPUAllocationMetrics(pod.Name)
@@ -193,14 +197,24 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 }
 
 func (r *PodReconciler) handleWorkerPodFinalizer(ctx context.Context, pod *corev1.Pod) (bool, error) {
-	// Handle our GPU resource cleanup finalizer
+	// Handle our GPU resource cleanup finalizer. The counter on the owner
+	// annotation IS admission-side state — webhook reads it to decide whether
+	// to admit more pods — so we cannot leave it drifted by skipping Decrease
+	// failures and forging ahead with finalizer removal. Decrease retries
+	// transient conflicts internally; anything that still surfaces here is
+	// persistent (RBAC, owner schema mismatch, ...) and must block finalizer
+	// removal so the pod requeues and a human can observe the failure.
 	shouldReturn, err := utils.HandleFinalizer(ctx, pod, r.Client, func(ctx context.Context, obj *corev1.Pod) (bool, error) {
 		// if the Pod keep terminating, should update deletion timestamp for raw cost calculation
 		metrics.RemoveWorkerMetrics(pod.Name, time.Now())
 		metrics.RemoveGPUAllocationMetrics(pod.Name)
 		counter := &v1.TensorFusionPodCounter{Client: r.Client}
 		if err := counter.Decrease(ctx, pod); err != nil {
-			return false, err
+			// Returning (false, err) keeps the finalizer in place and lets
+			// HandleFinalizer + controller-runtime requeue with backoff so
+			// the counter eventually decrements. Releasing the finalizer
+			// here would leak the count on every persistent failure path.
+			return false, fmt.Errorf("decrease pod counter (will retry): %w", err)
 		}
 		return true, nil
 	})

--- a/internal/gpuallocator/capacity_drift_unit_test.go
+++ b/internal/gpuallocator/capacity_drift_unit_test.go
@@ -1,0 +1,174 @@
+package gpuallocator
+
+import (
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testGPU1Name = "gpu-1"
+
+func qty(s string) resource.Quantity {
+	return resource.MustParse(s)
+}
+
+func makeGPU(name string, capTflops, capVram, availTflops, availVram string) *tfv1.GPU {
+	g := &tfv1.GPU{}
+	g.Name = name
+	g.Status.Capacity = &tfv1.Resource{Tflops: qty(capTflops), Vram: qty(capVram)}
+	g.Status.Available = &tfv1.Resource{Tflops: qty(availTflops), Vram: qty(availVram)}
+	return g
+}
+
+func TestClampGPUAvailableToCapacity(t *testing.T) {
+	t.Run("clamp Available > Capacity to Capacity", func(t *testing.T) {
+		g := makeGPU("g", "71", "24Gi", "142", "48Gi")
+		clampGPUAvailableToCapacity(g)
+		assert.Equal(t, "71", g.Status.Available.Tflops.String())
+		assert.Equal(t, "24Gi", g.Status.Available.Vram.String())
+	})
+
+	t.Run("Available <= Capacity is left alone", func(t *testing.T) {
+		g := makeGPU("g", "71", "24Gi", "30", "10Gi")
+		clampGPUAvailableToCapacity(g)
+		assert.Equal(t, "30", g.Status.Available.Tflops.String())
+		assert.Equal(t, "10Gi", g.Status.Available.Vram.String())
+	})
+
+	t.Run("nil capacity/available is a no-op (no panic)", func(t *testing.T) {
+		g := &tfv1.GPU{}
+		clampGPUAvailableToCapacity(g)
+
+		g.Status.Capacity = &tfv1.Resource{Tflops: qty("71"), Vram: qty("24Gi")}
+		clampGPUAvailableToCapacity(g) // available still nil
+		g.Status.Available = &tfv1.Resource{Tflops: qty("100"), Vram: qty("48Gi")}
+		clampGPUAvailableToCapacity(g)
+		assert.Equal(t, "71", g.Status.Available.Tflops.String())
+		assert.Equal(t, "24Gi", g.Status.Available.Vram.String())
+	})
+
+	t.Run("mixed: only Vram exceeds", func(t *testing.T) {
+		g := makeGPU("g", "71", "24Gi", "30", "100Gi")
+		clampGPUAvailableToCapacity(g)
+		assert.Equal(t, "30", g.Status.Available.Tflops.String())
+		assert.Equal(t, "24Gi", g.Status.Available.Vram.String())
+	})
+}
+
+func TestRecomputeGPUAvailableFromAllocations(t *testing.T) {
+	mkReq := func(podName string, gpuNames []string, tflops, vram string) *tfv1.AllocRequest {
+		return &tfv1.AllocRequest{
+			PodMeta:  metav1.ObjectMeta{Name: podName, Namespace: "ns"},
+			GPUNames: gpuNames,
+			Request:  tfv1.Resource{Tflops: qty(tflops), Vram: qty(vram)},
+		}
+	}
+
+	t.Run("subtracts requests targeting this GPU", func(t *testing.T) {
+		s := &GpuAllocator{
+			uniqueAllocation: map[string]*tfv1.AllocRequest{
+				"uid-a": mkReq("pod-a", []string{testGPU1Name}, "20", "8Gi"),
+				"uid-b": mkReq("pod-b", []string{testGPU1Name}, "10", "4Gi"),
+				"uid-c": mkReq("pod-c", []string{"gpu-2"}, "30", "8Gi"), // different GPU
+			},
+		}
+		g := makeGPU(testGPU1Name, "71", "24Gi", "71", "24Gi")
+		s.recomputeGPUAvailableFromAllocations(g)
+		// 71 - 20 - 10 = 41
+		assert.Equal(t, "41", g.Status.Available.Tflops.String())
+		// 24Gi - 8Gi - 4Gi = 12Gi
+		assert.Equal(t, "12Gi", g.Status.Available.Vram.String())
+	})
+
+	t.Run("no allocations -> Available equals Capacity", func(t *testing.T) {
+		s := &GpuAllocator{uniqueAllocation: map[string]*tfv1.AllocRequest{}}
+		g := makeGPU(testGPU1Name, "71", "24Gi", "0", "0")
+		s.recomputeGPUAvailableFromAllocations(g)
+		assert.Equal(t, "71", g.Status.Available.Tflops.String())
+		assert.Equal(t, "24Gi", g.Status.Available.Vram.String())
+	})
+
+	t.Run("nil capacity is a no-op (no panic)", func(t *testing.T) {
+		s := &GpuAllocator{uniqueAllocation: map[string]*tfv1.AllocRequest{}}
+		g := &tfv1.GPU{}
+		g.Name = testGPU1Name
+		// Status.Capacity is nil
+		s.recomputeGPUAvailableFromAllocations(g)
+		assert.Nil(t, g.Status.Capacity)
+	})
+}
+
+// TestHandleGPUUpdateCapacityDiff_HypervisorRestartPattern reproduces the exact
+// failure mode observed on dev for gpu-f5d00867: GPU CR is wiped (capacity=0),
+// the worker pod survives, and the hypervisor later restores capacity. Without
+// the recompute, Available would jump from 0 to Capacity even though the worker
+// is still holding allocation -> on subsequent Dealloc, Available > Capacity.
+func TestHandleGPUUpdateCapacityDiff_HypervisorRestartPattern(t *testing.T) {
+	gpuName := "gpu-f5d00867"
+	// Worker is allocated full GPU (vram=24Gi, tflops via ComputePercent absent here
+	// -> use plain Request.Tflops=71 for simplicity).
+	s := &GpuAllocator{
+		uniqueAllocation: map[string]*tfv1.AllocRequest{
+			"worker-uid": {
+				PodMeta:  metav1.ObjectMeta{Name: "worker", Namespace: "ns", UID: "worker-uid"},
+				GPUNames: []string{gpuName},
+				Request:  tfv1.Resource{Tflops: qty("71"), Vram: qty("24Gi")},
+			},
+		},
+	}
+	// "old" reflects in-memory state right after the GPU CR was re-created with
+	// empty status (handleGPUCreate initialized Available=Capacity=zero).
+	old := makeGPU(gpuName, "0", "0", "0", "0")
+	// "gpu" is what the hypervisor publishes after restart: full capacity.
+	incoming := makeGPU(gpuName, "71", "24Gi", "71", "24Gi")
+
+	s.handleGPUUpdateCapacityDiff(old, incoming)
+
+	// After the fix, Available reflects the active allocation (worker holds
+	// the full GPU), so Available should be zero, not 71/24Gi.
+	assert.Equal(t, "0", old.Status.Available.Tflops.String(),
+		"Available.Tflops should be 0 (worker holds full GPU); raw-diff math would give 71")
+	assert.Equal(t, "0", old.Status.Available.Vram.String(),
+		"Available.Vram should be 0; raw-diff math would give 24Gi")
+	// Capacity correctly updated.
+	assert.Equal(t, "71", old.Status.Capacity.Tflops.String())
+	assert.Equal(t, "24Gi", old.Status.Capacity.Vram.String())
+}
+
+// TestHandleGPUUpdateCapacityDiff_NormalGrowthStillWorks ensures the recompute
+// only triggers on the zero-capacity transition, not on routine updates.
+func TestHandleGPUUpdateCapacityDiff_NormalGrowthStillWorks(t *testing.T) {
+	gpuName := testGPU1Name
+	s := &GpuAllocator{uniqueAllocation: map[string]*tfv1.AllocRequest{}}
+	old := makeGPU(gpuName, "60", "20Gi", "50", "16Gi") // 10/4Gi already used
+	incoming := makeGPU(gpuName, "71", "24Gi", "71", "24Gi")
+
+	s.handleGPUUpdateCapacityDiff(old, incoming)
+
+	// Diff +11/+4Gi added to Available -> 50+11=61, 16Gi+4Gi=20Gi
+	assert.Equal(t, "61", old.Status.Available.Tflops.String())
+	assert.Equal(t, "20Gi", old.Status.Available.Vram.String())
+	assert.Equal(t, "71", old.Status.Capacity.Tflops.String())
+	assert.Equal(t, "24Gi", old.Status.Capacity.Vram.String())
+}
+
+// TestHandleGPUUpdateCapacityDiff_ClampPreventsOverCapacity guards against the
+// observable >Capacity symptom even if some upstream code path misbehaves.
+func TestHandleGPUUpdateCapacityDiff_ClampPreventsOverCapacity(t *testing.T) {
+	gpuName := testGPU1Name
+	s := &GpuAllocator{uniqueAllocation: map[string]*tfv1.AllocRequest{}}
+	// Pathological: incoming capacity is smaller than old Available (could
+	// happen if Capacity is downgraded). Available must clamp to new Capacity.
+	old := makeGPU(gpuName, "100", "40Gi", "100", "40Gi")
+	incoming := makeGPU(gpuName, "71", "24Gi", "71", "24Gi")
+
+	s.handleGPUUpdateCapacityDiff(old, incoming)
+
+	assert.True(t, old.Status.Available.Tflops.Cmp(old.Status.Capacity.Tflops) <= 0,
+		"Available.Tflops must not exceed Capacity.Tflops after diff")
+	assert.True(t, old.Status.Available.Vram.Cmp(old.Status.Capacity.Vram) <= 0,
+		"Available.Vram must not exceed Capacity.Vram after diff")
+}

--- a/internal/gpuallocator/get_allocation_info_unit_test.go
+++ b/internal/gpuallocator/get_allocation_info_unit_test.go
@@ -1,0 +1,92 @@
+package gpuallocator
+
+import (
+	"sync"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// newAllocatorForGetInfoTest builds an isolated GpuAllocator with the three
+// stores GetAllocationInfo reads from, without running the constructor (which
+// depends on real K8s client / indexAllocator).
+func newAllocatorForGetInfoTest() *GpuAllocator {
+	cap := &tfv1.Resource{
+		Tflops: resource.MustParse("100"),
+		Vram:   resource.MustParse("80Gi"),
+	}
+	gpu := &tfv1.GPU{}
+	gpu.Name = "gpu-1"
+	gpu.Status.Capacity = cap.DeepCopy()
+	gpu.Status.Available = cap.DeepCopy()
+
+	gpuKey := types.NamespacedName{Name: "gpu-1"}
+	allocReq := &tfv1.AllocRequest{PodMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-1"}}
+
+	return &GpuAllocator{
+		gpuStore:        map[types.NamespacedName]*tfv1.GPU{gpuKey: gpu},
+		nodeWorkerStore: map[string]map[types.NamespacedName]struct{}{"node-a": {gpuKey: {}}},
+		uniqueAllocation: map[string]*tfv1.AllocRequest{
+			"uid-1": allocReq,
+		},
+	}
+}
+
+func TestGetAllocationInfo_ReturnsDeepCopies(t *testing.T) {
+	s := newAllocatorForGetInfoTest()
+	gpuKey := types.NamespacedName{Name: "gpu-1"}
+
+	gpuStore, nodeWorkerStore, uniqueAllocation := s.GetAllocationInfo()
+
+	// 1. gpuStore: mutating the returned GPU must not affect internal store.
+	returnedGPU := gpuStore[gpuKey]
+	assert.NotNil(t, returnedGPU)
+	returnedGPU.Status.Available.Tflops = resource.MustParse("0")
+	originalInternal := s.gpuStore[gpuKey]
+	assert.NotEqual(t, "0", originalInternal.Status.Available.Tflops.String(),
+		"GetAllocationInfo must return a deep copy of gpuStore values")
+
+	// 2. nodeWorkerStore: mutating the returned inner map must not affect internal.
+	innerCopy := nodeWorkerStore["node-a"]
+	innerCopy[types.NamespacedName{Name: "extra"}] = struct{}{}
+	assert.NotContains(t, s.nodeWorkerStore["node-a"], types.NamespacedName{Name: "extra"},
+		"GetAllocationInfo must return a copied inner map for nodeWorkerStore")
+
+	// 3. uniqueAllocation: mutating the returned value must not affect internal.
+	returnedReq := uniqueAllocation["uid-1"]
+	assert.NotNil(t, returnedReq)
+	returnedReq.PodMeta.Name = "tampered"
+	assert.Equal(t, "pod-1", s.uniqueAllocation["uid-1"].PodMeta.Name,
+		"GetAllocationInfo must return a deep copy of uniqueAllocation values")
+}
+
+func TestGetAllocationInfo_ConcurrentReadIsSafe(t *testing.T) {
+	s := newAllocatorForGetInfoTest()
+	const goroutines = 8
+	const iterations = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				gpuStore, _, _ := s.GetAllocationInfo()
+				// Mutating snapshots in parallel must not race with the allocator's
+				// internal state (RWMutex + deep copy is what protects us).
+				if g, ok := gpuStore[types.NamespacedName{Name: "gpu-1"}]; ok && g.Status.Available != nil {
+					g.Status.Available.Tflops = resource.MustParse("0")
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Internal state must remain intact.
+	internalGPU := s.gpuStore[types.NamespacedName{Name: "gpu-1"}]
+	assert.Equal(t, "100", internalGPU.Status.Available.Tflops.String())
+}

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	goerrors "github.com/pkg/errors"
@@ -45,63 +46,177 @@ const CleanUpCheckInterval = 3 * time.Minute
 var mu sync.Mutex
 var GPUCapacityMap = map[string]tfv1.Resource{}
 
-// PartitionTemplateMap stores partition template info by GPU model
-// Key: GPU model (e.g., "A100_SXM_80G"), Value: map of templateID -> template info
-var PartitionTemplateMap = map[string]map[string]config.PartitionTemplateInfo{}
-
-// MaxPartitionsMap stores max partitions by GPU model
-// Key: GPU model, Value: max partitions (e.g., 7 for MIG)
-var MaxPartitionsMap = map[string]uint32{}
-
-// MaxPlacementSlotsMap stores max placement slots by GPU model
-// Key: GPU model, Value: max placement slots (e.g., 8 for MIG)
-var MaxPlacementSlotsMap = map[string]uint32{}
-
-// MaxIsolationGroupsMap stores max isolation groups by GPU model
-// Key: GPU model, Value: max isolation groups (e.g., 4 for Ascend vGroups)
-var MaxIsolationGroupsMap = map[string]uint32{}
-
-// TotalExtendedResourcesMap stores total extended resources by GPU model
-// Key: GPU model, Value: map of resource name -> total capacity
-// For Ascend NPU: {"AICORE": 8, "AICPU": 7, "VPC": 12, ...}
-var TotalExtendedResourcesMap = map[string]map[string]uint32{}
-
-// LoadPartitionTemplatesFromConfig loads partition templates and max partitions from GPU info config
-// This should be called when GPU info config is loaded/updated
-func LoadPartitionTemplatesFromConfig(gpuInfos []config.GpuInfo) {
+func GetGPUCapacity(model string) (tfv1.Resource, bool) {
 	mu.Lock()
 	defer mu.Unlock()
+	resource, found := GPUCapacityMap[model]
+	return resource, found
+}
 
-	// Rebuild maps on each refresh to avoid stale template/config entries.
-	PartitionTemplateMap = make(map[string]map[string]config.PartitionTemplateInfo, len(gpuInfos)*2)
-	MaxPartitionsMap = make(map[string]uint32, len(gpuInfos)*2)
-	MaxPlacementSlotsMap = make(map[string]uint32, len(gpuInfos)*2)
-	MaxIsolationGroupsMap = make(map[string]uint32, len(gpuInfos)*2)
-	TotalExtendedResourcesMap = make(map[string]map[string]uint32, len(gpuInfos)*2)
+// partitionConfig is an immutable snapshot of all 5 partition-related
+// config maps. The writer (LoadPartitionTemplatesFromConfig) constructs a
+// fresh *partitionConfig and publishes it atomically; readers do a single
+// atomic Load and then read freely from the snapshot.
+//
+// The contract is structural: once a *partitionConfig is published via
+// partitionConfigPtr.Store, NONE of its fields are mutated. Any
+// "modification" goes through publishing a brand-new snapshot. This makes
+// "post-publish immutability" a property of the type, not a comment.
+type partitionConfig struct {
+	// Templates: GPU model -> templateID -> template info.
+	Templates map[string]map[string]config.PartitionTemplateInfo
+	// MaxPartitions: GPU model -> max partitions (e.g. 7 for MIG).
+	MaxPartitions map[string]uint32
+	// MaxPlacementSlots: GPU model -> max placement slots (e.g. 8 for MIG).
+	MaxPlacementSlots map[string]uint32
+	// MaxIsolationGroups: GPU model -> max isolation groups (e.g. 4 for Ascend vGroups).
+	MaxIsolationGroups map[string]uint32
+	// TotalExtendedResources: GPU model -> resource name -> total capacity.
+	// For Ascend NPU: {"AICORE": 8, "AICPU": 7, "VPC": 12, ...}.
+	TotalExtendedResources map[string]map[string]uint32
+}
+
+func newEmptyPartitionConfig() *partitionConfig {
+	return &partitionConfig{
+		Templates:              map[string]map[string]config.PartitionTemplateInfo{},
+		MaxPartitions:          map[string]uint32{},
+		MaxPlacementSlots:      map[string]uint32{},
+		MaxIsolationGroups:     map[string]uint32{},
+		TotalExtendedResources: map[string]map[string]uint32{},
+	}
+}
+
+// clone shallow-copies the outer maps so test helpers can mutate the result
+// without disturbing the currently-published snapshot. Inner maps are
+// reference-shared and remain immutable.
+func (c *partitionConfig) clone() *partitionConfig {
+	next := &partitionConfig{
+		Templates:              make(map[string]map[string]config.PartitionTemplateInfo, len(c.Templates)),
+		MaxPartitions:          make(map[string]uint32, len(c.MaxPartitions)),
+		MaxPlacementSlots:      make(map[string]uint32, len(c.MaxPlacementSlots)),
+		MaxIsolationGroups:     make(map[string]uint32, len(c.MaxIsolationGroups)),
+		TotalExtendedResources: make(map[string]map[string]uint32, len(c.TotalExtendedResources)),
+	}
+	for k, v := range c.Templates {
+		next.Templates[k] = v
+	}
+	for k, v := range c.MaxPartitions {
+		next.MaxPartitions[k] = v
+	}
+	for k, v := range c.MaxPlacementSlots {
+		next.MaxPlacementSlots[k] = v
+	}
+	for k, v := range c.MaxIsolationGroups {
+		next.MaxIsolationGroups[k] = v
+	}
+	for k, v := range c.TotalExtendedResources {
+		next.TotalExtendedResources[k] = v
+	}
+	return next
+}
+
+// partitionConfigPtr holds the current snapshot. Read with .Load(); replace
+// with .Store(newCfg). NEVER mutate a value returned from .Load().
+var partitionConfigPtr atomic.Pointer[partitionConfig]
+
+func init() {
+	// Seed with an empty snapshot so readers never observe nil between
+	// process start and the first LoadPartitionTemplatesFromConfig.
+	partitionConfigPtr.Store(newEmptyPartitionConfig())
+}
+
+// GetPartitionTemplates returns the templates map for a GPU model from the
+// current snapshot. The returned inner map is post-publish-immutable, so
+// callers may iterate / read it without holding any lock.
+func GetPartitionTemplates(gpuModel string) (map[string]config.PartitionTemplateInfo, bool) {
+	templates, ok := partitionConfigPtr.Load().Templates[gpuModel]
+	return templates, ok
+}
+
+// GetMaxPartitions returns MaxPartitions for a model from the current
+// snapshot, or 0 if missing.
+func GetMaxPartitions(gpuModel string) uint32 {
+	return partitionConfigPtr.Load().MaxPartitions[gpuModel]
+}
+
+// GetMaxPlacementSlots returns MaxPlacementSlots for a model from the current
+// snapshot.
+func GetMaxPlacementSlots(gpuModel string) (uint32, bool) {
+	v, ok := partitionConfigPtr.Load().MaxPlacementSlots[gpuModel]
+	return v, ok
+}
+
+// GetMaxIsolationGroups returns MaxIsolationGroups for a model from the
+// current snapshot.
+func GetMaxIsolationGroups(gpuModel string) (uint32, bool) {
+	v, ok := partitionConfigPtr.Load().MaxIsolationGroups[gpuModel]
+	return v, ok
+}
+
+// GetTotalExtendedResources returns the extended-resources map for a GPU
+// model from the current snapshot.
+func GetTotalExtendedResources(gpuModel string) (map[string]uint32, bool) {
+	v, ok := partitionConfigPtr.Load().TotalExtendedResources[gpuModel]
+	return v, ok
+}
+
+// GetPartitionConfigSnapshot returns the MaxPartitions and PartitionTemplate
+// maps from the current snapshot as a single atomic pair. Used by callers
+// that hand both maps to a filter / strategy and need them cross-consistent.
+// Both maps are post-publish-immutable, so the snapshot is safe to use long
+// after the call returns.
+func GetPartitionConfigSnapshot() (map[string]uint32, map[string]map[string]config.PartitionTemplateInfo) {
+	cfg := partitionConfigPtr.Load()
+	return cfg.MaxPartitions, cfg.Templates
+}
+
+// MutatePartitionConfigForTesting clones the current snapshot, applies fn to
+// the clone, then atomically publishes the result. Test-only — production
+// code MUST go through LoadPartitionTemplatesFromConfig so the contract of
+// "writer constructs a whole new snapshot" is enforced.
+func MutatePartitionConfigForTesting(fn func(*partitionConfig)) {
+	old := partitionConfigPtr.Load()
+	next := old.clone()
+	fn(next)
+	partitionConfigPtr.Store(next)
+}
+
+// LoadPartitionTemplatesFromConfig builds a fresh *partitionConfig from the
+// supplied GPU info list and atomically publishes it. Called from
+// providerconfig_controller and pricing reload paths; concurrent readers
+// observe either the previous or the new snapshot, never a torn state.
+func LoadPartitionTemplatesFromConfig(gpuInfos []config.GpuInfo) {
+	cfg := &partitionConfig{
+		Templates:              make(map[string]map[string]config.PartitionTemplateInfo, len(gpuInfos)*2),
+		MaxPartitions:          make(map[string]uint32, len(gpuInfos)*2),
+		MaxPlacementSlots:      make(map[string]uint32, len(gpuInfos)*2),
+		MaxIsolationGroups:     make(map[string]uint32, len(gpuInfos)*2),
+		TotalExtendedResources: make(map[string]map[string]uint32, len(gpuInfos)*2),
+	}
 
 	for _, gpuInfo := range gpuInfos {
 		// Store max partitions
 		if gpuInfo.MaxPartitions > 0 {
-			MaxPartitionsMap[gpuInfo.Model] = gpuInfo.MaxPartitions
-			MaxPartitionsMap[gpuInfo.FullModelName] = gpuInfo.MaxPartitions
+			cfg.MaxPartitions[gpuInfo.Model] = gpuInfo.MaxPartitions
+			cfg.MaxPartitions[gpuInfo.FullModelName] = gpuInfo.MaxPartitions
 		}
 
 		// Store max placement slots
 		if gpuInfo.MaxPlacementSlots > 0 {
-			MaxPlacementSlotsMap[gpuInfo.Model] = gpuInfo.MaxPlacementSlots
-			MaxPlacementSlotsMap[gpuInfo.FullModelName] = gpuInfo.MaxPlacementSlots
+			cfg.MaxPlacementSlots[gpuInfo.Model] = gpuInfo.MaxPlacementSlots
+			cfg.MaxPlacementSlots[gpuInfo.FullModelName] = gpuInfo.MaxPlacementSlots
 		}
 
 		// Store max isolation groups (for Ascend vGroups)
 		if gpuInfo.MaxIsolationGroups > 0 {
-			MaxIsolationGroupsMap[gpuInfo.Model] = gpuInfo.MaxIsolationGroups
-			MaxIsolationGroupsMap[gpuInfo.FullModelName] = gpuInfo.MaxIsolationGroups
+			cfg.MaxIsolationGroups[gpuInfo.Model] = gpuInfo.MaxIsolationGroups
+			cfg.MaxIsolationGroups[gpuInfo.FullModelName] = gpuInfo.MaxIsolationGroups
 		}
 
 		// Store total extended resources (for Ascend AICORE, AICPU, etc.)
 		if len(gpuInfo.TotalExtendedResources) > 0 {
-			TotalExtendedResourcesMap[gpuInfo.Model] = gpuInfo.TotalExtendedResources
-			TotalExtendedResourcesMap[gpuInfo.FullModelName] = gpuInfo.TotalExtendedResources
+			cfg.TotalExtendedResources[gpuInfo.Model] = gpuInfo.TotalExtendedResources
+			cfg.TotalExtendedResources[gpuInfo.FullModelName] = gpuInfo.TotalExtendedResources
 		}
 
 		// Store partition templates
@@ -114,10 +229,12 @@ func LoadPartitionTemplatesFromConfig(gpuInfos []config.GpuInfo) {
 					templateMap[template.Name] = template
 				}
 			}
-			PartitionTemplateMap[gpuInfo.Model] = templateMap
-			PartitionTemplateMap[gpuInfo.FullModelName] = templateMap
+			cfg.Templates[gpuInfo.Model] = templateMap
+			cfg.Templates[gpuInfo.FullModelName] = templateMap
 		}
 	}
+
+	partitionConfigPtr.Store(cfg)
 }
 
 type Strategy interface {
@@ -242,6 +359,10 @@ func (s *GpuAllocator) RegisterBindHandler(handler func(req *tfv1.AllocRequest))
 	s.bindHandlers = append(s.bindHandlers, handler)
 }
 
+func (s *GpuAllocator) UpsertGPUForTesting(ctx context.Context, gpu *tfv1.GPU) {
+	s.handleGPUCreate(ctx, gpu)
+}
+
 func (s *GpuAllocator) GetAllocationInfo() (
 	gpuStore map[types.NamespacedName]*tfv1.GPU,
 	nodeWorkerStore map[string]map[types.NamespacedName]struct{},
@@ -249,7 +370,26 @@ func (s *GpuAllocator) GetAllocationInfo() (
 ) {
 	s.storeMutex.RLock()
 	defer s.storeMutex.RUnlock()
-	return s.gpuStore, s.nodeWorkerStore, s.uniqueAllocation
+
+	gpuStore = make(map[types.NamespacedName]*tfv1.GPU, len(s.gpuStore))
+	for key, gpu := range s.gpuStore {
+		if gpu == nil {
+			continue
+		}
+		gpuStore[key] = gpu.DeepCopy()
+	}
+
+	nodeWorkerStore = make(map[string]map[types.NamespacedName]struct{}, len(s.nodeWorkerStore))
+	for nodeName, workers := range s.nodeWorkerStore {
+		workerCopy := make(map[types.NamespacedName]struct{}, len(workers))
+		for worker := range workers {
+			workerCopy[worker] = struct{}{}
+		}
+		nodeWorkerStore[nodeName] = workerCopy
+	}
+
+	uniqueAllocation = cloneAllocRequestMap(s.uniqueAllocation)
+	return gpuStore, nodeWorkerStore, uniqueAllocation
 }
 
 func cloneGPUMap(gpuMap map[string]*tfv1.GPU) map[string]*tfv1.GPU {
@@ -402,7 +542,8 @@ func (s *GpuAllocator) Filter(
 
 	// 3. Partition template filter (only for partitioned mode)
 	if req.Isolation == tfv1.IsolationModePartitioned {
-		filterRegistry = filterRegistry.With(filter.NewPartitionTemplateFilter(req.Isolation, req.PartitionTemplateID, MaxPartitionsMap, PartitionTemplateMap))
+		maxPartitionsSnap, partitionTemplateSnap := GetPartitionConfigSnapshot()
+		filterRegistry = filterRegistry.With(filter.NewPartitionTemplateFilter(req.Isolation, req.PartitionTemplateID, maxPartitionsSnap, partitionTemplateSnap))
 	}
 
 	// 4. Resource filter (moved after isolation/partition filters)
@@ -663,7 +804,8 @@ func (s *GpuAllocator) buildPreemptFilterRegistry(req *tfv1.AllocRequest) *filte
 		filterRegistry = filterRegistry.With(filter.NewGPUIsolationModeFilter(req.Isolation))
 	}
 	if req.Isolation == tfv1.IsolationModePartitioned {
-		filterRegistry = filterRegistry.With(filter.NewPartitionTemplateFilter(req.Isolation, req.PartitionTemplateID, MaxPartitionsMap, PartitionTemplateMap))
+		maxPartitionsSnap, partitionTemplateSnap := GetPartitionConfigSnapshot()
+		filterRegistry = filterRegistry.With(filter.NewPartitionTemplateFilter(req.Isolation, req.PartitionTemplateID, maxPartitionsSnap, partitionTemplateSnap))
 	}
 	filterRegistry = filterRegistry.With(filter.NewResourceFilter(req.Request))
 	if req.GPUModel != "" {
@@ -735,8 +877,8 @@ func (s *GpuAllocator) GetMatchedPartition(
 
 	// Find the best GPU with the best matching partition template
 	for _, gpu := range filteredGPUs {
-		// Get partition templates from global config by GPU model
-		templateConfigs, hasTemplates := PartitionTemplateMap[gpu.Status.GPUModel]
+		// Get partition templates from global config by GPU model (locked accessor)
+		templateConfigs, hasTemplates := GetPartitionTemplates(gpu.Status.GPUModel)
 		if !hasTemplates || len(templateConfigs) == 0 {
 			continue // Skip GPUs without partition templates in config
 		}
@@ -1176,6 +1318,11 @@ func (s *GpuAllocator) Dealloc(
 		}
 
 		removeRunningApp(s.ctx, storeGPU, request)
+		// Safety net: if the GPU CR was reset between Reserve and Dealloc (e.g.
+		// hypervisor restart cleared status), Available wasn't actually subtracted
+		// when this allocation was made, so adding it back here would push Available
+		// above Capacity. Clamp to maintain the invariant Available <= Capacity.
+		clampGPUAvailableToCapacity(storeGPU)
 
 		s.markGPUDirty(gpuNameNs)
 	}
@@ -1666,7 +1813,7 @@ func (s *GpuAllocator) handleGPUCreate(ctx context.Context, gpu *tfv1.GPU) {
 	defer s.storeMutex.Unlock()
 
 	if s.gpuStore[key] != nil {
-		if gpu.Status.GPUModel != "" {
+		if gpu.Status.GPUModel != "" && gpu.Status.Capacity != nil {
 			mu.Lock()
 			if _, exists := GPUCapacityMap[gpu.Status.GPUModel]; !exists {
 				GPUCapacityMap[gpu.Status.GPUModel] = *gpu.Status.Capacity
@@ -1734,7 +1881,14 @@ func (s *GpuAllocator) handleGPUUpdate(ctx context.Context, gpu *tfv1.GPU) {
 		syncGPUMetadataAndStatusFromCluster(old, gpu)
 		log.V(6).Info("Updated GPU in store (preserve Available)", "name", key.Name, "phase", gpu.Status.Phase)
 	} else {
-		s.gpuStore[key] = gpu.DeepCopy()
+		gpuInMem := gpu.DeepCopy()
+		if gpuInMem.Status.Capacity == nil {
+			gpuInMem.Status.Capacity = &tfv1.Resource{}
+		}
+		if gpuInMem.Status.Available == nil {
+			gpuInMem.Status.Available = gpuInMem.Status.Capacity.DeepCopy()
+		}
+		s.gpuStore[key] = gpuInMem
 		log.V(6).Info("Updated GPU in store (new entry)", "name", key.Name, "phase", gpu.Status.Phase)
 	}
 
@@ -1742,6 +1896,9 @@ func (s *GpuAllocator) handleGPUUpdate(ctx context.Context, gpu *tfv1.GPU) {
 }
 
 func (s *GpuAllocator) addOrUpdateGPUMaps(gpuInMem *tfv1.GPU) {
+	if gpuInMem == nil {
+		return
+	}
 	if gpuInMem.Status.NodeSelector != nil {
 		gpuNodeName := gpuInMem.Status.NodeSelector[constants.KubernetesHostNameLabel]
 		if gpuNodeName != "" {
@@ -1766,7 +1923,7 @@ func (s *GpuAllocator) addOrUpdateGPUMaps(gpuInMem *tfv1.GPU) {
 		}
 	}
 
-	if gpuInMem.Status.GPUModel != "" {
+	if gpuInMem.Status.GPUModel != "" && gpuInMem.Status.Capacity != nil {
 		mu.Lock()
 		GPUCapacityMap[gpuInMem.Status.GPUModel] = *gpuInMem.Status.Capacity
 		mu.Unlock()
@@ -1808,6 +1965,14 @@ func (s *GpuAllocator) handleGPUUpdateCapacityDiff(old, gpu *tfv1.GPU) {
 		old.Status.Available = gpu.Status.Capacity.DeepCopy()
 	}
 
+	// Detect the hypervisor-restart pattern: GPU CR was reset to zero capacity
+	// (controller saw it disappear and reappear without status), and now the
+	// hypervisor publishes the real capacity. The naive "Available += diff"
+	// math is wrong in that case because it assumes Available already tracked
+	// active allocations through the transition, which it didn't (the worker
+	// was running the whole time but our in-memory Available was reset).
+	oldCapacityWasZero := old.Status.Capacity.Tflops.IsZero() && old.Status.Capacity.Vram.IsZero()
+
 	tflopsDiff := gpu.Status.Capacity.Tflops.DeepCopy()
 	tflopsDiff.Sub(old.Status.Capacity.Tflops)
 	if tflopsDiff.Value() != 0 {
@@ -1819,6 +1984,59 @@ func (s *GpuAllocator) handleGPUUpdateCapacityDiff(old, gpu *tfv1.GPU) {
 	if vramDiff.Value() != 0 {
 		old.Status.Capacity.Vram.Add(vramDiff)
 		old.Status.Available.Vram.Add(vramDiff)
+	}
+
+	if oldCapacityWasZero && (!old.Status.Capacity.Tflops.IsZero() || !old.Status.Capacity.Vram.IsZero()) {
+		// Rebuild Available = Capacity - sum(active Request on this GPU).
+		// uniqueAllocation is the authoritative ledger of who holds what.
+		s.recomputeGPUAvailableFromAllocations(old)
+	}
+	// Final safety net: a stale Dealloc or a Capacity downgrade can still drift
+	// Available above Capacity (the observable symptom). Clamp to invariant.
+	clampGPUAvailableToCapacity(old)
+}
+
+// recomputeGPUAvailableFromAllocations resets gpu.Status.Available to Capacity,
+// then subtracts every active allocation that references this GPU. Caller must
+// hold s.storeMutex.
+func (s *GpuAllocator) recomputeGPUAvailableFromAllocations(gpu *tfv1.GPU) {
+	if gpu == nil || gpu.Status.Capacity == nil {
+		return
+	}
+	available := gpu.Status.Capacity.DeepCopy()
+	for _, req := range s.uniqueAllocation {
+		if req == nil {
+			continue
+		}
+		for _, name := range req.GPUNames {
+			if name != gpu.Name {
+				continue
+			}
+			if !req.Request.ComputePercent.IsZero() {
+				tflops := utils.ComputePercentToTflops(gpu.Status.Capacity.Tflops, req.Request)
+				available.Tflops.Sub(*tflops)
+			} else {
+				available.Tflops.Sub(req.Request.Tflops)
+			}
+			available.Vram.Sub(req.Request.Vram)
+		}
+	}
+	gpu.Status.Available = available
+}
+
+// clampGPUAvailableToCapacity enforces the invariant Available <= Capacity for
+// both tflops and vram. This is defense-in-depth against any code path that
+// adds resources back to Available without a matching prior subtraction
+// (e.g., GPU CR reset + Dealloc of a pod that survived the reset).
+func clampGPUAvailableToCapacity(gpu *tfv1.GPU) {
+	if gpu == nil || gpu.Status.Capacity == nil || gpu.Status.Available == nil {
+		return
+	}
+	if gpu.Status.Available.Tflops.Cmp(gpu.Status.Capacity.Tflops) > 0 {
+		gpu.Status.Available.Tflops = gpu.Status.Capacity.Tflops.DeepCopy()
+	}
+	if gpu.Status.Available.Vram.Cmp(gpu.Status.Capacity.Vram) > 0 {
+		gpu.Status.Available.Vram = gpu.Status.Capacity.Vram.DeepCopy()
 	}
 }
 
@@ -2389,15 +2607,22 @@ func removeRunningApp(ctx context.Context, gpu *tfv1.GPU, allocRequest *tfv1.All
 			})
 		}
 	} else {
-		// should not happen, if deallocation twice, it should be a bug
-		log.FromContext(ctx).Info("[Warning] The app to remove not found, could be caused by deallocation twice bug", "gpu", gpu.Name, "namespace", gpu.Namespace, "workload", workloadNameNamespace.Name, "namespace", workloadNameNamespace.Namespace)
+		// Common false positive: the GPU CR's RunningApps was cleared (e.g. by a
+		// hypervisor restart) while the allocation entry survived in memory. In
+		// that case there's nothing to remove from RunningApps and that's fine.
+		// True "deallocation twice" would have been blocked earlier by the
+		// uniqueDeallocation guard in Dealloc.
+		log.FromContext(ctx).V(1).Info("running-app entry not present on GPU at dealloc time; likely GPU CR was reset between Reserve and Dealloc",
+			"gpu", gpu.Name,
+			"workloadNamespace", workloadNameNamespace.Namespace,
+			"workloadName", workloadNameNamespace.Name)
 	}
 }
 
 // bindPartition handles partition allocation for a single GPU in partitioned mode
 func (s *GpuAllocator) bindPartition(gpu *tfv1.GPU, req *tfv1.AllocRequest, selectedGPU string) error {
-	// Verify template exists in global config for this GPU model
-	templateConfigs, hasTemplates := PartitionTemplateMap[gpu.Status.GPUModel]
+	// Verify template exists in global config for this GPU model (locked accessor).
+	templateConfigs, hasTemplates := GetPartitionTemplates(gpu.Status.GPUModel)
 	if !hasTemplates {
 		return fmt.Errorf("no partition templates configured for GPU model %s", gpu.Status.GPUModel)
 	}

--- a/internal/gpuallocator/node_capacity.go
+++ b/internal/gpuallocator/node_capacity.go
@@ -26,7 +26,11 @@ func RefreshGPUNodeCapacity(
 		return nil, fmt.Errorf("failed to list GPUs: %w", err)
 	}
 	if len(gpuList.Items) == 0 {
-		// node discovery job not completed, wait next reconcile loop to check again
+		// Node discovery may not be complete, or GPU CRs may have been removed.
+		// Reconcile the progressive taint as idle so stale isolation does not block native scheduling forever.
+		if err := reconcileProgressiveTaint(ctx, k8sClient, coreNode, true); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
@@ -106,38 +110,63 @@ func RefreshGPUNodeCapacity(
 
 	node.Status.Phase = tfv1.TensorFusionGPUNodePhaseRunning
 
-	if !equality.Semantic.DeepEqual(node.Status, statusCopy) {
-		err := k8sClient.Status().Update(ctx, node)
-		if err != nil {
-			return nil, fmt.Errorf("failed to update GPU node status: %w", err)
-		}
-
-		// check if need to update K8S node label
-		if utils.IsProgressiveMigration() && coreNode != nil {
-			taint := &corev1.Taint{
-				Key:    constants.NodeUsedByTaintKey,
-				Effect: corev1.TaintEffectPreferNoSchedule,
-				Value:  constants.TensorFusionSystemName,
-			}
-			needUpdateNode := false
-			if node.Status.AvailableVRAM.Equal(node.Status.TotalVRAM) && node.Status.AvailableTFlops.Equal(node.Status.TotalTFlops) {
-				// check if need to remove the taint
-				coreNode, needUpdateNode, _ = taints.RemoveTaint(coreNode, taint)
-			} else if !taints.TaintExists(coreNode.Spec.Taints, taint) {
-				// check if need to add the taint
-				coreNode, needUpdateNode, _ = taints.AddOrUpdateTaint(coreNode, taint)
-			}
-			if needUpdateNode {
-				log.FromContext(ctx).Info("Updating K8S node taints for isolation of tensor-fusion and non-tensor-fusion used nodes",
-					"node", coreNode.Name, "taint", taint.Key)
-				err := k8sClient.Update(ctx, coreNode)
-				if err != nil {
-					return nil, fmt.Errorf("failed to update K8S node: %w", err)
-				}
-			}
+	statusChanged := !equality.Semantic.DeepEqual(node.Status, statusCopy)
+	var statusErr error
+	if statusChanged {
+		if err := k8sClient.Status().Update(ctx, node); err != nil {
+			statusErr = fmt.Errorf("failed to update GPU node status: %w", err)
 		}
 	}
-	return gpuModels, nil
+
+	// Best-effort: reconcile the progressive taint even when the status update above failed,
+	// so a transient API error does not leave the node in a stale isolation state. Surface
+	// the original status error to the caller for retry.
+	if !node.Status.TotalVRAM.IsZero() || !node.Status.TotalTFlops.IsZero() {
+		isIdle := node.Status.AvailableVRAM.Equal(node.Status.TotalVRAM) &&
+			node.Status.AvailableTFlops.Equal(node.Status.TotalTFlops)
+		if err := reconcileProgressiveTaint(ctx, k8sClient, coreNode, isIdle); err != nil {
+			if statusErr != nil {
+				log.FromContext(ctx).Error(err, "failed to reconcile progressive taint after status update failure",
+					"node", node.Name)
+				return nil, statusErr
+			}
+			return nil, err
+		}
+	}
+	return gpuModels, statusErr
+}
+
+func reconcileProgressiveTaint(ctx context.Context, k8sClient client.Client, coreNode *corev1.Node, isIdle bool) error {
+	if !utils.IsProgressiveMigration() || coreNode == nil {
+		return nil
+	}
+	taint := &corev1.Taint{
+		Key:    constants.NodeUsedByTaintKey,
+		Effect: corev1.TaintEffectPreferNoSchedule,
+		Value:  constants.TensorFusionSystemName,
+	}
+	hasTaint := taints.TaintExists(coreNode.Spec.Taints, taint)
+	var (
+		updated *corev1.Node
+		changed bool
+	)
+	switch {
+	case isIdle && hasTaint:
+		updated, changed, _ = taints.RemoveTaint(coreNode, taint)
+	case !isIdle && !hasTaint:
+		updated, changed, _ = taints.AddOrUpdateTaint(coreNode, taint)
+	default:
+		return nil
+	}
+	if !changed {
+		return nil
+	}
+	log.FromContext(ctx).Info("Updating K8S node taints for isolation of tensor-fusion and non-tensor-fusion used nodes",
+		"node", updated.Name, "taint", taint.Key, "idle", isIdle)
+	if err := k8sClient.Update(ctx, updated); err != nil {
+		return fmt.Errorf("failed to update K8S node: %w", err)
+	}
+	return nil
 }
 
 func calculateVirtualCapacity(node *tfv1.GPUNode, pool *tfv1.GPUPool) (resource.Quantity, resource.Quantity) {

--- a/internal/gpuallocator/node_capacity_unit_test.go
+++ b/internal/gpuallocator/node_capacity_unit_test.go
@@ -1,0 +1,105 @@
+package gpuallocator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NexusGPU/tensor-fusion/internal/utils"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/taints"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func nodeWithOptionalTaint(name string, withTaint bool) *corev1.Node {
+	n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if withTaint {
+		n.Spec.Taints = []corev1.Taint{{
+			Key:    constants.NodeUsedByTaintKey,
+			Effect: corev1.TaintEffectPreferNoSchedule,
+			Value:  constants.TensorFusionSystemName,
+		}}
+	}
+	return n
+}
+
+func TestReconcileProgressiveTaint(t *testing.T) {
+	orig := utils.IsProgressiveMigration()
+	t.Cleanup(func() { utils.SetProgressiveMigration(orig) })
+	utils.SetProgressiveMigration(true)
+
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+
+	check := func(t *testing.T, taintKey string, expectHasTaint bool, node *corev1.Node) {
+		t.Helper()
+		taint := &corev1.Taint{Key: taintKey, Effect: corev1.TaintEffectPreferNoSchedule, Value: constants.TensorFusionSystemName}
+		assert.Equal(t, expectHasTaint, taints.TaintExists(node.Spec.Taints, taint))
+	}
+
+	t.Run("idle+hasTaint => remove", func(t *testing.T) {
+		node := nodeWithOptionalTaint("n1", true)
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+
+		assert.NoError(t, reconcileProgressiveTaint(context.Background(), c, node, true))
+
+		got := &corev1.Node{}
+		assert.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "n1"}, got))
+		check(t, constants.NodeUsedByTaintKey, false, got)
+	})
+
+	t.Run("!idle+!hasTaint => add", func(t *testing.T) {
+		node := nodeWithOptionalTaint("n2", false)
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+
+		assert.NoError(t, reconcileProgressiveTaint(context.Background(), c, node, false))
+
+		got := &corev1.Node{}
+		assert.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "n2"}, got))
+		check(t, constants.NodeUsedByTaintKey, true, got)
+	})
+
+	t.Run("idle+!hasTaint => no-op", func(t *testing.T) {
+		node := nodeWithOptionalTaint("n3", false)
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+
+		assert.NoError(t, reconcileProgressiveTaint(context.Background(), c, node, true))
+
+		got := &corev1.Node{}
+		assert.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "n3"}, got))
+		assert.Equal(t, node.ResourceVersion, got.ResourceVersion, "no Update should have been issued")
+	})
+
+	t.Run("!idle+hasTaint => no-op", func(t *testing.T) {
+		node := nodeWithOptionalTaint("n4", true)
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+
+		assert.NoError(t, reconcileProgressiveTaint(context.Background(), c, node, false))
+
+		got := &corev1.Node{}
+		assert.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "n4"}, got))
+		assert.Equal(t, node.ResourceVersion, got.ResourceVersion)
+	})
+
+	t.Run("progressive migration disabled => no-op", func(t *testing.T) {
+		utils.SetProgressiveMigration(false)
+		defer utils.SetProgressiveMigration(true)
+		node := nodeWithOptionalTaint("n5", true)
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+
+		assert.NoError(t, reconcileProgressiveTaint(context.Background(), c, node, true))
+
+		got := &corev1.Node{}
+		assert.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "n5"}, got))
+		check(t, constants.NodeUsedByTaintKey, true, got)
+	})
+
+	t.Run("nil coreNode => no-op", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		assert.NoError(t, reconcileProgressiveTaint(context.Background(), c, nil, true))
+	})
+}

--- a/internal/gpuallocator/partition_template_race_test.go
+++ b/internal/gpuallocator/partition_template_race_test.go
@@ -1,0 +1,144 @@
+package gpuallocator
+
+import (
+	"sync"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/config"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// TestPartitionTemplateMaps_ConcurrentReloadVsRead guards against the data
+// race where providerconfig_controller / pricing reload calls
+// LoadPartitionTemplatesFromConfig (which atomically publishes a fresh
+// snapshot via atomic.Pointer[partitionConfig]) while the scheduler
+// concurrently reads through GetPartitionTemplates / GetMaxPartitions /
+// GetMaxPlacementSlots / GetMaxIsolationGroups / GetTotalExtendedResources /
+// GetPartitionConfigSnapshot. The atomic-snapshot model means readers see
+// either the previous or the new published *partitionConfig — never a
+// torn intermediate state. Run with -race.
+func TestPartitionTemplateMaps_ConcurrentReloadVsRead(t *testing.T) {
+	configs := func(seed int) []config.GpuInfo {
+		return []config.GpuInfo{
+			{
+				Model:              "M",
+				FullModelName:      "M-full",
+				MaxPartitions:      uint32(seed),
+				MaxPlacementSlots:  uint32(seed),
+				MaxIsolationGroups: uint32(seed),
+				TotalExtendedResources: map[string]uint32{
+					"AICORE": uint32(seed),
+				},
+				PartitionTemplates: []config.PartitionTemplateInfo{
+					{TemplateID: "t1", Name: "t1", ComputePercent: 50, MemoryGigabytes: 16},
+				},
+			},
+		}
+	}
+	// Seed once so readers don't trip the "no template configs" path.
+	LoadPartitionTemplatesFromConfig(configs(1))
+
+	gpuStatus := tfv1.GPUStatus{
+		GPUModel: "M",
+		Capacity: &tfv1.Resource{
+			Tflops: resource.MustParse("100"),
+			Vram:   resource.MustParse("80Gi"),
+		},
+	}
+	gpu := &tfv1.GPU{}
+	gpu.Name = "gpu-0"
+	gpu.Status = gpuStatus
+	gpu.Status.Available = &tfv1.Resource{
+		Tflops: resource.MustParse("100"),
+		Vram:   resource.MustParse("80Gi"),
+	}
+
+	stop := make(chan struct{})
+	var readersWG, writerWG sync.WaitGroup
+
+	// Writer: continuously reload templates until readers complete.
+	writerWG.Add(1)
+	go func() {
+		defer writerWG.Done()
+		for i := 1; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			LoadPartitionTemplatesFromConfig(configs(i))
+		}
+	}()
+
+	// Readers: hammer every accessor used by partitioned_scheduling.go.
+	const readers = 4
+	readersWG.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer readersWG.Done()
+			req := &tfv1.AllocRequest{
+				Request: tfv1.Resource{
+					Tflops: resource.MustParse("10"),
+					Vram:   resource.MustParse("4Gi"),
+				},
+			}
+			for j := 0; j < 200; j++ {
+				_, _ = MatchPartitionTemplate(gpuStatus, req)
+				_, _, _ = CalculatePartitionResourceUsage(gpuStatus.Capacity.Tflops, "M", "t1")
+				_ = CheckPartitionAvailability(gpu, "t1")
+			}
+		}()
+	}
+
+	readersWG.Wait()
+	close(stop)
+	writerWG.Wait()
+}
+
+// TestPartitionConfigSnapshot_PostPublishImmutability codifies the invariant
+// that LoadPartitionTemplatesFromConfig must build a fresh *partitionConfig
+// and Store it — never mutate an already-published one. If a future refactor
+// reintroduces in-place mutation, a reader that captured the snapshot before
+// the "update" would observe the mutated state, breaking this test.
+func TestPartitionConfigSnapshot_PostPublishImmutability(t *testing.T) {
+	LoadPartitionTemplatesFromConfig([]config.GpuInfo{{
+		Model:         "M-v1",
+		MaxPartitions: 7,
+		PartitionTemplates: []config.PartitionTemplateInfo{
+			{TemplateID: "t1", Name: "t1", ComputePercent: 50, MemoryGigabytes: 8},
+		},
+	}})
+
+	// Capture a snapshot before the next publish.
+	maxPartitionsV1, templatesV1 := GetPartitionConfigSnapshot()
+	assert.Equal(t, uint32(7), maxPartitionsV1["M-v1"])
+	assert.Contains(t, templatesV1, "M-v1")
+
+	// Publish a totally different config.
+	LoadPartitionTemplatesFromConfig([]config.GpuInfo{{
+		Model:         "M-v2",
+		MaxPartitions: 99,
+		PartitionTemplates: []config.PartitionTemplateInfo{
+			{TemplateID: "t2", Name: "t2", ComputePercent: 25, MemoryGigabytes: 4},
+		},
+	}})
+
+	// The previously-captured snapshot must NOT see the new publish. Its maps
+	// belong to a frozen *partitionConfig. If a refactor mutated the live maps
+	// in place, "M-v1" would be gone and "M-v2" would appear here.
+	assert.Equal(t, uint32(7), maxPartitionsV1["M-v1"],
+		"old snapshot must retain MaxPartitions=7 for M-v1 even after LoadPartitionTemplatesFromConfig publishes a new config")
+	assert.NotContains(t, maxPartitionsV1, "M-v2",
+		"old snapshot must NOT pick up newly-published entries — that would mean the writer mutated the live map in place")
+	assert.Contains(t, templatesV1, "M-v1",
+		"old snapshot must retain M-v1 template entry")
+	assert.NotContains(t, templatesV1, "M-v2",
+		"old snapshot must NOT pick up newly-published M-v2 template")
+
+	// New snapshot reflects the latest publish.
+	maxPartitionsV2, templatesV2 := GetPartitionConfigSnapshot()
+	assert.Equal(t, uint32(99), maxPartitionsV2["M-v2"])
+	assert.Contains(t, templatesV2, "M-v2")
+}

--- a/internal/gpuallocator/partitioned_ascend_test.go
+++ b/internal/gpuallocator/partitioned_ascend_test.go
@@ -31,17 +31,26 @@ func ptrUint32(v uint32) *uint32 { return &v }
 
 func setupAscendTestConfig() {
 	mu.Lock()
-	defer mu.Unlock()
 	GPUCapacityMap[ascendGPUModel] = tfv1.Resource{Tflops: resource.MustParse("22"), Vram: resource.MustParse("21Gi")}
-	MaxPartitionsMap[ascendGPUModel] = 7
-	MaxIsolationGroupsMap[ascendGPUModel] = 4
-	TotalExtendedResourcesMap[ascendGPUModel] = map[string]uint32{"AICORE": 8, "AICPU": 7}
-	PartitionTemplateMap[ascendGPUModel] = map[string]config.PartitionTemplateInfo{
-		"vir01":    {TemplateID: "vir01", Name: "vir01", MemoryGigabytes: 3, ComputePercent: 12.5, MaxPartition: 8, IsolationGroupSharing: config.IsolationGroupSharingShared, MaxPartitionsPerIsolationGroup: 2, ExtendedResources: map[string]uint32{"AICORE": 1, "AICPU": 1}},
-		"vir02":    {TemplateID: "vir02", Name: "vir02", MemoryGigabytes: 6, ComputePercent: 25.0, MaxPartition: 4, IsolationGroupSharing: config.IsolationGroupSharingExclusive, ExtendedResources: map[string]uint32{"AICORE": 2, "AICPU": 2}},
-		"vir04":    {TemplateID: "vir04", Name: "vir04", MemoryGigabytes: 12, ComputePercent: 50.0, MaxPartition: 2, IsolationGroupSharing: config.IsolationGroupSharingExclusive, ExtendedResources: map[string]uint32{"AICORE": 4, "AICPU": 4}},
-		"vir04_3c": {TemplateID: "vir04_3c", Name: "vir04_3c", MemoryGigabytes: 12, ComputePercent: 50.0, MaxPartition: 2, IsolationGroupSharing: config.IsolationGroupSharingExclusive, ExtendedResources: map[string]uint32{"AICORE": 4, "AICPU": 3}},
-	}
+	mu.Unlock()
+	MutatePartitionConfigForTesting(func(cfg *partitionConfig) {
+		cfg.MaxPartitions[ascendGPUModel] = 7
+		cfg.MaxIsolationGroups[ascendGPUModel] = 4
+		cfg.TotalExtendedResources[ascendGPUModel] = map[string]uint32{"AICORE": 8, "AICPU": 7}
+		cfg.Templates[ascendGPUModel] = map[string]config.PartitionTemplateInfo{
+			"vir01":    {TemplateID: "vir01", Name: "vir01", MemoryGigabytes: 3, ComputePercent: 12.5, MaxPartition: 8, IsolationGroupSharing: config.IsolationGroupSharingShared, MaxPartitionsPerIsolationGroup: 2, ExtendedResources: map[string]uint32{"AICORE": 1, "AICPU": 1}},
+			"vir02":    {TemplateID: "vir02", Name: "vir02", MemoryGigabytes: 6, ComputePercent: 25.0, MaxPartition: 4, IsolationGroupSharing: config.IsolationGroupSharingExclusive, ExtendedResources: map[string]uint32{"AICORE": 2, "AICPU": 2}},
+			"vir04":    {TemplateID: "vir04", Name: "vir04", MemoryGigabytes: 12, ComputePercent: 50.0, MaxPartition: 2, IsolationGroupSharing: config.IsolationGroupSharingExclusive, ExtendedResources: map[string]uint32{"AICORE": 4, "AICPU": 4}},
+			"vir04_3c": {TemplateID: "vir04_3c", Name: "vir04_3c", MemoryGigabytes: 12, ComputePercent: 50.0, MaxPartition: 2, IsolationGroupSharing: config.IsolationGroupSharingExclusive, ExtendedResources: map[string]uint32{"AICORE": 4, "AICPU": 3}},
+		}
+	})
+}
+
+// ascendTemplate fetches a configured Ascend test template by name, panicking
+// if the test didn't run setupAscendTestConfig() first.
+func ascendTemplate(name string) config.PartitionTemplateInfo {
+	templates, _ := GetPartitionTemplates(ascendGPUModel)
+	return templates[name]
 }
 
 func createAscendGPU(partitions map[string]tfv1.AllocatedPartition) *tfv1.GPU {
@@ -58,8 +67,9 @@ func createAscendGPU(partitions map[string]tfv1.AllocatedPartition) *tfv1.GPU {
 }
 
 func getAscendGpuConfig() *config.GpuInfo {
-	templates := make([]config.PartitionTemplateInfo, 0, len(PartitionTemplateMap[ascendGPUModel]))
-	for _, t := range PartitionTemplateMap[ascendGPUModel] {
+	templateMap, _ := GetPartitionTemplates(ascendGPUModel)
+	templates := make([]config.PartitionTemplateInfo, 0, len(templateMap))
+	for _, t := range templateMap {
 		templates = append(templates, t)
 	}
 	return &config.GpuInfo{
@@ -101,7 +111,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 	Describe("CheckAvailability", func() {
 		Context("when allocating first partition", func() {
 			It("should succeed for vir01", func() {
-				err := strategy.CheckAvailability(createAscendGPU(nil), PartitionTemplateMap[ascendGPUModel]["vir01"], gpuConfig)
+				err := strategy.CheckAvailability(createAscendGPU(nil), ascendTemplate("vir01"), gpuConfig)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -111,7 +121,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 				gpu := createAscendGPU(map[string]tfv1.AllocatedPartition{
 					"pod-1": {TemplateID: "vir04", PodUID: "pod-1", IsolationGroupID: ptrUint32(0)},
 				})
-				err := strategy.CheckAvailability(gpu, PartitionTemplateMap[ascendGPUModel]["vir04_3c"], gpuConfig)
+				err := strategy.CheckAvailability(gpu, ascendTemplate("vir04_3c"), gpuConfig)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -124,7 +134,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 					"pod-3": {TemplateID: "vir02", PodUID: "pod-3", IsolationGroupID: ptrUint32(2)},
 					"pod-4": {TemplateID: "vir02", PodUID: "pod-4", IsolationGroupID: ptrUint32(3)},
 				})
-				err := strategy.CheckAvailability(gpu, PartitionTemplateMap[ascendGPUModel]["vir02"], gpuConfig)
+				err := strategy.CheckAvailability(gpu, ascendTemplate("vir02"), gpuConfig)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("maximum partition count"))
 			})
@@ -138,7 +148,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 					"pod-1": {TemplateID: "vir04_3c", PodUID: "pod-1", IsolationGroupID: ptrUint32(0)},
 					"pod-2": {TemplateID: "vir04_3c", PodUID: "pod-2", IsolationGroupID: ptrUint32(1)},
 				})
-				err := strategy.CheckAvailability(gpu, PartitionTemplateMap[ascendGPUModel]["vir04_3c"], gpuConfig)
+				err := strategy.CheckAvailability(gpu, ascendTemplate("vir04_3c"), gpuConfig)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("maximum partition count"))
 			})
@@ -149,7 +159,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 				gpu := createAscendGPU(map[string]tfv1.AllocatedPartition{
 					"pod-1": {TemplateID: "vir01", PodUID: "pod-1", IsolationGroupID: ptrUint32(0)},
 				})
-				err := strategy.CheckAvailability(gpu, PartitionTemplateMap[ascendGPUModel]["vir01"], gpuConfig)
+				err := strategy.CheckAvailability(gpu, ascendTemplate("vir01"), gpuConfig)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -165,7 +175,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 					"pod-1": {TemplateID: "vir04_3c", PodUID: "pod-1", IsolationGroupID: ptrUint32(0)},
 					"pod-2": {TemplateID: "vir04_3c", PodUID: "pod-2", IsolationGroupID: ptrUint32(1)},
 				})
-				err := strategy.CheckAvailability(gpu, PartitionTemplateMap[ascendGPUModel]["vir01"], gpuConfig)
+				err := strategy.CheckAvailability(gpu, ascendTemplate("vir01"), gpuConfig)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("insufficient AICORE"))
 			})
@@ -175,7 +185,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 	Describe("AllocateSlot", func() {
 		Context("when allocating first partition", func() {
 			It("should allocate vGroup 0", func() {
-				groupID, slotStart, slotEnd, err := strategy.AllocateSlot(createAscendGPU(nil), PartitionTemplateMap[ascendGPUModel]["vir04"], gpuConfig)
+				groupID, slotStart, slotEnd, err := strategy.AllocateSlot(createAscendGPU(nil), ascendTemplate("vir04"), gpuConfig)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(groupID).NotTo(BeNil())
 				Expect(*groupID).To(Equal(uint32(0)))
@@ -189,7 +199,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 				gpu := createAscendGPU(map[string]tfv1.AllocatedPartition{
 					"pod-1": {TemplateID: "vir01", PodUID: "pod-1", IsolationGroupID: ptrUint32(0)},
 				})
-				groupID, _, _, err := strategy.AllocateSlot(gpu, PartitionTemplateMap[ascendGPUModel]["vir01"], gpuConfig)
+				groupID, _, _, err := strategy.AllocateSlot(gpu, ascendTemplate("vir01"), gpuConfig)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*groupID).To(Equal(uint32(0)))
 			})
@@ -199,7 +209,7 @@ var _ = Describe("Ascend Partition Strategy", func() {
 					"pod-1": {TemplateID: "vir01", PodUID: "pod-1", IsolationGroupID: ptrUint32(0)},
 					"pod-2": {TemplateID: "vir01", PodUID: "pod-2", IsolationGroupID: ptrUint32(0)},
 				})
-				groupID, _, _, err := strategy.AllocateSlot(gpu, PartitionTemplateMap[ascendGPUModel]["vir01"], gpuConfig)
+				groupID, _, _, err := strategy.AllocateSlot(gpu, ascendTemplate("vir01"), gpuConfig)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*groupID).To(Equal(uint32(1)))
 			})

--- a/internal/gpuallocator/partitioned_scheduling.go
+++ b/internal/gpuallocator/partitioned_scheduling.go
@@ -45,8 +45,9 @@ type PartitionMatchResult struct {
 func MatchPartitionTemplate(gpuStatus tfv1.GPUStatus, req *tfv1.AllocRequest) (*PartitionMatchResult, error) {
 	gpuModel := gpuStatus.GPUModel
 
-	// Get template configs from global map
-	templateConfigs, exists := PartitionTemplateMap[gpuModel]
+	// Get template configs from global map (locked accessor; the returned
+	// inner map is post-publish-immutable, see GetPartitionTemplates).
+	templateConfigs, exists := GetPartitionTemplates(gpuModel)
 	if !exists || len(templateConfigs) == 0 {
 		return nil, fmt.Errorf("no partition template configs found for GPU model %s", gpuModel)
 	}
@@ -63,10 +64,7 @@ func MatchPartitionTemplate(gpuStatus tfv1.GPUStatus, req *tfv1.AllocRequest) (*
 
 		var requestTflops float64
 		if !req.Request.ComputePercent.IsZero() {
-			mu.Lock()
-			gpuCapacity, capExists := GPUCapacityMap[gpuModel]
-			mu.Unlock()
-			if capExists {
+			if gpuCapacity, capExists := GetGPUCapacity(gpuModel); capExists {
 				requestTflops = utils.ComputePercentToTflops(gpuCapacity.Tflops, req.Request).AsApproximateFloat64()
 			}
 		} else {
@@ -99,9 +97,7 @@ func MatchPartitionTemplate(gpuStatus tfv1.GPUStatus, req *tfv1.AllocRequest) (*
 	var requestTflops float64
 	if !req.Request.ComputePercent.IsZero() {
 		// Get GPU capacity from global map to convert ComputePercent to TFLOPs
-		mu.Lock()
-		gpuCapacity, exists := GPUCapacityMap[gpuModel]
-		mu.Unlock()
+		gpuCapacity, exists := GetGPUCapacity(gpuModel)
 		if !exists {
 			return nil, fmt.Errorf("GPU capacity not found for model %s, cannot convert ComputePercent to TFLOPs", gpuModel)
 		}
@@ -112,8 +108,8 @@ func MatchPartitionTemplate(gpuStatus tfv1.GPUStatus, req *tfv1.AllocRequest) (*
 	}
 	requestVramBytes := req.Request.Vram.Value()
 
-	// Get max partitions from config
-	maxPartitions := MaxPartitionsMap[gpuModel]
+	// Get max partitions from config (locked accessor)
+	maxPartitions := GetMaxPartitions(gpuModel)
 	if maxPartitions <= 0 {
 		maxPartitions = DefaultMaxPartitionNum
 	}
@@ -201,7 +197,7 @@ func resolvePartitionTemplate(templateConfigs map[string]config.PartitionTemplat
 // CalculatePartitionResourceUsage calculates the resource usage for a partition template.
 // Gets template info from config.
 func CalculatePartitionResourceUsage(capacityTflops resource.Quantity, gpuModel, templateID string) (tflops resource.Quantity, vram resource.Quantity, err error) {
-	templateConfigs, exists := PartitionTemplateMap[gpuModel]
+	templateConfigs, exists := GetPartitionTemplates(gpuModel)
 	if !exists {
 		return resource.Quantity{}, resource.Quantity{}, fmt.Errorf("no partition template configs for GPU model %s", gpuModel)
 	}
@@ -228,7 +224,7 @@ func CheckPartitionAvailability(
 	templateID string,
 ) error {
 	// Get template info from config first to check template-specific constraints
-	templateConfigs, exists := PartitionTemplateMap[gpu.Status.GPUModel]
+	templateConfigs, exists := GetPartitionTemplates(gpu.Status.GPUModel)
 	if !exists {
 		return fmt.Errorf("no partition template configs for GPU model %s", gpu.Status.GPUModel)
 	}
@@ -273,32 +269,35 @@ func CheckPartitionAvailability(
 	return nil
 }
 
-// getGpuConfigFromMaps constructs a GpuInfo from the global maps for strategy use
+// getGpuConfigFromMaps constructs a GpuInfo from the global maps for strategy use.
+// All reads go through locked accessors so we don't race with
+// LoadPartitionTemplatesFromConfig running concurrently from
+// providerconfig_controller / pricing reload paths.
 func getGpuConfigFromMaps(gpuModel string) *config.GpuInfo {
 	gpuConfig := &config.GpuInfo{
 		Model:         gpuModel,
-		MaxPartitions: MaxPartitionsMap[gpuModel],
+		MaxPartitions: GetMaxPartitions(gpuModel),
 	}
 
 	// Get MaxPlacementSlots
-	if slots, exists := MaxPlacementSlotsMap[gpuModel]; exists {
+	if slots, exists := GetMaxPlacementSlots(gpuModel); exists {
 		gpuConfig.MaxPlacementSlots = slots
 	}
 
 	// Get MaxIsolationGroups (defaults to MaxPlacementSlots if not set)
-	if groups, exists := MaxIsolationGroupsMap[gpuModel]; exists {
+	if groups, exists := GetMaxIsolationGroups(gpuModel); exists {
 		gpuConfig.MaxIsolationGroups = groups
 	} else if gpuConfig.MaxPlacementSlots > 0 {
 		gpuConfig.MaxIsolationGroups = gpuConfig.MaxPlacementSlots
 	}
 
 	// Get TotalExtendedResources
-	if resources, exists := TotalExtendedResourcesMap[gpuModel]; exists {
+	if resources, exists := GetTotalExtendedResources(gpuModel); exists {
 		gpuConfig.TotalExtendedResources = resources
 	}
 
 	// Convert template map to slice
-	if templates, exists := PartitionTemplateMap[gpuModel]; exists {
+	if templates, exists := GetPartitionTemplates(gpuModel); exists {
 		for _, t := range templates {
 			gpuConfig.PartitionTemplates = append(gpuConfig.PartitionTemplates, t)
 		}

--- a/internal/gpuallocator/partitioned_scheduling_test.go
+++ b/internal/gpuallocator/partitioned_scheduling_test.go
@@ -33,20 +33,22 @@ const testGPUModel = "A100_SXM_80G"
 func TestMatchPartitionTemplate(t *testing.T) {
 	// Setup: Initialize partition template map
 	gpuModel := testGPUModel
-	PartitionTemplateMap[gpuModel] = map[string]config.PartitionTemplateInfo{
-		"1g.24gb": {
-			TemplateID:      "19",
-			Name:            "1g.24gb",
-			MemoryGigabytes: 24, // 24GB (function converts to bytes)
-			ComputePercent:  1.0 / 7.0 * 100,
-		},
-		"4g.94gb": {
-			TemplateID:      "9",
-			Name:            "4g.94gb",
-			MemoryGigabytes: 94, // 94GB (function converts to bytes)
-			ComputePercent:  4.0 / 7.0 * 100,
-		},
-	}
+	MutatePartitionConfigForTesting(func(cfg *partitionConfig) {
+		cfg.Templates[gpuModel] = map[string]config.PartitionTemplateInfo{
+			"1g.24gb": {
+				TemplateID:      "19",
+				Name:            "1g.24gb",
+				MemoryGigabytes: 24, // 24GB (function converts to bytes)
+				ComputePercent:  1.0 / 7.0 * 100,
+			},
+			"4g.94gb": {
+				TemplateID:      "9",
+				Name:            "4g.94gb",
+				MemoryGigabytes: 94, // 94GB (function converts to bytes)
+				ComputePercent:  4.0 / 7.0 * 100,
+			},
+		}
+	})
 	// Setup: Initialize GPU capacity map for ComputePercent conversion
 	// A100_SXM_80G has ~312 TFLOPs capacity
 	mu.Lock()
@@ -214,14 +216,16 @@ func TestCalculatePartitionResourceUsage(t *testing.T) {
 	// Setup
 	gpuModel := testGPUModel
 	templateID := "1g.24gb"
-	PartitionTemplateMap[gpuModel] = map[string]config.PartitionTemplateInfo{
-		templateID: {
-			TemplateID:      templateID,
-			Name:            "1g.24gb",
-			MemoryGigabytes: 24, // 24GB (function converts to bytes)
-			ComputePercent:  1.0 / 7.0 * 100,
-		},
-	}
+	MutatePartitionConfigForTesting(func(cfg *partitionConfig) {
+		cfg.Templates[gpuModel] = map[string]config.PartitionTemplateInfo{
+			templateID: {
+				TemplateID:      templateID,
+				Name:            "1g.24gb",
+				MemoryGigabytes: 24, // 24GB (function converts to bytes)
+				ComputePercent:  1.0 / 7.0 * 100,
+			},
+		}
+	})
 
 	tflops, vram, err := CalculatePartitionResourceUsage(resource.MustParse("312"), gpuModel, templateID)
 
@@ -243,30 +247,30 @@ func TestCheckPartitionAvailability(t *testing.T) {
 	template4g := "4g.94gb" // Profile 9
 
 	// Clear and setup maps for this test
-	mu.Lock()
-	PartitionTemplateMap[gpuModel] = map[string]config.PartitionTemplateInfo{
-		template1g: {
-			TemplateID:      template1g,
-			Name:            "1g.24gb",
-			MemoryGigabytes: 24, // 24GB
-			ComputePercent:  1.0 / 7.0 * 100,
-			MaxPartition:    7,                             // Can allocate up to 7 instances
-			PlacementLimit:  []uint32{0, 1, 2, 3, 4, 5, 6}, // Can start at any of these positions
-			PlacementOffSet: 1,                             // Occupies 1 slot
-		},
-		template4g: {
-			TemplateID:      template4g,
-			Name:            "4g.94gb",
-			MemoryGigabytes: 94, // 94GB
-			ComputePercent:  4.0 / 7.0 * 100,
-			MaxPartition:    2,              // Can only allocate 2 instances
-			PlacementLimit:  []uint32{0, 4}, // Can start at position 0 or 4
-			PlacementOffSet: 4,              // Occupies 4 slots (0-3 or 4-7)
-		},
-	}
-	MaxPartitionsMap[gpuModel] = 7
-	MaxPlacementSlotsMap[gpuModel] = 8 // A100 has 8 placement slots (0-7)
-	mu.Unlock()
+	MutatePartitionConfigForTesting(func(cfg *partitionConfig) {
+		cfg.Templates[gpuModel] = map[string]config.PartitionTemplateInfo{
+			template1g: {
+				TemplateID:      template1g,
+				Name:            "1g.24gb",
+				MemoryGigabytes: 24, // 24GB
+				ComputePercent:  1.0 / 7.0 * 100,
+				MaxPartition:    7,                             // Can allocate up to 7 instances
+				PlacementLimit:  []uint32{0, 1, 2, 3, 4, 5, 6}, // Can start at any of these positions
+				PlacementOffSet: 1,                             // Occupies 1 slot
+			},
+			template4g: {
+				TemplateID:      template4g,
+				Name:            "4g.94gb",
+				MemoryGigabytes: 94, // 94GB
+				ComputePercent:  4.0 / 7.0 * 100,
+				MaxPartition:    2,              // Can only allocate 2 instances
+				PlacementLimit:  []uint32{0, 4}, // Can start at position 0 or 4
+				PlacementOffSet: 4,              // Occupies 4 slots (0-3 or 4-7)
+			},
+		}
+		cfg.MaxPartitions[gpuModel] = 7
+		cfg.MaxPlacementSlots[gpuModel] = 8 // A100 has 8 placement slots (0-7)
+	})
 
 	tests := []struct {
 		name          string

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -40,6 +40,7 @@ var gpuResourceMetricsLock sync.RWMutex
 var gpuResourceMetricsMap = make(map[string]*GPUResourceMetrics, 100)
 
 var settingLock sync.RWMutex
+var tensorFusionSystemMetricsLock sync.RWMutex
 
 var log = ctrl.Log.WithName("metrics-recorder")
 
@@ -311,7 +312,10 @@ func SetNodeMetrics(node *tfv1.GPUNode, poolObj *tfv1.GPUPool, gpuModels []strin
 }
 
 func InitPoolMetricsWhenNotExists(poolObj *tfv1.GPUPool) {
-	if _, ok := poolMetricsMap[poolObj.Name]; !ok {
+	poolMetricsLock.RLock()
+	_, ok := poolMetricsMap[poolObj.Name]
+	poolMetricsLock.RUnlock()
+	if !ok {
 		SetPoolMetrics(poolObj)
 	}
 }
@@ -474,6 +478,8 @@ func SetGPUAllocationMetrics(gpuStore map[types.NamespacedName]*tfv1.GPU, pod *c
 }
 
 func SetSchedulerMetrics(poolName string, isSuccess bool) {
+	tensorFusionSystemMetricsLock.Lock()
+	defer tensorFusionSystemMetricsLock.Unlock()
 	if _, ok := TensorFusionSystemMetricsMap[poolName]; !ok {
 		TensorFusionSystemMetricsMap[poolName] = &TensorFusionSystemMetrics{
 			PoolName: poolName,
@@ -488,6 +494,8 @@ func SetSchedulerMetrics(poolName string, isSuccess bool) {
 
 // SetTopologyMetrics records GPU topology scheduling metrics.
 func SetTopologyMetrics(poolName string, satisfied bool, isFallback bool, isDegraded bool) {
+	tensorFusionSystemMetricsLock.Lock()
+	defer tensorFusionSystemMetricsLock.Unlock()
 	if _, ok := TensorFusionSystemMetricsMap[poolName]; !ok {
 		TensorFusionSystemMetricsMap[poolName] = &TensorFusionSystemMetrics{
 			PoolName: poolName,
@@ -509,6 +517,8 @@ func SetTopologyMetrics(poolName string, satisfied bool, isFallback bool, isDegr
 
 // TODO should record metrics after autoscaling feature added
 func SetAutoscalingMetrics(poolName string, isScaleUp bool) {
+	tensorFusionSystemMetricsLock.Lock()
+	defer tensorFusionSystemMetricsLock.Unlock()
 	if _, ok := TensorFusionSystemMetricsMap[poolName]; !ok {
 		TensorFusionSystemMetricsMap[poolName] = &TensorFusionSystemMetrics{
 			PoolName: poolName,
@@ -522,6 +532,8 @@ func SetAutoscalingMetrics(poolName string, isScaleUp bool) {
 }
 
 func getSchedulerMetricsByPool(poolName string) (int64, int64, int64, int64) {
+	tensorFusionSystemMetricsLock.RLock()
+	defer tensorFusionSystemMetricsLock.RUnlock()
 	if item, ok := TensorFusionSystemMetricsMap[poolName]; !ok {
 		return 0, 0, 0, 0
 	} else {
@@ -570,7 +582,16 @@ func (mr *MetricsRecorder) Start() {
 }
 
 func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
-	if len(workerMetricsMap) <= 0 && len(nodeMetricsMap) <= 0 && len(gpuResourceMetricsMap) <= 0 {
+	workerMetricsLock.RLock()
+	workerMetricsCount := len(workerMetricsMap)
+	workerMetricsLock.RUnlock()
+	nodeMetricsLock.RLock()
+	nodeMetricsCount := len(nodeMetricsMap)
+	nodeMetricsLock.RUnlock()
+	gpuResourceMetricsLock.RLock()
+	gpuResourceMetricsCount := len(gpuResourceMetricsMap)
+	gpuResourceMetricsLock.RUnlock()
+	if workerMetricsCount <= 0 && nodeMetricsCount <= 0 && gpuResourceMetricsCount <= 0 {
 		return
 	}
 
@@ -635,7 +656,7 @@ func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
 	}
 	workerMetricsLock.Unlock()
 
-	nodeMetricsLock.RLock()
+	nodeMetricsLock.Lock()
 
 	for _, metrics := range nodeMetricsMap {
 		metrics.RawCost = mr.getNodeRawCost(metrics, now.Sub(metrics.LastRecordTime), mr.HourlyUnitPriceMap)
@@ -676,16 +697,20 @@ func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
 		enc.AddField("total_allocation_success_cnt", successCount)
 		enc.AddField("total_scale_up_cnt", scaleUpCount)
 		enc.AddField("total_scale_down_cnt", scaleDownCount)
+		tensorFusionSystemMetricsLock.RLock()
 		if item, ok := TensorFusionSystemMetricsMap[poolName]; ok {
 			enc.AddField("total_topo_satisfied_cnt", item.TotalTopoSatisfiedCount)
 			enc.AddField("total_topo_unsatisfied_cnt", item.TotalTopoUnsatisfiedCount)
 			enc.AddField("total_topo_fallback_cnt", item.TotalTopoFallbackCount)
 			enc.AddField("total_topo_search_degraded_cnt", item.TotalTopoSearchDegradedCount)
 		}
+		tensorFusionSystemMetricsLock.RUnlock()
 		enc.EndLine(now)
 	}
+	nodeMetricsLock.Unlock()
 
 	// Additional Pool level metrics
+	poolMetricsLock.RLock()
 	for _, metrics := range poolMetricsMap {
 		enc.StartLine("tf_pool_metrics")
 		enc.AddTag("pool", metrics.PoolName)
@@ -703,6 +728,7 @@ func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
 		enc.AddField("gpu_count", int64(metrics.GPUCount))
 		enc.EndLine(now)
 	}
+	poolMetricsLock.RUnlock()
 
 	// GPU allocation metrics
 	gpuAllocationMetricsLock.RLock()
@@ -746,16 +772,14 @@ func (mr *MetricsRecorder) RecordMetrics(writer io.Writer) {
 	}
 	gpuResourceMetricsLock.RUnlock()
 
-	nodeMetricsLock.RUnlock()
-
 	if err := enc.Err(); err != nil {
-		log.Error(err, "metrics encoding error", "workerCount", activeWorkerCnt, "nodeCount", len(nodeMetricsMap))
+		log.Error(err, "metrics encoding error", "workerCount", activeWorkerCnt, "nodeCount", nodeMetricsCount)
 	}
 
 	if _, err := writer.Write(enc.Bytes()); err != nil {
-		log.Error(err, "metrics writing error", "workerCount", activeWorkerCnt, "nodeCount", len(nodeMetricsMap))
+		log.Error(err, "metrics writing error", "workerCount", activeWorkerCnt, "nodeCount", nodeMetricsCount)
 	}
-	log.Info("metrics and raw billing recorded:", "workerCount", activeWorkerCnt, "nodeCount", len(nodeMetricsMap))
+	log.Info("metrics and raw billing recorded:", "workerCount", activeWorkerCnt, "nodeCount", nodeMetricsCount)
 }
 
 // Update metrics recorder's raw billing map

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -141,8 +141,31 @@ func (e *NodeExpander) cleanupInFlightNodeClaim(nodeClaim *karpv1.NodeClaim) {
 }
 
 func (e *NodeExpander) GetNodeScalerInfo() any {
+	if e == nil {
+		return map[string]any{}
+	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
+
+	inFlightNodesCopy := make(map[string][]*tfv1.GPU, len(e.inFlightNodes))
+	for nodeName, gpus := range e.inFlightNodes {
+		gpuCopies := make([]*tfv1.GPU, 0, len(gpus))
+		for _, gpu := range gpus {
+			if gpu == nil {
+				continue
+			}
+			gpuCopies = append(gpuCopies, gpu.DeepCopy())
+		}
+		inFlightNodesCopy[nodeName] = gpuCopies
+	}
+
+	preSchedulePodsCopy := make(map[string]*tfv1.AllocRequest, len(e.preSchedulePods))
+	for podName, req := range e.preSchedulePods {
+		if req == nil {
+			continue
+		}
+		preSchedulePodsCopy[podName] = req.DeepCopy()
+	}
 
 	inFlightNodeClaimSnapshot := make(map[string]any)
 	e.inFlightNodeClaims.Range(func(key, value any) bool {
@@ -150,9 +173,9 @@ func (e *NodeExpander) GetNodeScalerInfo() any {
 		return true
 	})
 	return map[string]any{
-		"inFlightNodes":       e.inFlightNodes,
+		"inFlightNodes":       inFlightNodesCopy,
 		"inFlightNodeClaims":  inFlightNodeClaimSnapshot,
-		"preSchedulePods":     e.preSchedulePods,
+		"preSchedulePods":     preSchedulePodsCopy,
 		"preScheduleTimerNum": len(e.preScheduleTimers),
 	}
 }
@@ -161,11 +184,16 @@ func (e *NodeExpander) ProcessExpansion(ctx context.Context, pod *corev1.Pod) er
 	if pod == nil {
 		return fmt.Errorf("pod cannot be nil")
 	}
-	if _, ok := e.preSchedulePods[pod.Name]; ok {
+	e.mu.RLock()
+	_, alreadyInPreSchedule := e.preSchedulePods[pod.Name]
+	inFlightCount := len(e.inFlightNodes)
+	e.mu.RUnlock()
+
+	if alreadyInPreSchedule {
 		e.logger.Info("Pod already in pre-schedule state, skipping expansion check and wait for expansion", "pod", klog.KObj(pod))
 		return nil
 	}
-	if len(e.inFlightNodes) >= MaxInFlightNodes {
+	if inFlightCount >= MaxInFlightNodes {
 		e.logger.Error(nil, "Too many inFlight nodes, skipping expansion to avoid too many nodes provisioned concurrently")
 		time.Sleep(WaitingInFlightNodesPeriod)
 		return nil
@@ -200,14 +228,19 @@ func (e *NodeExpander) ProcessExpansion(ctx context.Context, pod *corev1.Pod) er
 			}
 		}
 	}
+	e.mu.RLock()
 	inFlightGPUSnapshot := make(map[string]*tfv1.GPU, len(e.inFlightNodes)*4)
 	for _, inFlightGPUs := range e.inFlightNodes {
 		for _, gpu := range inFlightGPUs {
+			if gpu == nil {
+				continue
+			}
 			snapshot := gpu.DeepCopy()
 			inFlightGPUSnapshot[gpu.Name] = snapshot
 			allGpus = append(allGpus, snapshot)
 		}
 	}
+	e.mu.RUnlock()
 	if len(allGpus) == 0 {
 		e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, "NodeExpansionCheck", "NoGPUNodes",
 			"all schedulable nodes are none GPU nodes, manual check required")
@@ -388,6 +421,9 @@ func (e *NodeExpander) simulateSchedulingWithoutGPU(ctx context.Context, pod *co
 	if !utils.IsTensorFusionPod(pod) {
 		return nil, fmt.Errorf("pod to check expansion is not a tensor fusion worker pod: %s", pod.Name)
 	}
+	if err := e.scheduler.UpdateNodeInfoSnapshot(ctx); err != nil {
+		return nil, fmt.Errorf("refresh scheduler snapshot before expansion simulation: %w", err)
+	}
 	delete(pod.Labels, constants.LabelComponent)
 	scheduleResult, _, _, _, err := e.scheduler.FindNodesThatFitPod(ctx, fwkInstance, state, pod)
 	pod.Labels[constants.LabelComponent] = constants.ComponentWorker
@@ -410,9 +446,21 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 	// NOTE: a known issue, if cpu/mem not enough or affinity not satisfied for pre-scheduled pods inside inFlightNodes,
 	// it will not be considered, when inflight created and the Pod still not be able to schedule on new node,
 	// wait next scheduling check and node expansion period (k8s move UnscheduleQueue to ActiveQueue every 5 minutes)
+	e.mu.RLock()
+	preScheduleSnapshot := make([]*tfv1.AllocRequest, 0, len(e.preSchedulePods))
 	for _, alloc := range e.preSchedulePods {
+		if alloc != nil {
+			preScheduleSnapshot = append(preScheduleSnapshot, alloc.DeepCopy())
+		}
+	}
+	e.mu.RUnlock()
+
+	for _, alloc := range preScheduleSnapshot {
 		preScheduledPodPreAllocated := false
 		for _, gpu := range inflightSnapshot {
+			if gpu == nil || gpu.Status.Capacity == nil || gpu.Status.Available == nil {
+				continue
+			}
 			reqTflops := alloc.Request.Tflops
 			if !alloc.Request.ComputePercent.IsZero() {
 				reqTflops = *utils.ComputePercentToTflops(gpu.Status.Capacity.Tflops, alloc.Request)
@@ -436,8 +484,6 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 	}
 
 	// Get allocation request
-	e.mu.RLock()
-	defer e.mu.RUnlock()
 	allocRequest, _, err := utils.ComposeAllocationRequest(e.ctx, pod)
 	if err != nil {
 		return nil, false, true, false
@@ -459,9 +505,9 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 			Tflops: resource.Quantity{},
 			Vram:   resource.Quantity{},
 		},
-		Workers: int32(len(e.preSchedulePods)),
+		Workers: int32(len(preScheduleSnapshot)),
 	}
-	for _, alloc := range e.preSchedulePods {
+	for _, alloc := range preScheduleSnapshot {
 		toScheduleResource.Requests.Tflops.Add(alloc.Request.Tflops)
 		toScheduleResource.Requests.Vram.Add(alloc.Request.Vram)
 		toScheduleResource.Limits.Tflops.Add(alloc.Limit.Tflops)

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -38,6 +38,7 @@ const Name = "GPUResourcesFit"
 const CycleStateAllocateRequest = "allocateRequest"
 const CycleStateGPUSchedulingResult = "gpuSchedulingResult"
 const SchedulerSimulationKey = "schedulerSimulation"
+const CycleStateProgressiveNodeNames = "progressiveNodeNames"
 
 var _ fwk.PreFilterPlugin = &GPUFit{}
 var _ fwk.PreEnqueuePlugin = &GPUFit{}
@@ -90,6 +91,14 @@ func (p *GPUSchedulingStateData) Clone() fwk.StateData {
 	return p
 }
 
+type ProgressiveNodeNamesState struct {
+	NodeNames sets.Set[string]
+}
+
+func (p *ProgressiveNodeNamesState) Clone() fwk.StateData {
+	return p
+}
+
 type PluginFactoryFunc func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error)
 
 func NewWithDeps(allocator *gpuallocator.GpuAllocator, indexAllocator *indexallocator.IndexAllocator, gangManager *gang.Manager, client client.Client) PluginFactoryFunc {
@@ -137,6 +146,7 @@ func (s *GPUFit) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Po
 	// Handle progressive migration case
 	if utils.IsProgressiveMigration() && utils.HasGPUResourceRequest(pod) {
 		nodeNames := s.allocator.ListNonUsingNodes()
+		state.Write(CycleStateProgressiveNodeNames, &ProgressiveNodeNamesState{NodeNames: nodeNames})
 		s.fh.EventRecorder().Eventf(pod, pod, v1.EventTypeNormal, "ScheduleWithNativeGPU",
 			"Scheduling non-TF workload for progressive migration",
 			"use native GPU resources, available native GPU nodes: "+strconv.Itoa(len(nodeNames)))

--- a/internal/scheduler/gpuresources/gpuresources_test.go
+++ b/internal/scheduler/gpuresources/gpuresources_test.go
@@ -756,13 +756,11 @@ var _ = Describe("GPUFit Plugin", func() {
 			Expect(k8sClient.Create(ctx, workerPod)).To(Succeed())
 
 			// Manually add GPU to allocator store
-			gpuStore, _, _ := allocator.GetAllocationInfo()
-			key := types.NamespacedName{Name: "gpu-test-percent"}
 			gpuCopy := gpu.DeepCopy()
 			if gpuCopy.Status.Available == nil {
 				gpuCopy.Status.Available = gpuCopy.Status.Capacity.DeepCopy()
 			}
-			gpuStore[key] = gpuCopy
+			allocator.UpsertGPUForTesting(ctx, gpuCopy)
 
 			// Reconcile allocation state
 			allocator.ReconcileAllocationStateForTesting()
@@ -866,13 +864,11 @@ var _ = Describe("GPUFit Plugin", func() {
 			Expect(k8sClient.Create(ctx, workerPod2)).To(Succeed())
 
 			// Manually add GPU to allocator store
-			gpuStore, _, _ := allocator.GetAllocationInfo()
-			key := types.NamespacedName{Name: "gpu-test-mixed"}
 			gpuCopy := gpu.DeepCopy()
 			if gpuCopy.Status.Available == nil {
 				gpuCopy.Status.Available = gpuCopy.Status.Capacity.DeepCopy()
 			}
-			gpuStore[key] = gpuCopy
+			allocator.UpsertGPUForTesting(ctx, gpuCopy)
 
 			// Reconcile allocation state
 			allocator.ReconcileAllocationStateForTesting()
@@ -1007,20 +1003,17 @@ var _ = Describe("GPUFit Plugin", func() {
 			Expect(k8sClient.Create(ctx, workerPod2)).To(Succeed())
 
 			// Manually add GPUs to allocator store
-			gpuStore, _, _ := allocator.GetAllocationInfo()
-			key1 := types.NamespacedName{Name: "gpu-mixed-1"}
 			gpuCopy1 := gpu1.DeepCopy()
 			if gpuCopy1.Status.Available == nil {
 				gpuCopy1.Status.Available = gpuCopy1.Status.Capacity.DeepCopy()
 			}
-			gpuStore[key1] = gpuCopy1
+			allocator.UpsertGPUForTesting(ctx, gpuCopy1)
 
-			key2 := types.NamespacedName{Name: "gpu-mixed-2"}
 			gpuCopy2 := gpu2.DeepCopy()
 			if gpuCopy2.Status.Available == nil {
 				gpuCopy2.Status.Available = gpuCopy2.Status.Capacity.DeepCopy()
 			}
-			gpuStore[key2] = gpuCopy2
+			allocator.UpsertGPUForTesting(ctx, gpuCopy2)
 
 			// Reconcile allocation state
 			allocator.ReconcileAllocationStateForTesting()

--- a/internal/server/router/allocator_info.go
+++ b/internal/server/router/allocator_info.go
@@ -2,8 +2,11 @@ package router
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"sort"
 
 	"time"
 
@@ -119,27 +122,81 @@ func (r *AllocatorInfoRouter) SimulateScheduleOnePod(ctx *gin.Context) {
 	scheduleResult, err := r.scheduler.SchedulePod(ctx, fwkInstance, state, pod)
 	gpuCycleState, _ := state.Read(gpuresources.CycleStateGPUSchedulingResult)
 	simulateSchedulingFilterDetail, _ := state.Read(fwk.StateKey(constants.SchedulerSimulationKey))
+	progressiveNodes := readProgressiveNodeNames(state)
+	var errorPayload gin.H
 	if err != nil {
-		if fitError, ok := err.(*framework.FitError); ok {
-			ctx.JSON(http.StatusOK, gin.H{
-				"scheduleResult": scheduleResult,
-				"filterDetail":   simulateSchedulingFilterDetail,
-				"error": gin.H{
-					"numAllNodes": fitError.NumAllNodes,
-					"diagnosis":   fitError.Diagnosis,
-				},
-				"cycleState":        state,
-				"gpuSchedulerState": gpuCycleState,
-			})
-			return
+		log.FromContext(ctx).Error(err, "Simulate schedule pod failed",
+			"pod", pod.Name, "namespace", pod.Namespace, "errorType", fmt.Sprintf("%T", err))
+		errorPayload = gin.H{
+			"type":    fmt.Sprintf("%T", err),
+			"message": err.Error(),
+		}
+		var fitError *framework.FitError
+		if errors.As(err, &fitError) {
+			errorPayload["numAllNodes"] = fitError.NumAllNodes
+			errorPayload["diagnosis"] = renderDiagnosis(&fitError.Diagnosis)
 		}
 	}
 	ctx.JSON(http.StatusOK, gin.H{
-		"scheduleResult":    scheduleResult,
-		"filterDetail":      simulateSchedulingFilterDetail,
-		"error":             err,
-		"cycleState":        state,
-		"gpuSchedulerState": gpuCycleState,
+		"scheduleResult":       scheduleResult,
+		"filterDetail":         simulateSchedulingFilterDetail,
+		"error":                errorPayload,
+		"cycleState":           state,
+		"gpuSchedulerState":    gpuCycleState,
+		"progressiveNodeNames": progressiveNodes,
 	})
-	log.FromContext(ctx).Info("Simulate schedule pod completed", "pod", pod.Name, "namespace", pod.Namespace, "duration", time.Since(start))
+	log.FromContext(ctx).Info("Simulate schedule pod completed",
+		"pod", pod.Name, "namespace", pod.Namespace, "duration", time.Since(start), "scheduleError", err != nil)
+}
+
+func renderDiagnosis(d *framework.Diagnosis) gin.H {
+	if d == nil {
+		return nil
+	}
+	out := gin.H{
+		"preFilterMsg":         d.PreFilterMsg,
+		"postFilterMsg":        d.PostFilterMsg,
+		"unschedulablePlugins": d.UnschedulablePlugins.UnsortedList(),
+		"pendingPlugins":       d.PendingPlugins.UnsortedList(),
+	}
+	if d.NodeToStatus != nil {
+		nodeStatuses := gin.H{}
+		d.NodeToStatus.ForEachExplicitNode(func(name string, s *fwk.Status) {
+			nodeStatuses[name] = renderStatus(s)
+		})
+		out["nodeToStatus"] = gin.H{
+			"nodes":             nodeStatuses,
+			"absentNodesStatus": renderStatus(d.NodeToStatus.AbsentNodesStatus()),
+		}
+	}
+	return out
+}
+
+func renderStatus(s *fwk.Status) gin.H {
+	if s == nil {
+		return gin.H{"code": "Success"}
+	}
+	return gin.H{
+		"code":    s.Code().String(),
+		"plugin":  s.Plugin(),
+		"reasons": s.Reasons(),
+		"message": s.Message(),
+	}
+}
+
+func readProgressiveNodeNames(state *framework.CycleState) gin.H {
+	raw, err := state.Read(gpuresources.CycleStateProgressiveNodeNames)
+	if err != nil || raw == nil {
+		return nil
+	}
+	s, ok := raw.(*gpuresources.ProgressiveNodeNamesState)
+	if !ok || s.NodeNames == nil {
+		return nil
+	}
+	names := s.NodeNames.UnsortedList()
+	sort.Strings(names)
+	return gin.H{
+		"count": len(names),
+		"nodes": names,
+	}
 }

--- a/internal/server/router/node_scaler_info.go
+++ b/internal/server/router/node_scaler_info.go
@@ -20,6 +20,12 @@ func NewNodeScalerInfoRouter(
 }
 
 func (r *NodeScalerInfoRouter) Get(ctx *gin.Context) {
+	if r.nodeExpander == nil {
+		ctx.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "node scaler not enabled",
+		})
+		return
+	}
 	ctx.JSON(http.StatusOK, gin.H{
 		"data": r.nodeExpander.GetNodeScalerInfo(),
 	})

--- a/internal/webhook/v1/pod_counter.go
+++ b/internal/webhook/v1/pod_counter.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -99,7 +100,14 @@ func (c *TensorFusionPodCounter) Increase(ctx context.Context, pod *corev1.Pod) 
 	return nil
 }
 
-// Decrease decreases the counter in owner annotation by key
+// Decrease decreases the counter in owner annotation by key. Wraps the
+// Get+modify+Update in retry.RetryOnConflict so a transient ResourceVersion
+// race with the workload controller (or another finalizer hook on the same
+// owner) does not surface as a failure to the caller. Genuine errors
+// (RBAC, network, persistent conflict after retries) propagate so the pod
+// reconciler can requeue and the count stays consistent with admission-side
+// bookkeeping — silently swallowing them would leak the owner annotation
+// past the pod's lifetime and skew future admission decisions.
 func (c *TensorFusionPodCounter) Decrease(ctx context.Context, pod *corev1.Pod) error {
 	log := log.FromContext(ctx)
 	ownerRef := getControllerOwnerRef(pod)
@@ -108,42 +116,45 @@ func (c *TensorFusionPodCounter) Decrease(ctx context.Context, pod *corev1.Pod) 
 		return nil
 	}
 	key := getOrGenerateKey(pod)
-	ownerObj := &unstructured.Unstructured{}
-	ownerObj.SetAPIVersion(ownerRef.APIVersion)
-	ownerObj.SetKind(ownerRef.Kind)
 	objKey := client.ObjectKey{Name: ownerRef.Name, Namespace: pod.Namespace}
-	if err := c.Client.Get(ctx, objKey, ownerObj); err != nil {
-		// when owner accidentally deleted, just ignore
-		if errors.IsNotFound(err) {
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		ownerObj := &unstructured.Unstructured{}
+		ownerObj.SetAPIVersion(ownerRef.APIVersion)
+		ownerObj.SetKind(ownerRef.Kind)
+		if err := c.Client.Get(ctx, objKey, ownerObj); err != nil {
+			// owner already gone — there is no counter to decrement.
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to get owner object: %w", err)
+		}
+		annotations := ownerObj.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		val := annotations[key]
+		if val == "" {
+			val = "0"
+		}
+		count, err := strconv.ParseInt(val, 10, 32)
+		if err != nil {
+			// Corrupt annotation — give up silently rather than spin on retries.
+			log.Error(err, "invalid count annotation", "namespace", pod.Namespace, "name", pod.Name)
 			return nil
 		}
-		log.Error(err, "failed to get owner object", "namespace", pod.Namespace, "name", pod.Name)
+		count--
+		if count <= 0 {
+			delete(annotations, key)
+		} else {
+			annotations[key] = fmt.Sprintf("%d", count)
+		}
+		ownerObj.SetAnnotations(annotations)
+		if err := c.Client.Update(ctx, ownerObj); err != nil {
+			return fmt.Errorf("failed to update owner annotation: %w", err)
+		}
 		return nil
-	}
-	annotations := ownerObj.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	val := annotations[key]
-	if val == "" {
-		val = "0"
-	}
-	count, err := strconv.ParseInt(val, 10, 32)
-	if err != nil {
-		log.Error(err, "invalid count annotation", "namespace", pod.Namespace, "name", pod.Name)
-		return nil
-	}
-	count--
-	if count <= 0 {
-		delete(annotations, key)
-	} else {
-		annotations[key] = fmt.Sprintf("%d", count)
-	}
-	ownerObj.SetAnnotations(annotations)
-	if err := c.Client.Update(ctx, ownerObj); err != nil {
-		return fmt.Errorf("failed to update owner annotation, try later: %w", err)
-	}
-	return nil
+	})
 }
 
 // getControllerOwnerRef returns the controller owner reference of a pod

--- a/internal/webhook/v1/pod_counter_decrease_test.go
+++ b/internal/webhook/v1/pod_counter_decrease_test.go
@@ -1,0 +1,128 @@
+package v1
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func makeCounterPod(name string, ownerKey string) *corev1.Pod {
+	tt := true
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      name,
+			Annotations: map[string]string{
+				constants.TensorFusionPodCounterKeyAnnotation: ownerKey,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       "rs",
+				UID:        "rs-uid",
+				Controller: &tt,
+			}},
+		},
+	}
+}
+
+// TestDecrease_RetriesOnConflict reproduces the failure mode where two
+// Decrease callers concurrently bump the same owner annotation and the
+// second Update fires before the first commits. Previously a single
+// conflict propagated to pod_controller, which then SWALLOWED it and
+// proceeded to remove the finalizer, leaking the counter past the pod's
+// lifetime. The fix wraps Decrease in retry.RetryOnConflict so transient
+// races recover and only persistent errors surface.
+func TestDecrease_RetriesOnConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, appsv1.AddToScheme(scheme))
+
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "ns",
+			Name:        "rs",
+			UID:         "rs-uid",
+			Annotations: map[string]string{"counter-key": "5"},
+		},
+	}
+
+	// First N Updates return Conflict, then the real fake-client write succeeds.
+	const firstConflicts = 2
+	var attempts int32
+	conflictyClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(rs).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if n := atomic.AddInt32(&attempts, 1); n <= firstConflicts {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "apps", Resource: "replicasets"},
+						"rs", assert.AnError)
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	counter := &TensorFusionPodCounter{Client: conflictyClient}
+	pod := makeCounterPod("pod-1", "counter-key")
+	assert.NoError(t, counter.Decrease(context.Background(), pod),
+		"Decrease should swallow transient conflicts via internal retry")
+
+	// Verify the annotation was decremented exactly once (5 -> 4).
+	got := &appsv1.ReplicaSet{}
+	assert.NoError(t, conflictyClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "rs"}, got))
+	v, _ := strconv.Atoi(got.Annotations["counter-key"])
+	assert.Equal(t, 4, v, "counter must end at 4 (5 - 1), not 3 or 5")
+	assert.Equal(t, int32(firstConflicts+1), atomic.LoadInt32(&attempts),
+		"retry.RetryOnConflict should have retried %d times before succeeding", firstConflicts)
+}
+
+// TestDecrease_PropagatesPersistentError ensures a non-conflict Update error
+// (RBAC-style) is NOT silently swallowed: it must propagate so pod_controller
+// can keep the finalizer in place and requeue, surfacing the failure to a
+// human instead of leaking the counter on the owner.
+func TestDecrease_PropagatesPersistentError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, appsv1.AddToScheme(scheme))
+
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "ns",
+			Name:        "rs",
+			UID:         "rs-uid",
+			Annotations: map[string]string{"counter-key": "5"},
+		},
+	}
+	rbacClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(rs).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return apierrors.NewForbidden(
+					schema.GroupResource{Group: "apps", Resource: "replicasets"},
+					"rs", assert.AnError)
+			},
+		}).
+		Build()
+
+	counter := &TensorFusionPodCounter{Client: rbacClient}
+	pod := makeCounterPod("pod-2", "counter-key")
+	err := counter.Decrease(context.Background(), pod)
+	assert.Error(t, err, "persistent (non-conflict) errors must propagate so pod_controller keeps the finalizer")
+}

--- a/internal/webhook/v1/tf_parser.go
+++ b/internal/webhook/v1/tf_parser.go
@@ -657,8 +657,8 @@ func handleDedicatedGPU(pod *corev1.Pod, workloadProfile *tfv1.WorkloadProfile) 
 		return fmt.Errorf("dedicated GPU requires gpu-model annotation to be specified")
 	}
 
-	// Get full GPU capacity from pricing provider
-	resource, found := gpuallocator.GPUCapacityMap[workloadProfile.Spec.GPUModel]
+	// Get full GPU capacity from pricing provider.
+	resource, found := gpuallocator.GetGPUCapacity(workloadProfile.Spec.GPUModel)
 	if !found {
 		return fmt.Errorf("could not find capacity information for GPU model: %s", workloadProfile.Spec.GPUModel)
 	}

--- a/patches/scheduler-sched-one.patch
+++ b/patches/scheduler-sched-one.patch
@@ -4,7 +4,16 @@
 -	feasibleNodes, diagnosis, nodeHint, signature, err := sched.findNodesThatFitPod(ctx, fwk, state, pod)
 +	feasibleNodes, diagnosis, nodeHint, signature, err := sched.FindNodesThatFitPod(ctx, fwk, state, pod)
  	if err != nil {
-@@ -482,2 +482,2 @@
+@@ -480,2 +480,7 @@
+-// Filters the nodes to find the ones that fit the pod based on the framework
++// UpdateNodeInfoSnapshot refreshes the scheduler's shared node snapshot for dry-run simulations.
++func (sched *Scheduler) UpdateNodeInfoSnapshot(ctx context.Context) error {
++	return sched.Cache.UpdateSnapshot(klog.FromContext(ctx), sched.nodeInfoSnapshot)
++}
++
++// Filters the nodes to find the ones that fit the pod based on the framework
+ // filter plugins and filter extenders.
+@@ -482,2 +487,2 @@
 -func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, pod *v1.Pod) ([]fwk.NodeInfo, framework.Diagnosis, string, fwk.PodSignature, error) {
 +func (sched *Scheduler) FindNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, pod *v1.Pod) ([]fwk.NodeInfo, framework.Diagnosis, string, fwk.PodSignature, error) {
  	logger := klog.FromContext(ctx)


### PR DESCRIPTION
 ## Summary

  适配 v1 #660 / #668 / #669 到主仓,并补上 review
  期间发现的几个新问题。按功能拆 6 个
  commit,逐个独立可 review。修的都是数据正确性 /
  资源泄漏 / 死状态问题,所有改动都有回归测试,`-race`
   全绿。

  ## Commits

  1. **`fix(autoscaler)`** — `State` 加 RWMutex +
  locked accessor;seed-once Status 防
  `loadWorkloads` 覆盖 recommender
  写入;recommendation 回写 State;percentile
  estimator 跨 workload 共享状态去掉;ticker 泄漏 +
  UID 追踪
  2. **`fix(gpuallocator)`** — 5 张 partition 全局
  map 合并成 `atomic.Pointer[partitionConfig]`,读路
  径无锁;`GetAllocationInfo` 深拷贝;`handleGPU*` 加
  Capacity nil 守护;`GetGPUCapacity` 锁版本
  3. **`fix(scheduler)`** — expander 加锁 +
  深拷贝;`simulateSchedulingWithoutGPU` 调度前刷
  `UpdateNodeInfoSnapshot`;`/api/simulate-schedule`
  渲染 `FitError.Diagnosis`
  4. **`fix(progressive-migration)`** — taint
  reconcile best-effort 不依赖 status update
  成功;hypervisor `CrashLoopBackOff` 通过
  `RestartCount > threshold` 自愈
  5. **`fix(podcounter)`** — `Decrease` 内置
  `retry.RetryOnConflict`;`pod_controller` 不再吞
  `Decrease` 持续错误
  6. **`fix(metrics)`** —
  `TensorFusionSystemMetricsMap`
  加锁;`RecordMetrics` 裸读全部走锁

  ## 不在范围

  workload Replicas 1→2 短暂出现 3 个 pod ——
  production 秒级自愈、不累积。完整修需要
  expectations pattern + 重设计
  `PodTemplateHash`(目前包含 Replicas),留单独 PR。

  ## 测试

  - `make lint`:0 issues
  - `go build ./...` / `go vet ./internal/...`:clean
  - envtest 12/13 pass(剩 1 个 `HaveLen(2)` 是上述
  over-scaling 的预存在 failure,baseline 也 fail)
  - 新增 12+ 回归测试,每个都验证过"修复前 fail /
  修复后 pass