### PR TITLE
fix: validate port range parsing and retry pod counter on conflict

### DIFF
--- a/internal/portallocator/portallocator.go
+++ b/internal/portallocator/portallocator.go
@@ -64,19 +64,43 @@ type PortAllocator struct {
 	}
 }
 
+// parsePortRange parses an "<start>-<end>" string and validates that both
+// sides are well-formed integers and that start < end. A misconfigured flag
+// (missing dash, non-numeric, reversed) would otherwise either panic on slice
+// indexing, silently produce a zero-size bitmap, or pass a negative length to
+// make() — all of which surface only at the first allocation request.
+func parsePortRange(raw string, label string) (int, int, error) {
+	parts := strings.Split(raw, "-")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid %s port range %q: expected format <start>-<end>", label, raw)
+	}
+	start, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid %s port range %q: start: %w", label, raw, err)
+	}
+	end, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid %s port range %q: end: %w", label, raw, err)
+	}
+	if start <= 0 || end <= 0 || start >= end {
+		return 0, 0, fmt.Errorf("invalid %s port range %q: require 0 < start < end", label, raw)
+	}
+	return start, end, nil
+}
+
 func NewPortAllocator(ctx context.Context, client client.Client, nodeLevelPortRange string, clusterLevelPortRange string) (*PortAllocator, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client cannot be nil")
 	}
 
-	nodeLevelRange := strings.Split(nodeLevelPortRange, "-")
-	clusterLevelRange := strings.Split(clusterLevelPortRange, "-")
-
-	portRangeStartNode, _ := strconv.Atoi(nodeLevelRange[0])
-	portRangeEndNode, _ := strconv.Atoi(nodeLevelRange[1])
-
-	portRangeStartCluster, _ := strconv.Atoi(clusterLevelRange[0])
-	portRangeEndCluster, _ := strconv.Atoi(clusterLevelRange[1])
+	portRangeStartNode, portRangeEndNode, err := parsePortRange(nodeLevelPortRange, "node-level")
+	if err != nil {
+		return nil, err
+	}
+	portRangeStartCluster, portRangeEndCluster, err := parsePortRange(clusterLevelPortRange, "cluster-level")
+	if err != nil {
+		return nil, err
+	}
 
 	allocator := &PortAllocator{
 		PortRangeStartNode:    portRangeStartNode,

--- a/internal/webhook/v1/pod_counter.go
+++ b/internal/webhook/v1/pod_counter.go
@@ -65,39 +65,48 @@ func (c *TensorFusionPodCounter) Get(ctx context.Context, pod *corev1.Pod) (int3
 	return int32(count), key, nil
 }
 
-// Increase increases the counter in owner annotation by key
+// Increase increases the counter in owner annotation by key. Wrapped in
+// retry.RetryOnConflict so concurrent admission of multiple pods sharing the
+// same owner (e.g. a Deployment scaling up) does not surface as a 500 to the
+// API server — each concurrent webhook would otherwise read the same
+// ResourceVersion, both compute count+1, and only the first Update succeeds.
+// Mirrors Decrease's retry strategy so admission-side and finalizer-side
+// bookkeeping stay symmetric.
 func (c *TensorFusionPodCounter) Increase(ctx context.Context, pod *corev1.Pod) error {
 	ownerRef := getControllerOwnerRef(pod)
 	if ownerRef == nil {
 		return fmt.Errorf("no controller owner reference found for pod %s/%s", pod.Namespace, pod.Name)
 	}
 	key := getOrGenerateKey(pod)
-	ownerObj := &unstructured.Unstructured{}
-	ownerObj.SetAPIVersion(ownerRef.APIVersion)
-	ownerObj.SetKind(ownerRef.Kind)
 	objKey := client.ObjectKey{Name: ownerRef.Name, Namespace: pod.Namespace}
-	if err := c.Client.Get(ctx, objKey, ownerObj); err != nil {
-		return fmt.Errorf("failed to get owner object: %w", err)
-	}
-	annotations := ownerObj.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	val := annotations[key]
-	if val == "" {
-		val = "0"
-	}
-	count, err := strconv.ParseInt(val, 10, 32)
-	if err != nil {
-		return fmt.Errorf("invalid count annotation: %s, err: %w", val, err)
-	}
-	count++
-	annotations[key] = fmt.Sprintf("%d", count)
-	ownerObj.SetAnnotations(annotations)
-	if err := c.Client.Update(ctx, ownerObj); err != nil {
-		return fmt.Errorf("failed to update owner annotation: %w", err)
-	}
-	return nil
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		ownerObj := &unstructured.Unstructured{}
+		ownerObj.SetAPIVersion(ownerRef.APIVersion)
+		ownerObj.SetKind(ownerRef.Kind)
+		if err := c.Client.Get(ctx, objKey, ownerObj); err != nil {
+			return fmt.Errorf("failed to get owner object: %w", err)
+		}
+		annotations := ownerObj.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		val := annotations[key]
+		if val == "" {
+			val = "0"
+		}
+		count, err := strconv.ParseInt(val, 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid count annotation: %s, err: %w", val, err)
+		}
+		count++
+		annotations[key] = fmt.Sprintf("%d", count)
+		ownerObj.SetAnnotations(annotations)
+		if err := c.Client.Update(ctx, ownerObj); err != nil {
+			return fmt.Errorf("failed to update owner annotation: %w", err)
+		}
+		return nil
+	})
 }
 
 // Decrease decreases the counter in owner annotation by key. Wraps the


### PR DESCRIPTION
- portallocator: extract parsePortRange helper that requires len==2, surfaces Atoi errors instead of silently producing zeros, and enforces 0 < start < end. Previously a misconfigured flag (missing dash, non-numeric, reversed) could panic on slice index, build a zero/negative-sized bitmap, or pass a negative length to make() — all only at first allocation.
- pod_counter: wrap Increase in retry.RetryOnConflict to mirror Decrease. Concurrent admission of multiple pods sharing one owner (e.g. Deployment scale-up) all read the same ResourceVersion; only the first Update wins and the rest got a 500 back from the webhook. Retrying eliminates the transient admission failures and keeps the counter symmetric with finalizer-side decrements.