### PR TITLE
fix(expander): R13-1..4 + R13-7 node provisioning correctness

### DIFF
--- a/config/samples/v1_gpunodeclaim.yaml
+++ b/config/samples/v1_gpunodeclaim.yaml
@@ -4,6 +4,35 @@ metadata:
   labels:
     app.kubernetes.io/name: tensor-fusion
     app.kubernetes.io/managed-by: kustomize
+    # The pool that owns this claim. The GPUPool reconciler reads this label
+    # to associate the claim back to its pool.
+    tensor-fusion.ai/owner: gpupool-sample
   name: gpunodeclaim-sample
 spec:
-  # TODO(user): Add fields here
+  # Desired node name; defaults to a generated name if omitted.
+  nodeName: gpu-node-1
+
+  # Cloud-provider placement.
+  region: us-east-1
+  zone: us-east-1a
+  instanceType: g5.xlarge
+  # Capacity type: OnDemand | Reserved | Spot
+  capacityType: OnDemand
+
+  # Reference to the GPUNodeClass that supplies launch-template / image /
+  # security-group settings for this instance.
+  nodeClassRef:
+    group: tensor-fusion.ai
+    version: v1
+    kind: GPUNodeClass
+    name: gpunodeclass-sample
+
+  # Resources this single node is expected to offer once it comes online.
+  # These are required fields on the CRD; the reconciler uses them to update
+  # the pool's available capacity once the node is registered.
+  tflopsOffered: "70"
+  vramOffered: 24Gi
+  gpuDeviceOffered: 1
+
+  # Optional provider-specific parameters (e.g. user-data, custom tags).
+  extraParams: {}

--- a/internal/cloudprovider/alibaba/ecs.go
+++ b/internal/cloudprovider/alibaba/ecs.go
@@ -31,6 +31,7 @@ func NewAlibabaGPUNodeProvider(ctx context.Context, config tfv1.ComputingVendorC
 
 	if cachedClient != nil {
 		provider.client = cachedClient
+		provider.nodeClass = nodeClass
 		return provider, nil
 	}
 

--- a/internal/cloudprovider/aws/ec2.go
+++ b/internal/cloudprovider/aws/ec2.go
@@ -78,11 +78,16 @@ func (p AWSGPUNodeProvider) CreateNode(ctx context.Context, param *tfv1.GPUNodeC
 			},
 		},
 	}
-	_, err := p.ec2Client.RunInstances(ctx, input)
+	output, err := p.ec2Client.RunInstances(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create instance: %w", err)
 	}
-	return &types.GPUNodeStatus{}, nil
+	if output == nil || len(output.Instances) == 0 {
+		return nil, fmt.Errorf("RunInstances returned no instances")
+	}
+	return &types.GPUNodeStatus{
+		InstanceID: aws.ToString(output.Instances[0].InstanceId),
+	}, nil
 }
 
 func (p AWSGPUNodeProvider) TerminateNode(ctx context.Context, param *types.NodeIdentityParam) error {

--- a/internal/cloudprovider/karpenter/nodeclaim.go
+++ b/internal/cloudprovider/karpenter/nodeclaim.go
@@ -37,8 +37,8 @@ var (
 	// CapacityTypeMapping maps the CapacityTypeEnum to the corresponding Karpenter capacity type
 	CapacityTypeMapping = map[tfv1.CapacityTypeEnum]string{
 		tfv1.CapacityTypeOnDemand: AWSOnDemandType,
-		tfv1.CapacityTypeSpot:     AWSReservedType,
-		tfv1.CapacityTypeReserved: AWSSpotType,
+		tfv1.CapacityTypeSpot:     AWSSpotType,
+		tfv1.CapacityTypeReserved: AWSReservedType,
 	}
 )
 

--- a/internal/controller/gpunodeclaim_controller.go
+++ b/internal/controller/gpunodeclaim_controller.go
@@ -71,6 +71,12 @@ func (r *GPUNodeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	provider, cluster, err := createProvisionerAndQueryCluster(ctx, pool, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if cluster == nil {
+		return ctrl.Result{}, fmt.Errorf("cluster is nil after createProvisionerAndQueryCluster")
+	}
 	vendorCfg := cluster.Spec.ComputingVendor
 	if vendorCfg == nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get computing vendor config for cluster %s", cluster.Name)


### PR DESCRIPTION
- karpenter/nodeclaim.go CapacityTypeMapping (R13-3): Spot and Reserved were mapped to each other's Karpenter strings, so users asking for a Spot pool got Reserved instances (paying multiples) and vice versa. Swap the two mapping values to their correct Karpenter labels.
- aws/ec2.go CreateNode (R13-2): the RunInstances response (which carries the new InstanceID) was discarded with `_`. Each subsequent reconcile would re-create the instance because tensor-fusion had no record of the previous one, and TerminateNode could never find an InstanceID to release, leaving orphan EC2 instances. Capture the output and return the InstanceID in GPUNodeStatus.
- gpunodeclaim_controller.go Reconcile (R13-1): the err and nil cluster cases from createProvisionerAndQueryCluster were ignored, then the next line dereferenced cluster.Spec.ComputingVendor and panicked. Bail out on err or nil cluster before the deref.
- alibaba/ecs.go NewAlibabaGPUNodeProvider (R13-4): the cached-client path returned without populating provider.nodeClass, so the second and subsequent constructions of the Alibaba provider would panic in CreateNode at p.nodeClass.Spec. Set nodeClass in the cached path too.
- config/samples/v1_gpunodeclaim.yaml (R13-7): the sample shipped with an empty spec ("TODO(user): Add fields here") even though tflopsOffered, vramOffered and gpuDeviceOffered are required fields, so `kubectl apply -f` of the sample failed CRD validation. Replace with a complete, working example covering placement, nodeClassRef and required capacity fields.