### PR TITLE
fix: host-port leak, allocator port validation, webhook fail-closed，nil pool config guard

### DIFF
--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -87,7 +87,12 @@ controller:
       cpu: 2000m
 
   admissionWebhooks:
-    failurePolicy: Ignore
+    # Default Fail: the mutating webhook is scoped via objectSelector to only
+    # tensor-fusion.ai/enabled=true pods, so a failure won't block unrelated
+    # workloads. Failing closed prevents TF pods from being admitted without
+    # the required resource injection / control sidecars when the webhook is
+    # unavailable.
+    failurePolicy: Fail
     secretName: tensor-fusion-webhook-secret
     patch:
       image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0

--- a/internal/controller/gpupool_controller.go
+++ b/internal/controller/gpupool_controller.go
@@ -141,6 +141,12 @@ func (r *GPUPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// For provisioning mode, check if need to scale up GPUNodes upon AvailableCapacity changed
+	// NodeManagerConfig is optional in the CRD; guard against nil to avoid panicking on
+	// upgraded/restored pool objects missing this field.
+	if pool.Spec.NodeManagerConfig == nil {
+		log.Info("GPUPool has no NodeManagerConfig, skipping provisioning checks", "pool", pool.Name)
+		return ctrl.Result{RequeueAfter: constants.StatusCheckInterval}, nil
+	}
 	isProvisioningMode := pool.Spec.NodeManagerConfig.ProvisioningMode == tfv1.ProvisioningModeProvisioned ||
 		pool.Spec.NodeManagerConfig.ProvisioningMode == tfv1.ProvisioningModeKarpenter
 

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -136,10 +136,18 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	// Release cluster level port when Pod deleted
 	if !pod.DeletionTimestamp.IsZero() {
-		if pod.Annotations[constants.GenHostPortLabel] == constants.GenHostPortLabelValue {
-			podPortNumber, _ := strconv.Atoi(pod.Annotations[constants.GenPortNumberAnnotation])
-			_ = r.PortAllocator.ReleaseClusterLevelHostPort(pod.Name, podPortNumber, false)
-			log.Info("Released port", "pod", pod.Name, "port", podPortNumber)
+		if pod.Labels[constants.GenHostPortLabel] == constants.GenHostPortLabelValue {
+			portStr := pod.Annotations[constants.GenPortNumberAnnotation]
+			podPortNumber, err := strconv.Atoi(portStr)
+			if err != nil || podPortNumber <= 0 {
+				log.Info("Skip releasing port: invalid or missing port annotation",
+					"pod", pod.Name, "namespace", pod.Namespace, "value", portStr)
+			} else if err := r.PortAllocator.ReleaseClusterLevelHostPort(pod.Namespace, pod.Name, podPortNumber, false); err != nil {
+				log.Error(err, "Failed to release cluster level host port",
+					"pod", pod.Name, "namespace", pod.Namespace, "port", podPortNumber)
+			} else {
+				log.Info("Released port", "pod", pod.Name, "namespace", pod.Namespace, "port", podPortNumber)
+			}
 		}
 	}
 

--- a/internal/portallocator/portallocator.go
+++ b/internal/portallocator/portallocator.go
@@ -52,8 +52,9 @@ type PortAllocator struct {
 	ctx               context.Context
 
 	clusterLevelPortReleaseQueue chan struct {
-		podName string
-		port    int
+		namespace string
+		podName   string
+		port      int
 	}
 
 	nodeLevelPortReleaseQueue chan struct {
@@ -92,8 +93,9 @@ func NewPortAllocator(ctx context.Context, client client.Client, nodeLevelPortRa
 		ctx:               ctx,
 
 		clusterLevelPortReleaseQueue: make(chan struct {
-			podName string
-			port    int
+			namespace string
+			podName   string
+			port      int
 		}),
 		nodeLevelPortReleaseQueue: make(chan struct {
 			nodeName string
@@ -212,12 +214,25 @@ func (s *PortAllocator) AssignClusterLevelHostPort(podName string) (int, error) 
 	return 0, fmt.Errorf("no available port on cluster")
 }
 
-func (s *PortAllocator) ReleaseClusterLevelHostPort(podName string, port int, immediateRelease bool) error {
-	if port == 0 {
-		return fmt.Errorf("port cannot be 0 when release host port, may caused by portNumber annotation not detected, podName: %s", podName)
+// clusterPortOffset validates port against the cluster range and the bitmap
+// size, returning the bit offset to use for masking. Rejecting here keeps the
+// bitmap indexing below from panicking on malformed or stale annotations.
+func (s *PortAllocator) clusterPortOffset(port int) (int, error) {
+	if port < s.PortRangeStartCluster || port >= s.PortRangeEndCluster {
+		return 0, fmt.Errorf("port %d out of cluster range [%d, %d)", port, s.PortRangeStartCluster, s.PortRangeEndCluster)
 	}
+	offset := port - s.PortRangeStartCluster
+	if offset/64 >= len(s.BitmapCluster) {
+		return 0, fmt.Errorf("port %d offset %d exceeds bitmap size %d", port, offset, len(s.BitmapCluster)*64)
+	}
+	return offset, nil
+}
 
-	portOffset := port - s.PortRangeStartCluster
+func (s *PortAllocator) ReleaseClusterLevelHostPort(namespace string, podName string, port int, immediateRelease bool) error {
+	portOffset, err := s.clusterPortOffset(port)
+	if err != nil {
+		return fmt.Errorf("invalid port for pod %s/%s: %w", namespace, podName, err)
+	}
 
 	if immediateRelease {
 		s.storeMutexCluster.Lock()
@@ -227,30 +242,40 @@ func (s *PortAllocator) ReleaseClusterLevelHostPort(podName string, port int, im
 	} else {
 		// put into queue, release until Pod not found
 		s.clusterLevelPortReleaseQueue <- struct {
-			podName string
-			port    int
-		}{podName, port}
+			namespace string
+			podName   string
+			port      int
+		}{namespace, podName, port}
 	}
 	return nil
 }
 
 func (s *PortAllocator) releaseClusterPortUntilPodDeleted() {
 	for item := range s.clusterLevelPortReleaseQueue {
+		namespace := item.namespace
 		podName := item.podName
-		portOffset := item.port - s.PortRangeStartCluster
+		portOffset, offsetErr := s.clusterPortOffset(item.port)
+		if offsetErr != nil {
+			// Defensive: queue is fed by ReleaseClusterLevelHostPort which
+			// already validates, but guard the bitmap indexing anyway so a
+			// bad item can never crash the background worker.
+			log.Log.Error(offsetErr, "drop release request for invalid port",
+				"namespace", namespace, "pod", podName, "port", item.port)
+			continue
+		}
 
 		_ = retry.OnError(RETRY_CONFIG, func(_ error) bool {
 			return true
 		}, func() error {
 			pod := &v1.Pod{}
-			err := s.Client.Get(s.ctx, client.ObjectKey{Name: podName}, pod)
+			err := s.Client.Get(s.ctx, client.ObjectKey{Namespace: namespace, Name: podName}, pod)
 			if errors.IsNotFound(err) {
 				s.storeMutexCluster.Lock()
 				defer s.storeMutexCluster.Unlock()
 				s.BitmapCluster[portOffset/64] &^= 1 << (portOffset % 64)
 				return nil
 			}
-			return fmt.Errorf("pod still there, can not release port %s", podName)
+			return fmt.Errorf("pod still there, can not release port %s/%s", namespace, podName)
 		})
 	}
 }

--- a/internal/portallocator/portallocator_test.go
+++ b/internal/portallocator/portallocator_test.go
@@ -109,10 +109,10 @@ var _ = Describe("Port Allocator", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(port).To(Equal(42002))
 
-			err = pa.ReleaseClusterLevelHostPort(podName, port, true)
+			err = pa.ReleaseClusterLevelHostPort("default", podName, port, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = pa.ReleaseClusterLevelHostPort(podName, 59999, true)
+			err = pa.ReleaseClusterLevelHostPort("default", podName, 59999, true)
 			Expect(err).NotTo(HaveOccurred())
 
 			port, err = pa.AssignClusterLevelHostPort(podName)
@@ -121,9 +121,25 @@ var _ = Describe("Port Allocator", func() {
 		})
 
 		It("should fail to release a cluster port with invalid parameters", func() {
-			err := pa.ReleaseClusterLevelHostPort("test-pod", 0, true)
+			By("rejecting port 0")
+			err := pa.ReleaseClusterLevelHostPort("default", "test-pod", 0, true)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("port cannot be 0 when release host port"))
+			Expect(err.Error()).To(ContainSubstring("out of cluster range"))
+
+			By("rejecting negative port")
+			err = pa.ReleaseClusterLevelHostPort("default", "test-pod", -1, true)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("out of cluster range"))
+
+			By("rejecting port above range end")
+			err = pa.ReleaseClusterLevelHostPort("default", "test-pod", 60000, true)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("out of cluster range"))
+
+			By("rejecting port well above range end")
+			err = pa.ReleaseClusterLevelHostPort("default", "test-pod", 99999, true)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("out of cluster range"))
 		})
 	})
 


### PR DESCRIPTION
- pod_controller: check Labels (not Annotations) for GenHostPortLabel so the cluster-level host port is actually released on Pod delete; pass Namespace end-to-end and validate the port annotation before calling the allocator
- portallocator: validate cluster port range (rejects 0, negative, and out-of-range values) in both the sync release path and the background queue worker to prevent BitmapCluster out-of-bounds panics; Get pod with {Namespace, Name} so same-named pods across namespaces don't trigger early release; tests cover -1 / 60000 / 99999 rejection
- gpupool_controller: nil-guard pool.Spec.NodeManagerConfig before dereferencing ProvisioningMode to avoid panics on upgraded/restored pools
- helm: default mutating webhook failurePolicy to Fail; objectSelector already scopes it to tensor-fusion.ai/enabled=true pods, so unrelated workloads are unaffected while TF pods are no longer admitted unmutated