### PR TITLE
fix(connection): R12-4 + R12-6 webhook method + sample manifest

### DIFF
--- a/config/samples/v1_tensorfusionconnection.yaml
+++ b/config/samples/v1_tensorfusionconnection.yaml
@@ -7,10 +7,9 @@ metadata:
   name: tensorfusionconnection-sample
   namespace: tensor-fusion
 spec:
-  resources:
-    limits:
-      tflops: '100'
-      vram: 8Gi
-    requests:
-      tflops: '20'
-      vram: 9Gi
+  # Name of the TensorFusionWorkload that owns the worker pool this connection
+  # routes to. Must reference an existing TensorFusionWorkload in the same
+  # namespace.
+  workloadName: tensorfusionworkload-sample
+  # Name of the client Pod requesting GPU access through this connection.
+  clientPod: my-client-pod

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -702,7 +702,10 @@ func (m *TensorFusionPodMutator) assignClusterHostPortFromLeader(pod *corev1.Pod
 	}
 
 	urlStr := fmt.Sprintf("http://%s:%s/api/assign-host-port?podName=%s", leaderIP, operatorPort, pod.Name)
-	req, err := http.NewRequest("GET", urlStr, nil)
+	// Server-side registers this endpoint as POST in internal/server/server.go,
+	// so the request method must match — using GET here returned 405 Method Not
+	// Allowed on non-leader webhook replicas and blocked admission.
+	req, err := http.NewRequest("POST", urlStr, nil)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
- pod_webhook.go assignClusterHostPortFromLeader (R12-4): the /api/assign-host-port endpoint is registered as POST in internal/server/server.go but non-leader webhook replicas were issuing a GET against it, so every host-port assignment on a non-leader replica failed with 405 and blocked pod admission. Switch the client to POST to match the server route.
- v1_tensorfusionconnection.yaml (R12-6): the previous sample only set a spec.resources block which doesn't exist on TensorFusionConnectionSpec (the schema has workloadName + clientPod). Apply would either drop the entire spec via schema pruning or fail CRD validation. Rewrite the sample with the real required fields.