### PR TITLE
fix(autoscaler): R7-3 + R7-4 + R7-5 robustness fixes

### DIFF
--- a/internal/autoscaler/recommender/percentile_recommender.go
+++ b/internal/autoscaler/recommender/percentile_recommender.go
@@ -234,7 +234,7 @@ func (p *PercentileRecommender) Recommend(ctx context.Context, workload *workloa
 			// Still update recommendation in status
 			return &RecResult{
 				Resources:        recommendation,
-				HasApplied:       false,
+				HasApplied:       true,
 				ScaleDownLocking: false,
 			}, nil
 		}

--- a/internal/autoscaler/recommender/recommender.go
+++ b/internal/autoscaler/recommender/recommender.go
@@ -39,7 +39,7 @@ func (r recommenderToRecResult) generateRecommendation() *tfv1.Resources {
 	}
 
 	if recommendation.IsZero() ||
-		(recommendation.Requests.Tflops.Cmp(minRes.Requests.Tflops) < 0 &&
+		(recommendation.Requests.Tflops.Cmp(minRes.Requests.Tflops) < 0 ||
 			recommendation.Requests.Vram.Cmp(minRes.Requests.Vram) < 0) {
 		return nil
 	}

--- a/internal/autoscaler/workload_metrics_loader.go
+++ b/internal/autoscaler/workload_metrics_loader.go
@@ -68,9 +68,9 @@ func (l *workloadMetricsLoader) addWorkload(ctx context.Context, workloadID Work
 	}
 
 	// Parse durations
-	initialDelay, _ := parseDurationOrDefault(asr.InitialDelayPeriod, 30*time.Minute)
-	evaluationInterval, _ := parseDurationOrDefault(asr.Interval, getDefaultEvaluationInterval())
-	historyDataPeriod, _ := parseDurationOrDefault(asr.HistoryDataPeriod, 2*time.Hour)
+	initialDelay := parseDurationOrDefault(asr.InitialDelayPeriod, 30*time.Minute)
+	evaluationInterval := parseDurationOrDefault(asr.Interval, getDefaultEvaluationInterval())
+	historyDataPeriod := parseDurationOrDefault(asr.HistoryDataPeriod, 2*time.Hour)
 
 	// Enforce 30-day max on HistoryDataPeriod
 	if historyDataPeriod > maxHistoryDataPeriod {
@@ -247,11 +247,17 @@ func (l *workloadMetricsLoader) loadRealtimeMetricsForWorkload(loaderState *work
 	return nil
 }
 
-func parseDurationOrDefault(durationStr string, defaultDuration time.Duration) (time.Duration, error) {
+func parseDurationOrDefault(durationStr string, defaultDuration time.Duration) time.Duration {
 	if durationStr == "" {
-		return defaultDuration, nil
+		return defaultDuration
 	}
-	return time.ParseDuration(durationStr)
+	d, err := time.ParseDuration(durationStr)
+	if err != nil {
+		log.Log.Info("invalid duration string, falling back to default",
+			"value", durationStr, "default", defaultDuration, "error", err)
+		return defaultDuration
+	}
+	return d
 }
 
 func getDefaultEvaluationInterval() time.Duration {


### PR DESCRIPTION
- parseDurationOrDefault: actually fall back to default on parse failure (previously returned (0, err) which the caller silently used, causing time.NewTicker(0) panic when users wrote invalid duration strings like "5min"); also log the bad value and chosen default. Drop the always-nil error return so callers don't have to discard it. (R7-3)
- percentile_recommender InsideUpdateThreshold branch: set HasApplied: true so the unwanted recommendation is no longer merged and applied to the workload, matching the "no update performed" semantics used by the LowConfidence branch. (R7-4)
- generateRecommendation: change the scale-down floor check from && to || so a cron-locked lower bound rejects the recommendation when EITHER resource would dip below the floor, not only when both do. (R7-5)