### PR TITLE
fix(quota/metrics): R1 + R14 observability/quota correctness fixes

### DIFF
--- a/config/samples/v1_gpuresourcequota.yaml
+++ b/config/samples/v1_gpuresourcequota.yaml
@@ -6,29 +6,30 @@ metadata:
 spec:
   # Total namespace limits (similar to ResourceQuotas)
   total:
-    requests.tflops: "1000"
-    requests.vram: "200Gi"
-    limits.tflops: "1500"
-    limits.vram: "300Gi"
-    workers: 100
+    requests:
+      tflops: "1000"
+      vram: "200Gi"
+    limits:
+      tflops: "1500"
+      vram: "300Gi"
+    maxWorkers: 100
     alertThresholdPercent: 90
-    
+
   # Per-workload limits (similar to LimitRanges)
   single:
-    max:
+    maxRequests:
       tflops: "200"
       vram: "40Gi"
-      workers: 10
-    min:
-      tflops: "100m"
-      vram: "256Mi"
-      workers: 1
-    default:
-      tflops: "1"
-      vram: "2Gi"
-    defaultRequest:
+    maxLimits:
+      tflops: "300"
+      vram: "60Gi"
+    maxGPUCount: 8
+    defaultRequests:
       tflops: "500m"
       vram: "1Gi"
+    defaultLimits:
+      tflops: "1"
+      vram: "2Gi"
 ---
 apiVersion: tensor-fusion.ai/v1
 kind: GPUResourceQuota
@@ -38,29 +39,30 @@ metadata:
 spec:
   # Total namespace limits for development
   total:
-    requests.tflops: "200"
-    requests.vram: "40Gi"
-    limits.tflops: "300"
-    limits.vram: "60Gi"
-    workers: 20
+    requests:
+      tflops: "200"
+      vram: "40Gi"
+    limits:
+      tflops: "300"
+      vram: "60Gi"
+    maxWorkers: 20
     alertThresholdPercent: 95
-    
+
   # Per-workload limits for development
   single:
-    max:
+    maxRequests:
       tflops: "50"
       vram: "8Gi"
-      workers: 5
-    min:
-      tflops: "50m"
-      vram: "128Mi"
-      workers: 1
-    default:
-      tflops: "500m"
-      vram: "1Gi"
-    defaultRequest:
+    maxLimits:
+      tflops: "80"
+      vram: "12Gi"
+    maxGPUCount: 2
+    defaultRequests:
       tflops: "250m"
       vram: "512Mi"
+    defaultLimits:
+      tflops: "500m"
+      vram: "1Gi"
 ---
 apiVersion: tensor-fusion.ai/v1
 kind: GPUResourceQuota
@@ -70,26 +72,27 @@ metadata:
 spec:
   # Total namespace limits for research
   total:
-    requests.tflops: "2000"
-    requests.vram: "400Gi"
-    limits.tflops: "3000"
-    limits.vram: "600Gi"
-    workers: 200
+    requests:
+      tflops: "2000"
+      vram: "400Gi"
+    limits:
+      tflops: "3000"
+      vram: "600Gi"
+    maxWorkers: 200
     alertThresholdPercent: 85
-    
+
   # Per-workload limits for research (more flexible)
   single:
-    max:
+    maxRequests:
       tflops: "500"
       vram: "80Gi"
-      workers: 20
-    min:
-      tflops: "200m"
-      vram: "512Mi"
-      workers: 1
-    default:
+    maxLimits:
+      tflops: "800"
+      vram: "120Gi"
+    maxGPUCount: 16
+    defaultRequests:
+      tflops: "1"
+      vram: "2Gi"
+    defaultLimits:
       tflops: "2"
       vram: "4Gi"
-    defaultRequest:
-      tflops: "1"
-      vram: "2Gi" 

--- a/internal/controller/tensorfusionworkload_controller.go
+++ b/internal/controller/tensorfusionworkload_controller.go
@@ -117,11 +117,16 @@ func (r *TensorFusionWorkloadReconciler) Reconcile(ctx context.Context, req ctrl
 	if err := r.Get(ctx, client.ObjectKey{Name: workload.Spec.PoolName}, pool); err != nil {
 		return ctrl.Result{}, fmt.Errorf("gpu pool(%s) does not exist", workload.Spec.PoolName)
 	}
-
 	// Create worker generator
+	var workerConfig *tfv1.WorkerConfig
+	var hypervisorConfig *tfv1.HypervisorConfig
+	if pool.Spec.ComponentConfig != nil {
+		workerConfig = pool.Spec.ComponentConfig.Worker
+		hypervisorConfig = pool.Spec.ComponentConfig.Hypervisor
+	}
 	workerGenerator := &worker.WorkerGenerator{
-		WorkerConfig:     pool.Spec.ComponentConfig.Worker,
-		HypervisorConfig: pool.Spec.ComponentConfig.Hypervisor,
+		WorkerConfig:     workerConfig,
+		HypervisorConfig: hypervisorConfig,
 	}
 
 	podTemplateHash, err := workerGenerator.PodTemplateHash(workload.Spec)

--- a/internal/metrics/connect.go
+++ b/internal/metrics/connect.go
@@ -134,6 +134,11 @@ func (t *TimeSeriesDB) SetTableTTL(ttl string) error {
 		&HypervisorGPUUsageMetrics{},
 		&PoolResourceMetrics{},
 		&GPUAllocationMetrics{},
+		// tf_gpu_metrics — per-GPU capacity/availability rows, a distinct schema
+		// from tf_gpu_usage (HypervisorGPUUsageMetrics). Omitting it from the
+		// dynamic TTL update pins its retention to the boot-time default while
+		// every other table reacts to runtime changes.
+		&GPUResourceMetrics{},
 	}
 	if t == nil || t.DB == nil {
 		return nil

--- a/internal/quota/calculator.go
+++ b/internal/quota/calculator.go
@@ -109,8 +109,8 @@ func (c *Calculator) IsAlertThresholdReached(availablePercent string, threshold 
 		// should not happen, default to "100"
 		return true
 	}
-	available, _ := strconv.ParseInt(availablePercent, 10, 64)
-	return available < minAvailablePercent
+	available, _ := strconv.ParseFloat(availablePercent, 64)
+	return available < float64(minAvailablePercent)
 }
 
 // CreateStandardConditions creates standard quota conditions
@@ -147,7 +147,7 @@ func (c *Calculator) CalculateConditions(availablePercent *tfv1.GPUResourceAvail
 		return []metav1.Condition{
 			{
 				Type:               constants.ConditionStatusTypeReady,
-				Status:             metav1.ConditionFalse,
+				Status:             metav1.ConditionTrue,
 				LastTransitionTime: now,
 				Reason:             "CapacitySufficient",
 				Message:            QuotaReadyAndCapacitySufficient,

--- a/internal/quota/quota_store.go
+++ b/internal/quota/quota_store.go
@@ -492,36 +492,44 @@ func (qs *QuotaStore) InitQuotaStore() error {
 
 // ValidateQuotaConfig validates quota configuration
 func (qs *QuotaStore) validateQuotaConfig(quota *tfv1.GPUResourceQuota) error {
-	// Check for negative values
-	if !quota.Spec.Total.Requests.Tflops.IsZero() && quota.Spec.Total.Requests.Tflops.Cmp(resource.Quantity{}) < 0 {
-		return fmt.Errorf("requests.tflops cannot be negative")
+	req := quota.Spec.Total.Requests
+	lim := quota.Spec.Total.Limits
+
+	if req != nil {
+		if !req.Tflops.IsZero() && req.Tflops.Cmp(resource.Quantity{}) < 0 {
+			return fmt.Errorf("requests.tflops cannot be negative")
+		}
+		if !req.Vram.IsZero() && req.Vram.Cmp(resource.Quantity{}) < 0 {
+			return fmt.Errorf("requests.vram cannot be negative")
+		}
 	}
-	if !quota.Spec.Total.Requests.Vram.IsZero() && quota.Spec.Total.Requests.Vram.Cmp(resource.Quantity{}) < 0 {
-		return fmt.Errorf("requests.vram cannot be negative")
+
+	if lim != nil {
+		if !lim.Tflops.IsZero() && lim.Tflops.Cmp(resource.Quantity{}) < 0 {
+			return fmt.Errorf("limits.tflops cannot be negative")
+		}
+		if !lim.Vram.IsZero() && lim.Vram.Cmp(resource.Quantity{}) < 0 {
+			return fmt.Errorf("limits.vram cannot be negative")
+		}
 	}
-	if !quota.Spec.Total.Limits.Tflops.IsZero() && quota.Spec.Total.Limits.Tflops.Cmp(resource.Quantity{}) < 0 {
-		return fmt.Errorf("limits.tflops cannot be negative")
-	}
-	if !quota.Spec.Total.Limits.Vram.IsZero() && quota.Spec.Total.Limits.Vram.Cmp(resource.Quantity{}) < 0 {
-		return fmt.Errorf("limits.vram cannot be negative")
-	}
+
 	if quota.Spec.Total.MaxWorkers != nil && *quota.Spec.Total.MaxWorkers < 0 {
 		return fmt.Errorf("workers cannot be negative")
 	}
 
-	// Validate limits >= requests
-	if !quota.Spec.Total.Requests.Tflops.IsZero() && !quota.Spec.Total.Limits.Tflops.IsZero() {
-		if quota.Spec.Total.Limits.Tflops.Cmp(quota.Spec.Total.Requests.Tflops) < 0 {
-			return fmt.Errorf("limits.tflops cannot be less than requests.tflops")
+	if req != nil && lim != nil {
+		if !req.Tflops.IsZero() && !lim.Tflops.IsZero() {
+			if lim.Tflops.Cmp(req.Tflops) < 0 {
+				return fmt.Errorf("limits.tflops cannot be less than requests.tflops")
+			}
 		}
-	}
-	if !quota.Spec.Total.Requests.Vram.IsZero() && !quota.Spec.Total.Limits.Vram.IsZero() {
-		if quota.Spec.Total.Limits.Vram.Cmp(quota.Spec.Total.Requests.Vram) < 0 {
-			return fmt.Errorf("limits.vram cannot be less than requests.vram")
+		if !req.Vram.IsZero() && !lim.Vram.IsZero() {
+			if lim.Vram.Cmp(req.Vram) < 0 {
+				return fmt.Errorf("limits.vram cannot be less than requests.vram")
+			}
 		}
 	}
 
-	// Validate alert threshold percentage range
 	if quota.Spec.Total.AlertThresholdPercent != nil {
 		threshold := *quota.Spec.Total.AlertThresholdPercent
 		if threshold < 0 || threshold > 100 {
@@ -669,9 +677,13 @@ func (e *QuotaExceededError) Error() string {
 
 // handleGPUQuotaCreate handles GPU quota creation events
 func (qs *QuotaStore) handleGPUQuotaCreate(ctx context.Context, gpuQuota *tfv1.GPUResourceQuota) {
+
 	log := log.FromContext(ctx)
 	key := gpuQuota.Namespace
-
+	if err := qs.validateQuotaConfig(gpuQuota); err != nil {
+		log.Error(err, "Invalid quota configuration, skipping", "namespace", key)
+		return
+	}
 	qs.StoreMutex.Lock()
 	defer qs.StoreMutex.Unlock()
 
@@ -707,6 +719,10 @@ func (qs *QuotaStore) handleGPUQuotaUpdate(ctx context.Context, gpuQuota *tfv1.G
 	log := log.FromContext(ctx)
 	key := gpuQuota.Namespace
 
+	if err := qs.validateQuotaConfig(gpuQuota); err != nil {
+		log.Error(err, "Invalid quota configuration update, skipping", "namespace", key)
+		return
+	}
 	qs.StoreMutex.Lock()
 	defer qs.StoreMutex.Unlock()
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -35,6 +35,11 @@ func (wg *WorkerGenerator) GenerateWorkerPod(
 	desiredMembers int32,
 ) (*v1.Pod, error) {
 	podTmpl := &v1.PodTemplate{}
+	if wg.WorkerConfig == nil || wg.WorkerConfig.PodTemplate == nil ||
+		len(wg.WorkerConfig.PodTemplate.Raw) == 0 {
+		return nil, fmt.Errorf("worker pod template is not configured in pool %s",
+			workload.Spec.PoolName)
+	}
 	err := json.Unmarshal(wg.WorkerConfig.PodTemplate.Raw, podTmpl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal pod template: %w", err)

--- a/pkg/hypervisor/metrics/metrics.go
+++ b/pkg/hypervisor/metrics/metrics.go
@@ -207,10 +207,10 @@ func (h *HypervisorMetricsRecorder) RecordWorkerMetrics(writer io.Writer) {
 			}
 
 			workloadName := "unknown"
-			// Try to get workload name from worker ID or pod name
-			if allocation.WorkerInfo != nil && allocation.WorkerInfo.WorkerUID != "" {
-				workloadName = allocation.WorkerInfo.WorkerUID
+			if allocation.WorkerInfo != nil && allocation.WorkerInfo.WorkloadName != "" {
+				workloadName = allocation.WorkerInfo.WorkloadName
 			}
+
 			enc.AddTag("workload", workloadName)
 			enc.AddTag("worker", workerUID)
 


### PR DESCRIPTION
Quota (R1):
- validateQuotaConfig: nil-guard optional Requests/Limits pointers to avoid panic at InitQuotaStore (R1-1)
- CalculateConditions: report ConditionTrue on the healthy-transition branch so quota Ready reflects actual state (R1-2)
- IsAlertThresholdReached: parse percentage as float to match the "X.XX" producer; ParseInt silently treated every non-empty quota as alarming (R1-3)
- handleGPUQuotaCreate/Update: run validateQuotaConfig before mutating store so informer events behave the same as startup init (R1-4)
- v1_gpuresourcequota.yaml: rewrite sample with the real CRD field names (requests/limits objects, maxWorkers, maxRequests/maxLimits, defaultRequests/defaultLimits); prior keys were silently pruned on apply (R1-5)

Metrics (R14):
- hypervisor tf_worker_usage: tag `workload` with WorkloadName (the TensorFusionWorkload CR name) instead of the pod UID (R14-1)
- SetTableTTL: include GPUResourceMetrics so tf_gpu_metrics honors the dynamic retention setting (R14-3)