### PR TITLE
fix: inject legacy TF_CUDA_MEMORY_LIMIT alongside TF_GPU_MEMORY_LIMIT

### DIFF
--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -1303,12 +1303,16 @@ func SetWorkerContainerSpec(
 	// when compute isolation mode is hard-isolation, memory limit also change to hard-mode
 	// open source vgpu.rs memory limiter is feedback-loop based, potentially cause resource contention
 	if workloadProfile.Isolation == tfv1.IsolationModeHard {
+		memLimitMB := strconv.FormatInt(workloadProfile.Resources.Limits.Vram.Value()/(1024*1024), 10)
 		container.Env = append(container.Env, v1.EnvVar{
 			Name:  constants.HardSMLimiterEnv,
 			Value: workloadProfile.Resources.Limits.ComputePercent.String(),
 		}, v1.EnvVar{
 			Name:  constants.HardMemLimiterEnv,
-			Value: strconv.FormatInt(workloadProfile.Resources.Limits.Vram.Value()/(1024*1024), 10),
+			Value: memLimitMB,
+		}, v1.EnvVar{
+			Name:  constants.LegacyHardMemLimiterEnv,
+			Value: memLimitMB,
 		})
 	}
 

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -150,8 +150,10 @@ const (
 	// hard limiter (not open sourced) in megabytes, only take effect on worker container and
 	// when open source vgpu.rs gpu-limiter is disabled
 	// when use this mode, memory request can not autoscale dynamically
-	// (legacy name kept for reference: "TF_CUDA_MEMORY_LIMIT")
 	HardMemLimiterEnv = "TF_GPU_MEMORY_LIMIT"
+	// legacy name of HardMemLimiterEnv, injected alongside for backward compatibility with
+	// older hard limiter builds that still read TF_CUDA_MEMORY_LIMIT
+	LegacyHardMemLimiterEnv = "TF_CUDA_MEMORY_LIMIT"
 
 	TensorFusionRemoteWorkerPortNumber = 8000
 	TensorFusionRemoteWorkerPortName   = "remote-vgpu"


### PR DESCRIPTION
Older hard limiter builds still read TF_CUDA_MEMORY_LIMIT. Inject both env vars with the same MB value so new and old worker images both work.