### PR TITLE
fix(autoscaler/quota): validate limit deltas and multi-GPU usage on AdjustAllocation

### DIFF
--- a/api/v1/gpuresourcequota_types.go
+++ b/api/v1/gpuresourcequota_types.go
@@ -215,7 +215,10 @@ type GPUAllocationInfo struct {
 }
 
 type AdjustRequest struct {
-	PodUID     string
+	PodUID string
+	// Deprecated: kept for source compatibility. The allocator pre-checks
+	// per-GPU capacity and namespace quota unconditionally, so callers no
+	// longer need to declare scale direction. The value is ignored.
 	IsScaleUp  bool
 	NewRequest Resource
 	NewLimit   Resource

--- a/internal/autoscaler/workload/handler.go
+++ b/internal/autoscaler/workload/handler.go
@@ -261,15 +261,8 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 		return nil
 	}
 
-	// When curRes is nil (parse failure above), treat as a scale-up so AdjustAllocation
-	// runs the quota pre-check — safer than skipping it.
-	isScaleUp := curRes == nil ||
-		recommendation.Requests.Tflops.Cmp(curRes.Requests.Tflops) > 0 ||
-		recommendation.Requests.Vram.Cmp(curRes.Requests.Vram) > 0
-
-	_, deltaRes, err := h.allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+	_, deltaReq, deltaLimit, err := h.allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
 		PodUID:     string(worker.UID),
-		IsScaleUp:  isScaleUp,
 		NewRequest: recommendation.Requests,
 		NewLimit:   recommendation.Limits,
 	}, false)
@@ -287,26 +280,25 @@ func (h *handler) applyRecommendationToWorker(ctx context.Context, workload *Sta
 	patch := client.MergeFrom(worker.DeepCopy())
 	maps.Copy(worker.Annotations, annotationsToUpdate)
 	if err := h.Patch(ctx, worker, patch); err != nil {
-		// Rollback the allocation change by calculating original values from current state and delta
-		// After AdjustAllocation, the allocator state is now recommendation, so we need to subtract deltaRes
-		// to get back to the original curRes values
+		// Rollback by reconstructing the pre-adjust values from the new recommendation
+		// and the per-resource deltas. Request and limit must use their own deltas;
+		// recommendations can scale them independently.
 		originalRequest := tfv1.Resource{
 			Tflops: recommendation.Requests.Tflops.DeepCopy(),
 			Vram:   recommendation.Requests.Vram.DeepCopy(),
 		}
-		originalRequest.Tflops.Sub(deltaRes.Tflops)
-		originalRequest.Vram.Sub(deltaRes.Vram)
+		originalRequest.Tflops.Sub(deltaReq.Tflops)
+		originalRequest.Vram.Sub(deltaReq.Vram)
 
 		originalLimit := tfv1.Resource{
 			Tflops: recommendation.Limits.Tflops.DeepCopy(),
 			Vram:   recommendation.Limits.Vram.DeepCopy(),
 		}
-		originalLimit.Tflops.Sub(deltaRes.Tflops)
-		originalLimit.Vram.Sub(deltaRes.Vram)
+		originalLimit.Tflops.Sub(deltaLimit.Tflops)
+		originalLimit.Vram.Sub(deltaLimit.Vram)
 
-		if _, _, rollbackErr := h.allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+		if _, _, _, rollbackErr := h.allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
 			PodUID:     string(worker.UID),
-			IsScaleUp:  !isScaleUp,
 			NewRequest: originalRequest,
 			NewLimit:   originalLimit,
 		}, false); rollbackErr != nil {

--- a/internal/autoscaler/workload/handler_rollback_test.go
+++ b/internal/autoscaler/workload/handler_rollback_test.go
@@ -1,0 +1,189 @@
+package workload
+
+import (
+	"context"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestApplyRecommendationToWorker_RollbackRestoresLimitIndependently exercises
+// the patch-failure rollback path with a recommendation that scales request and
+// limit by different amounts. Before the fix, AdjustAllocation only returned a
+// request-delta and the rollback used it to back out the limit as well, leaving
+// QuotaStore.CurrentUsage drifted on every retry. The assertions below pin the
+// quota state back to its pre-adjust baseline so any regression of that bug fails.
+func TestApplyRecommendationToWorker_RollbackRestoresLimitIndependently(t *testing.T) {
+	const (
+		ns         = "rollback-test-ns"
+		workload   = "rollback-test-workload"
+		poolName   = "rollback-test-pool"
+		podName    = "rollback-test-pod"
+		podUID     = "rollback-test-pod-uid"
+		gpuName    = "rollback-test-gpu"
+		nodeName   = "rollback-test-node"
+		hostName   = "rollback-test-host"
+		workerName = podName // worker.Name == pod.Name
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, tfv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	gpu := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gpuName,
+			Labels: map[string]string{
+				constants.LabelKeyOwner: nodeName,
+				constants.GpuPoolKey:    poolName,
+			},
+		},
+		Status: tfv1.GPUStatus{
+			Phase: tfv1.TensorFusionGPUPhaseRunning,
+			Capacity: &tfv1.Resource{
+				Tflops: *resource.NewQuantity(200, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(2000, resource.BinarySI),
+			},
+			Available: &tfv1.Resource{
+				Tflops: *resource.NewQuantity(200, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(2000, resource.BinarySI),
+			},
+			NodeSelector: map[string]string{
+				constants.KubernetesHostNameLabel: hostName,
+			},
+		},
+	}
+	pool := &tfv1.GPUPool{
+		ObjectMeta: metav1.ObjectMeta{Name: poolName},
+		Status:     tfv1.GPUPoolStatus{Phase: tfv1.TensorFusionPoolPhaseRunning},
+	}
+	maxWorkers := int32(10)
+	quotaObj := &tfv1.GPUResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "q", Namespace: ns},
+		Spec: tfv1.GPUResourceQuotaSpec{
+			Total: tfv1.GPUResourceQuotaTotal{
+				Requests: &tfv1.Resource{
+					Tflops: *resource.NewQuantity(500, resource.DecimalSI),
+					Vram:   *resource.NewQuantity(5000, resource.BinarySI),
+				},
+				Limits: &tfv1.Resource{
+					Tflops: *resource.NewQuantity(500, resource.DecimalSI),
+					Vram:   *resource.NewQuantity(5000, resource.BinarySI),
+				},
+				MaxWorkers: &maxWorkers,
+			},
+		},
+	}
+
+	// The worker pod is deliberately NOT registered in the fake client so the
+	// inner h.Patch(...) returns NotFound — that triggers the rollback path.
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gpu, pool).
+		WithLists(&tfv1.GPUResourceQuotaList{Items: []tfv1.GPUResourceQuota{*quotaObj}}).
+		Build()
+
+	ctx := context.Background()
+	allocator := gpuallocator.NewGpuAllocator(ctx, nil, fakeClient, 0)
+	require.NoError(t, allocator.InitGPUAndQuotaStore())
+	allocator.ReconcileAllocationState()
+	allocator.SetAllocatorReady()
+
+	allocReq := &tfv1.AllocRequest{
+		PoolName: poolName,
+		WorkloadNameNamespace: tfv1.NameNamespace{
+			Namespace: ns,
+			Name:      workload,
+		},
+		Request: tfv1.Resource{
+			Tflops: *resource.NewQuantity(30, resource.DecimalSI),
+			Vram:   *resource.NewQuantity(300, resource.BinarySI),
+		},
+		Limit: tfv1.Resource{
+			Tflops: *resource.NewQuantity(30, resource.DecimalSI),
+			Vram:   *resource.NewQuantity(300, resource.BinarySI),
+		},
+		Count: 1,
+		PodMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      podName,
+			UID:       podUID,
+		},
+	}
+	allocatedGPUs, err := allocator.Alloc(allocReq)
+	require.NoError(t, err)
+	require.Len(t, allocatedGPUs, 1)
+
+	qs := allocator.GetQuotaStore()
+	baseline, ok := qs.GetQuotaStatus(ns)
+	require.True(t, ok)
+	require.Equal(t, int64(30), baseline.Requests.Tflops.Value())
+	require.Equal(t, int64(30), baseline.Limits.Tflops.Value())
+
+	worker := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      podName,
+			UID:       podUID,
+			Annotations: map[string]string{
+				constants.TFLOPSRequestAnnotation: "30",
+				constants.TFLOPSLimitAnnotation:   "30",
+				constants.VRAMRequestAnnotation:   "300",
+				constants.VRAMLimitAnnotation:     "300",
+				constants.GpuCountAnnotation:      "1",
+				constants.GpuPoolKey:              poolName,
+			},
+		},
+	}
+
+	state := NewWorkloadState()
+	state.Namespace = ns
+	state.Name = workload
+	state.Spec.AutoScalingConfig = tfv1.AutoScalingConfig{
+		AutoSetResources: &tfv1.AutoSetResources{
+			Enable:         true,
+			TargetResource: tfv1.ScalingTargetResourceAll,
+		},
+	}
+
+	// Request grows by 10, limit grows by 30 — deliberately asymmetric so a
+	// rollback that uses the request delta for the limit (the old bug) leaves
+	// quota.Limits stuck at 50 instead of returning to the 30 baseline.
+	recommendation := &tfv1.Resources{
+		Requests: tfv1.Resource{
+			Tflops: *resource.NewQuantity(40, resource.DecimalSI),
+			Vram:   *resource.NewQuantity(400, resource.BinarySI),
+		},
+		Limits: tfv1.Resource{
+			Tflops: *resource.NewQuantity(60, resource.DecimalSI),
+			Vram:   *resource.NewQuantity(600, resource.BinarySI),
+		},
+	}
+
+	h := &handler{
+		Client:    fakeClient,
+		allocator: allocator,
+	}
+
+	err = h.applyRecommendationToWorker(ctx, state, worker, recommendation)
+	require.Error(t, err, "expected patch failure to bubble up so the caller can retry")
+
+	after, ok := qs.GetQuotaStatus(ns)
+	require.True(t, ok)
+	require.Equal(t, int64(30), after.Requests.Tflops.Value(),
+		"request usage should be restored to the pre-adjust baseline")
+	require.Equal(t, int64(300), after.Requests.Vram.Value(),
+		"request vram usage should be restored to the pre-adjust baseline")
+	require.Equal(t, int64(30), after.Limits.Tflops.Value(),
+		"limit usage should be restored to the pre-adjust baseline (regression: would be 50 if rollback used request delta for limit)")
+	require.Equal(t, int64(300), after.Limits.Vram.Value(),
+		"limit vram usage should be restored to the pre-adjust baseline")
+}

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -1396,16 +1396,21 @@ func (s *GpuAllocator) Dealloc(
 		"vram", request.Request.Vram.String())
 }
 
-// Used for scale up decision, dryRun to pre-check capacity to determine if the allocation
-// is valid when scaling up, return error and the max new requests/limits on existing GPU
-// Auto scaler can directly call AdjustAllocation for scaling down decision
-// it has to call AdjustAllocation with dryRun=true when scaling up,
-// if return error is ScalingQuotaExceededError,
-// it means the allocation is invalid, and it should scale up with another AdjustRequest
-// to make sure not exceed quota, which returns in the first returned result
-// retry until AdjustAllocation returns nil error, at most pre-configured maxRetry times
-// returns remaining resource, delta resource, error
-func (s *GpuAllocator) AdjustAllocation(ctx context.Context, adjustRequest tfv1.AdjustRequest, dryRun bool) (tfv1.Resource, tfv1.Resource, error) {
+// AdjustAllocation applies an in-place request/limit change to an existing
+// pod allocation. It always pre-checks per-GPU capacity and namespace quota
+// — including the limit dimension — regardless of which direction any single
+// resource moves. Callers must not gate this check themselves: an autoscaler
+// recommendation can grow Limits while leaving Requests flat (or shrinking
+// them), and only the allocator has the full picture needed to validate that.
+// With dryRun=true, no state is mutated; otherwise the allocator's per-pod
+// state, per-GPU available, and the namespace quota usage are updated.
+//
+// Returns (remaining resource on the first failing GPU when capacity is
+// exceeded, per-GPU request delta, per-GPU limit delta, error). Deltas are
+// per-GPU (matching the units of request.Request/Limit) so callers can
+// reconstruct the pre-adjust per-GPU values by subtracting the deltas from
+// the new request/limit they passed in.
+func (s *GpuAllocator) AdjustAllocation(ctx context.Context, adjustRequest tfv1.AdjustRequest, dryRun bool) (tfv1.Resource, tfv1.Resource, tfv1.Resource, error) {
 
 	<-s.initializedCh
 	s.storeMutex.Lock()
@@ -1413,7 +1418,7 @@ func (s *GpuAllocator) AdjustAllocation(ctx context.Context, adjustRequest tfv1.
 
 	request, exists := s.uniqueAllocation[adjustRequest.PodUID]
 	if !exists || request == nil {
-		return tfv1.Resource{}, tfv1.Resource{}, fmt.Errorf("pod %s has not allocated GPUs", adjustRequest.PodUID)
+		return tfv1.Resource{}, tfv1.Resource{}, tfv1.Resource{}, fmt.Errorf("pod %s has not allocated GPUs", adjustRequest.PodUID)
 	}
 
 	deltaTFlopsRequest := adjustRequest.NewRequest.Tflops
@@ -1428,36 +1433,32 @@ func (s *GpuAllocator) AdjustAllocation(ctx context.Context, adjustRequest tfv1.
 	deltaVRAMLimit := adjustRequest.NewLimit.Vram
 	deltaVRAMLimit.Sub(request.Limit.Vram)
 
-	if adjustRequest.IsScaleUp {
-		for _, gpuName := range request.GPUNames {
-			gpuNameNs := types.NamespacedName{Name: gpuName}
-			gpu, exists := s.gpuStore[gpuNameNs]
-			if !exists {
-				return tfv1.Resource{}, tfv1.Resource{}, fmt.Errorf("GPU not found in allocator store %s", gpuName)
-			}
-			if remain, err := s.checkGPUCapacityAndQuota(gpu, request.Request, adjustRequest.NewRequest); err != nil {
-				return remain, tfv1.Resource{}, err
-			}
+	// Per-GPU capacity check. Scale-down trivially passes (new <= old), so
+	// running this unconditionally is safe and removes the previous brittle
+	// dependency on a caller-supplied scale direction flag.
+	for _, gpuName := range request.GPUNames {
+		gpuNameNs := types.NamespacedName{Name: gpuName}
+		gpu, exists := s.gpuStore[gpuNameNs]
+		if !exists {
+			return tfv1.Resource{}, tfv1.Resource{}, tfv1.Resource{}, fmt.Errorf("GPU not found in allocator store %s", gpuName)
 		}
-
-		// check namespaced level quota
-		if err := s.quotaStore.CheckQuotaAvailable(&tfv1.AllocRequest{
-			WorkloadNameNamespace: request.WorkloadNameNamespace,
-
-			Count: uint(len(request.GPUNames)),
-			Request: tfv1.Resource{
-				Tflops: deltaTFlopsRequest,
-				Vram:   deltaVRAMRequest,
-			},
-			Limit: tfv1.Resource{
-				Tflops: deltaTFlopsLimit,
-				Vram:   deltaVRAMLimit,
-			},
-			GPUNames: request.GPUNames,
-			PodMeta:  request.PodMeta,
-		}); err != nil {
-			return tfv1.Resource{}, tfv1.Resource{}, err
+		if remain, err := s.checkGPUCapacityAndQuota(gpu, request.Request, adjustRequest.NewRequest); err != nil {
+			return remain, tfv1.Resource{}, tfv1.Resource{}, err
 		}
+	}
+
+	// Namespace quota check. Single-quota caps must compare against the absolute
+	// new values; total-quota math is delta-based. CheckAdjustQuotaAvailable
+	// handles both correctly.
+	if err := s.quotaStore.CheckAdjustQuotaAvailable(&tfv1.AllocRequest{
+		WorkloadNameNamespace: request.WorkloadNameNamespace,
+		Count:                 uint(len(request.GPUNames)),
+		Request:               adjustRequest.NewRequest,
+		Limit:                 adjustRequest.NewLimit,
+		GPUNames:              request.GPUNames,
+		PodMeta:               request.PodMeta,
+	}, request.Request, request.Limit); err != nil {
+		return tfv1.Resource{}, tfv1.Resource{}, tfv1.Resource{}, err
 	}
 
 	// pre check passed, change GPU request and QuotaStore and markDirty to sync to Kubernetes
@@ -1473,12 +1474,27 @@ func (s *GpuAllocator) AdjustAllocation(ctx context.Context, adjustRequest tfv1.
 			s.markGPUDirty(gpuNameNs)
 		}
 
+		// Quota usage is tracked as the total across all GPUs of the workload,
+		// matching the normal Alloc path which multiplies by allocation.Count via
+		// Calculator.IncreaseUsage. AdjustQuota itself adds the deltas verbatim,
+		// so we must scale single-GPU deltas by GPU count here. DeepCopy to avoid
+		// mutating the per-GPU deltas we return to the caller.
+		gpuCount := int64(len(request.GPUNames))
+		scaledReqTflops := deltaTFlopsRequest.DeepCopy()
+		scaledReqTflops.Mul(gpuCount)
+		scaledReqVram := deltaVRAMRequest.DeepCopy()
+		scaledReqVram.Mul(gpuCount)
+		scaledLimitTflops := deltaTFlopsLimit.DeepCopy()
+		scaledLimitTflops.Mul(gpuCount)
+		scaledLimitVram := deltaVRAMLimit.DeepCopy()
+		scaledLimitVram.Mul(gpuCount)
+
 		s.quotaStore.AdjustQuota(request.PodMeta.Namespace, tfv1.Resource{
-			Tflops: deltaTFlopsRequest,
-			Vram:   deltaVRAMRequest,
+			Tflops: scaledReqTflops,
+			Vram:   scaledReqVram,
 		}, tfv1.Resource{
-			Tflops: deltaTFlopsLimit,
-			Vram:   deltaVRAMLimit,
+			Tflops: scaledLimitTflops,
+			Vram:   scaledLimitVram,
 		})
 		request.Request = adjustRequest.NewRequest
 		request.Limit = adjustRequest.NewLimit
@@ -1493,9 +1509,12 @@ func (s *GpuAllocator) AdjustAllocation(ctx context.Context, adjustRequest tfv1.
 			"limit vram", request.Limit.Vram.String())
 	}
 	return tfv1.Resource{}, tfv1.Resource{
-		Tflops: deltaTFlopsRequest,
-		Vram:   deltaVRAMRequest,
-	}, nil
+			Tflops: deltaTFlopsRequest,
+			Vram:   deltaVRAMRequest,
+		}, tfv1.Resource{
+			Tflops: deltaTFlopsLimit,
+			Vram:   deltaVRAMLimit,
+		}, nil
 }
 
 func (s *GpuAllocator) ListNonUsingNodes() sets.Set[string] {

--- a/internal/gpuallocator/gpuallocator_test.go
+++ b/internal/gpuallocator/gpuallocator_test.go
@@ -275,9 +275,8 @@ var _ = Describe("GPU Allocator", func() {
 			Expect(gpus).To(HaveLen(1))
 
 			gpu := getGPU(gpus[0].Name)
-			remain, _, err := allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
-				PodUID:    string(testPodMeta.UID),
-				IsScaleUp: true,
+			remain, _, _, err := allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+				PodUID: string(testPodMeta.UID),
 				NewRequest: tfv1.Resource{
 					Tflops: resource.MustParse("300"),
 					Vram:   resource.MustParse("30Gi"),
@@ -292,9 +291,8 @@ var _ = Describe("GPU Allocator", func() {
 			Expect(remain.Tflops.Value()).To(BeEquivalentTo(gpu.Status.Available.Tflops.Value()))
 			Expect(remain.Vram.Value()).To(BeEquivalentTo(gpu.Status.Available.Vram.Value()))
 
-			_, _, err = allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
-				PodUID:    string(testPodMeta.UID),
-				IsScaleUp: true,
+			_, _, _, err = allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+				PodUID: string(testPodMeta.UID),
 				NewRequest: tfv1.Resource{
 					Tflops: resource.MustParse("90"),
 					Vram:   resource.MustParse("15Gi"),
@@ -312,9 +310,8 @@ var _ = Describe("GPU Allocator", func() {
 				To(BeEquivalentTo(5 * 1024 * 1024 * 1024))
 
 			// test scale down
-			_, _, err = allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
-				PodUID:    string(testPodMeta.UID),
-				IsScaleUp: false,
+			_, _, _, err = allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+				PodUID: string(testPodMeta.UID),
 				NewRequest: tfv1.Resource{
 					Tflops: resource.MustParse("10"),
 					Vram:   resource.MustParse("1Gi"),

--- a/internal/gpuallocator/quota_consolidated_test.go
+++ b/internal/gpuallocator/quota_consolidated_test.go
@@ -425,6 +425,198 @@ var _ = Describe("GPUAllocator Quota Integration", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("total.max.tflops"))
 	})
+
+	// Regression for the bug where AdjustAllocation passed per-GPU deltas to
+	// AdjustQuota without multiplying by GPU count, while normal Alloc/IncreaseUsage
+	// does multiply — leaving multi-GPU workload quota usage permanently underreported
+	// after any autoscale event.
+	It("should scale quota usage by GPU count when AdjustAllocation runs on multi-GPU workload", func() {
+		scheme := runtime.NewScheme()
+		Expect(tfv1.AddToScheme(scheme)).To(Succeed())
+
+		quotaObj := createTestQuota(200, 2000, 10)
+		gpus := []tfv1.GPU{
+			createAvailableGPU("gpu1", 100, 1000),
+			createAvailableGPU("gpu2", 100, 1000),
+		}
+
+		testPool := createTestGPUPool()
+		allObjects := objectsFromGPUs(gpus)
+		allObjects = append(allObjects, testPool)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(allObjects...).
+			WithLists(&tfv1.GPUResourceQuotaList{Items: []tfv1.GPUResourceQuota{*quotaObj}}).
+			Build()
+
+		ctx := context.Background()
+		allocator := NewGpuAllocator(ctx, nil, fakeClient, 0)
+		initAllocator(allocator)
+
+		req := createAllocRequest(30, 300, 2)
+		req.PodMeta = podMeta
+		allocatedGPUs, err := allocator.Alloc(req)
+		Expect(err).To(Succeed())
+		Expect(allocatedGPUs).To(HaveLen(2))
+
+		usage, exists := allocator.quotaStore.GetQuotaStatus(TestNamespace)
+		Expect(exists).To(BeTrue())
+		Expect(usage.Requests.Tflops.Value()).To(Equal(int64(60))) // 30 * 2
+		Expect(usage.Limits.Tflops.Value()).To(Equal(int64(60)))
+
+		_, deltaReq, deltaLimit, err := allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+			PodUID: string(podMeta.UID),
+			NewRequest: tfv1.Resource{
+				Tflops: *resource.NewQuantity(40, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(400, resource.BinarySI),
+			},
+			NewLimit: tfv1.Resource{
+				Tflops: *resource.NewQuantity(50, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(500, resource.BinarySI),
+			},
+		}, false)
+		Expect(err).To(Succeed())
+		// Returned deltas are per-GPU so callers can reconstruct pre-adjust per-GPU
+		// values; the multiplication by Count happens inside AdjustAllocation.
+		Expect(deltaReq.Tflops.Value()).To(Equal(int64(10)))
+		Expect(deltaLimit.Tflops.Value()).To(Equal(int64(20)))
+
+		usage, exists = allocator.quotaStore.GetQuotaStatus(TestNamespace)
+		Expect(exists).To(BeTrue())
+		// requests = 60 (initial) + 2 GPUs * 10 per-GPU delta = 80
+		Expect(usage.Requests.Tflops.Value()).To(Equal(int64(80)))
+		Expect(usage.Requests.Vram.Value()).To(Equal(int64(800)))
+		// limits = 60 (initial) + 2 GPUs * 20 per-GPU delta = 100
+		Expect(usage.Limits.Tflops.Value()).To(Equal(int64(100)))
+		Expect(usage.Limits.Vram.Value()).To(Equal(int64(1000)))
+
+		// Scale back down and verify the quota returns to its post-Alloc baseline,
+		// not to some drifted value.
+		_, _, _, err = allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+			PodUID: string(podMeta.UID),
+			NewRequest: tfv1.Resource{
+				Tflops: *resource.NewQuantity(30, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(300, resource.BinarySI),
+			},
+			NewLimit: tfv1.Resource{
+				Tflops: *resource.NewQuantity(30, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(300, resource.BinarySI),
+			},
+		}, false)
+		Expect(err).To(Succeed())
+
+		usage, exists = allocator.quotaStore.GetQuotaStatus(TestNamespace)
+		Expect(exists).To(BeTrue())
+		Expect(usage.Requests.Tflops.Value()).To(Equal(int64(60)))
+		Expect(usage.Requests.Vram.Value()).To(Equal(int64(600)))
+		Expect(usage.Limits.Tflops.Value()).To(Equal(int64(60)))
+		Expect(usage.Limits.Vram.Value()).To(Equal(int64(600)))
+	})
+
+	// Regression for the bug where AdjustAllocation only ran the namespace
+	// quota pre-check when the caller flagged scale-up — letting a
+	// limit-only growth (request flat) skip validation and push total
+	// limit usage past the quota cap.
+	It("should reject AdjustAllocation when limit-only growth would exceed total quota", func() {
+		scheme := runtime.NewScheme()
+		Expect(tfv1.AddToScheme(scheme)).To(Succeed())
+
+		// Total caps at 200/2000 — InitQuotaStore rejects quotas where limits < requests,
+		// so requests and limits must move together for the entry to be admitted.
+		quotaObj := createTestQuota(200, 2000, 10)
+		gpus := []tfv1.GPU{createAvailableGPU("gpu1", 500, 5000)}
+
+		testPool := createTestGPUPool()
+		allObjects := objectsFromGPUs(gpus)
+		allObjects = append(allObjects, testPool)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(allObjects...).
+			WithLists(&tfv1.GPUResourceQuotaList{Items: []tfv1.GPUResourceQuota{*quotaObj}}).
+			Build()
+
+		ctx := context.Background()
+		allocator := NewGpuAllocator(ctx, nil, fakeClient, 0)
+		initAllocator(allocator)
+
+		req := createAllocRequest(30, 300, 1)
+		req.PodMeta = podMeta
+		_, err := allocator.Alloc(req)
+		Expect(err).To(Succeed())
+
+		// Request stays flat; limit grows from 30 to 250 — past the 200 total cap.
+		_, _, _, err = allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+			PodUID: string(podMeta.UID),
+			NewRequest: tfv1.Resource{
+				Tflops: *resource.NewQuantity(30, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(300, resource.BinarySI),
+			},
+			NewLimit: tfv1.Resource{
+				Tflops: *resource.NewQuantity(250, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(2500, resource.BinarySI),
+			},
+		}, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("total.max.tflops.limit"))
+
+		// QuotaStore must not have absorbed the rejected change.
+		usage, exists := allocator.quotaStore.GetQuotaStatus(TestNamespace)
+		Expect(exists).To(BeTrue())
+		Expect(usage.Limits.Tflops.Value()).To(Equal(int64(30)))
+	})
+
+	// Regression for the bug where checkSingleQuotas was fed per-GPU deltas
+	// instead of absolute new values during adjust, so a workload whose new
+	// limit blew past single.MaxLimits could slip through whenever the delta
+	// itself stayed under the cap.
+	It("should reject AdjustAllocation when new absolute limit exceeds single.MaxLimits", func() {
+		scheme := runtime.NewScheme()
+		Expect(tfv1.AddToScheme(scheme)).To(Succeed())
+
+		quotaObj := createTestQuota(500, 5000, 10)
+		quotaObj.Spec.Single.MaxLimits = &tfv1.Resource{
+			Tflops: *resource.NewQuantity(100, resource.DecimalSI),
+			Vram:   *resource.NewQuantity(1000, resource.BinarySI),
+		}
+		gpus := []tfv1.GPU{createAvailableGPU("gpu1", 500, 5000)}
+
+		testPool := createTestGPUPool()
+		allObjects := objectsFromGPUs(gpus)
+		allObjects = append(allObjects, testPool)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(allObjects...).
+			WithLists(&tfv1.GPUResourceQuotaList{Items: []tfv1.GPUResourceQuota{*quotaObj}}).
+			Build()
+
+		ctx := context.Background()
+		allocator := NewGpuAllocator(ctx, nil, fakeClient, 0)
+		initAllocator(allocator)
+
+		req := createAllocRequest(50, 500, 1)
+		req.PodMeta = podMeta
+		_, err := allocator.Alloc(req)
+		Expect(err).To(Succeed())
+
+		// New limit 150 exceeds single.MaxLimits=100. The per-GPU delta would be 100,
+		// which equals the cap and would silently pass the old delta-vs-absolute compare.
+		_, _, _, err = allocator.AdjustAllocation(ctx, tfv1.AdjustRequest{
+			PodUID: string(podMeta.UID),
+			NewRequest: tfv1.Resource{
+				Tflops: *resource.NewQuantity(50, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(500, resource.BinarySI),
+			},
+			NewLimit: tfv1.Resource{
+				Tflops: *resource.NewQuantity(150, resource.DecimalSI),
+				Vram:   *resource.NewQuantity(500, resource.BinarySI),
+			},
+		}, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("single.max.tflops.limit"))
+	})
 })
 
 var _ = Describe("GPUAllocator Assume Commit Flow", func() {

--- a/internal/quota/quota_store.go
+++ b/internal/quota/quota_store.go
@@ -125,6 +125,50 @@ func (qs *QuotaStore) CheckTotalQuotaWithPreScheduled(req *tfv1.AllocRequest, to
 	return qs.checkTotalQuotas(entry, req, nil, toScheduleResource)
 }
 
+// CheckAdjustQuotaAvailable validates an in-place resource change to an existing
+// allocation. new* are the absolute per-GPU values after the change; old* are
+// the current per-GPU values. Single per-workload caps are checked against the
+// new absolute values (a delta is meaningless here); namespace totals are
+// checked against effectiveUsage + (new-old)*count without phantom-incrementing
+// the worker count.
+func (qs *QuotaStore) CheckAdjustQuotaAvailable(
+	req *tfv1.AllocRequest,
+	oldRequest tfv1.Resource,
+	oldLimit tfv1.Resource,
+) error {
+	qs.StoreMutex.RLock()
+	defer qs.StoreMutex.RUnlock()
+
+	entry, exists := qs.QuotaStore[req.WorkloadNameNamespace.Namespace]
+	if !exists {
+		return nil
+	}
+
+	// req carries the absolute new request/limit, so checkSingleQuotas compares
+	// them directly against single.MaxRequests / single.MaxLimits.
+	if err := qs.checkSingleQuotas(entry, req); err != nil {
+		return err
+	}
+
+	// For the namespace total check, swap to a delta-shaped request: checkTotalExceeded
+	// multiplies req.Request/Limit by Count and adds to current usage, so we need delta
+	// here, not absolute values. toAddResource is zeroed (instead of nil) so addWorkers
+	// defaults to 0 rather than 1 — adjusts don't add a worker.
+	deltaReqTflops := req.Request.Tflops.DeepCopy()
+	deltaReqTflops.Sub(oldRequest.Tflops)
+	deltaReqVram := req.Request.Vram.DeepCopy()
+	deltaReqVram.Sub(oldRequest.Vram)
+	deltaLimitTflops := req.Limit.Tflops.DeepCopy()
+	deltaLimitTflops.Sub(oldLimit.Tflops)
+	deltaLimitVram := req.Limit.Vram.DeepCopy()
+	deltaLimitVram.Sub(oldLimit.Vram)
+
+	deltaReq := *req
+	deltaReq.Request = tfv1.Resource{Tflops: deltaReqTflops, Vram: deltaReqVram}
+	deltaReq.Limit = tfv1.Resource{Tflops: deltaLimitTflops, Vram: deltaLimitVram}
+	return qs.checkTotalQuotas(entry, &deltaReq, nil, qs.Calculator.CreateZeroUsage())
+}
+
 func (qs *QuotaStore) AdjustQuota(namespace string, reqDelta tfv1.Resource, limitDelta tfv1.Resource) {
 	qs.StoreMutex.Lock()
 	defer qs.StoreMutex.Unlock()


### PR DESCRIPTION
Four related defects caused namespace quota usage to drift and let autoscaler-driven adjustments bypass quota enforcement:

1. AdjustAllocation passed per-GPU deltas to AdjustQuota without multiplying by GPU count, while the normal Alloc path multiplies via Calculator.IncreaseUsage. Multi-GPU workloads underreported usage on every scale event.
2. AdjustAllocation only returned the request delta; handler.go's patch-failure rollback used it to restore the limit too, drifting limit usage whenever request and limit scaled by different amounts.
3. The capacity + quota pre-check ran only when callers passed IsScaleUp=true, but isScaleUp was computed from request-only comparison. Recommendations that grew limits while leaving requests flat (cron / external / percentile recommenders all support this) skipped validation and slipped past total/single limit caps.
4. checkSingleQuotas was fed per-GPU deltas instead of absolute new values during adjust, so a new limit could exceed single.MaxLimits whenever the delta itself stayed under the cap.

Fixes:

- gpuallocator.AdjustAllocation now scales request/limit deltas by GPU count before AdjustQuota and returns both request and limit deltas so handler.go's rollback can restore each dimension independently.
- The pre-check (per-GPU capacity + namespace quota) runs unconditionally; the brittle IsScaleUp gate is gone. AdjustRequest keeps the IsScaleUp field as a deprecated no-op for source compatibility.
- New quota.QuotaStore.CheckAdjustQuotaAvailable validates per-workload caps against absolute new values and total caps against (new-old)*count with a zero toAddResource so workers aren't phantom-incremented.

Regression tests cover all four scenarios.