### PR TITLE
fix(partition): R9-2 + R9-3 + R9-4 partition lifecycle fixes

### DIFF
--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -2958,46 +2958,39 @@ func (s *GpuAllocator) bindPartition(gpu *tfv1.GPU, req *tfv1.AllocRequest, sele
 	return nil
 }
 
-// deallocPartition handles partition deallocation for a single GPU in partitioned mode
+// deallocPartition handles partition deallocation for a single GPU in partitioned mode.
+// Callers guarantee request.PartitionTemplateID is non-empty, so we always compute the
+// release amount from the request's template — symmetric with the allocation path.
+// In partitioned mode req.Request.Tflops/Vram are typically zero (resources are fixed
+// by the template), so falling back to them would permanently shrink Available.
 func (s *GpuAllocator) deallocPartition(storeGPU *tfv1.GPU, request *tfv1.AllocRequest, gpu string) {
 	logger := log.FromContext(s.ctx)
-	// Find and remove the allocated partition using podUID as key
 	podUID := string(request.PodMeta.UID)
-	if storeGPU.Status.AllocatedPartitions != nil {
-		allocatedPartition, exists := storeGPU.Status.AllocatedPartitions[podUID]
-		if exists {
-			// Calculate partition resource usage from config (no overhead)
-			partitionTflops, partitionVram, err := CalculatePartitionResourceUsage(storeGPU.Status.Capacity.Tflops, storeGPU.Status.GPUModel, allocatedPartition.TemplateID)
-			if err != nil {
-				// Fallback: add back request resources if template not found in config
-				logger.Info("Partition template not found in config during deallocation, using request resources",
-					"gpu", gpu, "template", allocatedPartition.TemplateID, "error", err)
-				storeGPU.Status.Available.Tflops.Add(request.Request.Tflops)
-				storeGPU.Status.Available.Vram.Add(request.Request.Vram)
-			} else {
-				// Add back partition resources (no overhead)
-				storeGPU.Status.Available.Tflops.Add(partitionTflops)
-				storeGPU.Status.Available.Vram.Add(partitionVram)
-			}
 
-			// Remove partition from allocated partitions map using podUID
+	partitionTflops, partitionVram, err := CalculatePartitionResourceUsage(
+		storeGPU.Status.Capacity.Tflops, storeGPU.Status.GPUModel, request.PartitionTemplateID)
+	if err != nil {
+		// Template no longer in config (upgrade removed/renamed it). Skip the
+		// Available restore — the reconcile loop will rebuild Available from
+		// actual worker state. Still drop the in-memory partition entry so it
+		// doesn't linger.
+		logger.Info("[WARNING] partition template not in config at dealloc; skipping Available restore (will be reconciled)",
+			"gpu", gpu, "template", request.PartitionTemplateID, "error", err)
+		if storeGPU.Status.AllocatedPartitions != nil {
 			delete(storeGPU.Status.AllocatedPartitions, podUID)
-			logger.Info("Removed partition allocation",
-				"gpu", gpu,
-				"podUID", podUID,
-				"template", allocatedPartition.TemplateID)
-		} else {
-			logger.Info("Partition not found in allocated partitions during deallocation",
-				"gpu", gpu, "podUID", podUID)
-			// Fallback: add back request resources
-			storeGPU.Status.Available.Tflops.Add(request.Request.Tflops)
-			storeGPU.Status.Available.Vram.Add(request.Request.Vram)
 		}
-	} else {
-		// No allocated partitions map, fallback to request resources
-		storeGPU.Status.Available.Tflops.Add(request.Request.Tflops)
-		storeGPU.Status.Available.Vram.Add(request.Request.Vram)
+		return
 	}
+
+	storeGPU.Status.Available.Tflops.Add(partitionTflops)
+	storeGPU.Status.Available.Vram.Add(partitionVram)
+	if storeGPU.Status.AllocatedPartitions != nil {
+		delete(storeGPU.Status.AllocatedPartitions, podUID)
+	}
+	logger.Info("Removed partition allocation",
+		"gpu", gpu,
+		"podUID", podUID,
+		"template", request.PartitionTemplateID)
 }
 func (s *GpuAllocator) ComposeAllocationRequest(pod *v1.Pod) (*tfv1.AllocRequest, string, error) {
 	// allow Pods with no requests/limits to use TensorFusion, Pod webhook will ensure at least one request/limit is set

--- a/internal/gpuallocator/partitioned_scheduling.go
+++ b/internal/gpuallocator/partitioned_scheduling.go
@@ -64,9 +64,12 @@ func MatchPartitionTemplate(gpuStatus tfv1.GPUStatus, req *tfv1.AllocRequest) (*
 
 		var requestTflops float64
 		if !req.Request.ComputePercent.IsZero() {
-			if gpuCapacity, capExists := GetGPUCapacity(gpuModel); capExists {
-				requestTflops = utils.ComputePercentToTflops(gpuCapacity.Tflops, req.Request).AsApproximateFloat64()
+			gpuCapacity, capExists := GetGPUCapacity(gpuModel)
+			if !capExists {
+				return nil, fmt.Errorf("GPU capacity not found for model %s, cannot convert ComputePercent to TFLOPs for explicit template %s",
+					gpuModel, req.PartitionTemplateID)
 			}
+			requestTflops = utils.ComputePercentToTflops(gpuCapacity.Tflops, req.Request).AsApproximateFloat64()
 		} else {
 			requestTflops = req.Request.Tflops.AsApproximateFloat64()
 		}

--- a/pkg/hypervisor/worker/allocation.go
+++ b/pkg/hypervisor/worker/allocation.go
@@ -62,13 +62,22 @@ func (a *AllocationController) AllocateWorkerDevices(request *api.WorkerInfo) (*
 	// partitioned mode, call split device
 	isPartitioned := request.IsolationMode == tfv1.IsolationModePartitioned && request.PartitionTemplateID != ""
 
+	// Track partitions created in this call so we can release them on any
+	// subsequent failure. Without this, mid-loop / post-loop errors leave
+	// hardware partitions allocated with no entry in workerAllocations,
+	// so DeallocateWorker (triggered by pod deletion) finds nothing to clean
+	// and the partition stays orphaned until manual intervention.
+	var splittedPartitions []*api.DeviceInfo
+
 	for _, deviceUUID := range request.AllocatedDevices {
 		if device, exists := a.deviceController.GetDevice(deviceUUID); exists {
 			if isPartitioned {
 				deviceInfo, err := a.deviceController.SplitDevice(deviceUUID, request.PartitionTemplateID)
 				if err != nil {
+					a.rollbackSplits(splittedPartitions)
 					return nil, err
 				}
+				splittedPartitions = append(splittedPartitions, deviceInfo)
 				deviceInfos = append(deviceInfos, deviceInfo)
 			} else {
 				deviceInfos = append(deviceInfos, device)
@@ -85,6 +94,7 @@ func (a *AllocationController) AllocateWorkerDevices(request *api.WorkerInfo) (*
 		} else {
 			// Fatal errors (INTERNAL, OPERATION_FAILED, etc.) should block allocation
 			klog.Errorf("failed to get vendor mount libs for worker %s: %v", request.WorkerUID, err)
+			a.rollbackSplits(splittedPartitions)
 			return nil, err
 		}
 	}
@@ -136,6 +146,21 @@ func (a *AllocationController) AllocateWorkerDevices(request *api.WorkerInfo) (*
 		a.addDeviceAllocation(deviceUUID, allocation)
 	}
 	return allocation, nil
+}
+
+// rollbackSplits releases partitions that were created during a failed
+// allocation. Errors are logged best-effort; the caller is already returning
+// the original allocation error.
+func (a *AllocationController) rollbackSplits(splits []*api.DeviceInfo) {
+	for _, split := range splits {
+		if split == nil || split.ParentUUID == "" {
+			continue
+		}
+		if err := a.deviceController.RemovePartitionedDevice(split.UUID, split.ParentUUID); err != nil {
+			klog.Errorf("rollback partition %s on parent %s failed: %v",
+				split.UUID, split.ParentUUID, err)
+		}
+	}
 }
 
 // DeallocateWorker deallocates devices for a worker


### PR DESCRIPTION
- AllocateWorkerDevices: roll back already-split partitions when a later device split (or fatal mount-libs error) fails mid-loop. Previously the failure path returned without releasing the hardware partitions that had already been created, leaving them orphaned — DeallocateWorker on pod removal could not find them because workerAllocations was never populated for the failed call. (R9-2)
- deallocPartition: stop falling back to req.Request.Tflops/Vram when the partition's metadata is missing. In partitioned mode the user request is usually zero (resources are fixed by the template), so adding it back permanently shrinks Available. Compute the release amount from request.PartitionTemplateID (callers already guarantee it is non-empty); only when the template itself is no longer in config do we skip the Available restore and let the reconcile loop rebuild Available from worker state. (R9-3)
- MatchPartitionTemplate explicit-template branch: return an error when ComputePercent is requested but GPU capacity is missing from the config map, instead of silently treating the requested TFLOPs as zero (which made every template look "sufficient"). (R9-4)