### PR TITLE
fix(defrag): keep MaxDuration window active across idle reconciles

### DIFF
--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -62,6 +62,20 @@ const (
 
 	defragStatusPersistTimeout = 30 * time.Second
 	defragActiveStepRequeue    = 10 * time.Second
+	// defragInWindowIdleRequeue keeps reconciles cheap-but-frequent inside
+	// an active campaign window when there is nothing to evict yet (no
+	// candidates / all skipped). Without this, a long compaction Period
+	// (e.g. 8m) would shadow a 60m defrag window and we'd evaluate the
+	// pool at most a handful of times per campaign.
+	//
+	// Trade-off: hard-coded so very short MaxDuration values (< 10m) get a
+	// fixed ~60s cadence and very long ones (> 1h) re-evaluate more often
+	// than strictly necessary. Both ends are acceptable: each retry is a
+	// candidate filter pass + a no-op when nothing changed. If operators
+	// ever observe excessive defrag controller traffic on a pool with a
+	// multi-hour window, the right fix is to expose this as a config field
+	// rather than chase a derived heuristic.
+	defragInWindowIdleRequeue = 60 * time.Second
 )
 
 const (
@@ -206,16 +220,7 @@ func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, po
 	if campaign.skipMissed {
 		logger.Info("defrag campaign expired before this reconcile; skipping missed schedule window",
 			"advancedAnchor", campaign.start, "maxDuration", maxDuration)
-		persistCtx, persistCancel := context.WithTimeout(ctx, defragStatusPersistTimeout)
-		defer persistCancel()
-		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaign.start); err != nil {
-			logger.Error(err, "failed to patch pool.Status.LastDefragTime after expired defrag campaign")
-		}
-		// A missed window counts as a finished cycle, so drop the
-		// campaign-scoped evict-skip list before the next tick.
-		if err := r.clearAllDefragEvictSkipMarkersForPool(persistCtx, pool); err != nil {
-			logger.Error(err, "failed to clear defrag evict-skip markers after expired defrag campaign")
-		}
+		r.advanceCampaignAnchor(ctx, pool, campaign.start, defragFinishReasonSkipMissed)
 		return 0
 	}
 
@@ -227,23 +232,57 @@ func (r *GPUPoolCompactionReconciler) maybeRunDefragStep(ctx context.Context, po
 	}
 	defer flag.Store(false)
 
-	runCtx, cancel := context.WithDeadline(ctx, campaign.start.Add(maxDuration))
+	deadline := campaign.start.Add(maxDuration)
+	runCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 	result := r.runDefragStep(runCtx, pool.DeepCopy(), campaign.start)
-	if result.finishCampaign {
-		persistCtx, persistCancel := context.WithTimeout(ctx, defragStatusPersistTimeout)
-		defer persistCancel()
-		if err := r.patchPoolLastDefragTime(persistCtx, pool, campaign.start); err != nil {
-			logger.Error(err, "failed to patch pool.Status.LastDefragTime after defrag step")
-		}
-		// Reset the campaign-scoped evict-skip list. Stuck workers will
-		// re-trigger the marker on the next campaign, but defrag is never
-		// permanently blind to them.
-		if err := r.clearAllDefragEvictSkipMarkersForPool(persistCtx, pool); err != nil {
-			logger.Error(err, "failed to clear defrag evict-skip markers after defrag campaign")
-		}
+
+	if reason, advance := decideDefragCampaignProgress(result, time.Now(), deadline); advance {
+		r.advanceCampaignAnchor(ctx, pool, campaign.start, reason)
 	}
 	return defragRequeueAfter(result, normalRequeue)
+}
+
+// decideDefragCampaignProgress decides whether one defrag step should close
+// the current campaign window (advance LastDefragTime + clear pool-scoped
+// evict-skip markers). The core invariant: idle in-window passes
+// (noCandidates / allSkipped) MUST NOT advance the anchor, because doing
+// so closes the entire MaxDuration window after the first idle pass and
+// the remaining minutes go silent (the regression that motivated the
+// rewrite: a 60m window observed going dark for 59 minutes after the
+// first reconcile inside it). Only a real Deadline outcome or a wall
+// clock that has already crossed the deadline closes the campaign.
+func decideDefragCampaignProgress(result defragStepResult, now, deadline time.Time) (defragFinishReason, bool) {
+	if result.finishReason == defragFinishReasonDeadline {
+		return defragFinishReasonDeadline, true
+	}
+	if now.After(deadline) {
+		return defragFinishReasonWindowClosed, true
+	}
+	return defragFinishReasonNone, false
+}
+
+// advanceCampaignAnchor persists pool.Status.LastDefragTime and drops the
+// pool-scoped evict-skip markers, marking the end of a campaign. Both
+// operations are best-effort: a failure here just means the next campaign
+// gets a chance sooner / works through one stuck node again, neither of
+// which is harmful.
+func (r *GPUPoolCompactionReconciler) advanceCampaignAnchor(
+	ctx context.Context,
+	pool *tfv1.GPUPool,
+	campaignStart time.Time,
+	reason defragFinishReason,
+) {
+	logger := log.FromContext(ctx).WithValues("pool", pool.Name, "component", "defrag",
+		"campaignStart", campaignStart, "reason", reason.String())
+	persistCtx, persistCancel := context.WithTimeout(ctx, defragStatusPersistTimeout)
+	defer persistCancel()
+	if err := r.patchPoolLastDefragTime(persistCtx, pool, campaignStart); err != nil {
+		logger.Error(err, "failed to patch pool.Status.LastDefragTime after defrag campaign end")
+	}
+	if err := r.clearAllDefragEvictSkipMarkersForPool(persistCtx, pool); err != nil {
+		logger.Error(err, "failed to clear defrag evict-skip markers after defrag campaign end")
+	}
 }
 
 type defragSchedule interface {
@@ -358,20 +397,88 @@ func sourceNodeMarkerTTL(cfg *tfv1.NodeDefragConfig, logger interface{ Info(stri
 
 // ----- main run ---------------------------------------------------------
 
-type defragStepResult struct {
-	evictedNode         bool
-	finishCampaign      bool
-	blockedByEvictedPod bool
-	blockedBySourceNode bool
+// defragFinishReason explains *why* a defrag step ended.
+//
+// Within a step result it's only meaningful when finishCampaign is true:
+// the caller uses it to decide whether to advance pool.Status.LastDefragTime
+// (Deadline closes the window; NoCandidates / AllSkipped do not, so the
+// next reconcile inside the same window re-scans).
+//
+// SkipMissed and WindowClosed are produced by the caller, not by a step.
+// They share the same type so advanceCampaignAnchor takes one strongly
+// typed reason for logging instead of a free-form string.
+type defragFinishReason int
+
+const (
+	defragFinishReasonNone defragFinishReason = iota
+	defragFinishReasonDeadline
+	defragFinishReasonNoCandidates
+	defragFinishReasonAllSkipped
+	defragFinishReasonSkipMissed
+	defragFinishReasonWindowClosed
+)
+
+func (r defragFinishReason) String() string {
+	switch r {
+	case defragFinishReasonDeadline:
+		return "deadline"
+	case defragFinishReasonNoCandidates:
+		return "noCandidates"
+	case defragFinishReasonAllSkipped:
+		return "allSkipped"
+	case defragFinishReasonSkipMissed:
+		return "skipMissed"
+	case defragFinishReasonWindowClosed:
+		return "windowClosed"
+	default:
+		return "none"
+	}
 }
 
+type defragStepResult struct {
+	evictedNode         bool
+	abortedNode         bool
+	finishCampaign      bool
+	finishReason        defragFinishReason
+	blockedByEvictedPod bool
+	blockedBySourceNode bool
+	// idleStep is true when this step did neither evict nor abort: candidates
+	// were either absent (noCandidates) or all skipped (allSkipped). Used to
+	// dedupe DefragStarted/DefragFinished noise across in-window retries.
+	idleStep bool
+}
+
+// defragRequeueAfter picks how soon the controller should come back, picking
+// the tightest of three tiers:
+//
+//   - active (evicted / aborted / blocked): something happened this step and
+//     the next step should follow immediately (~10s) so the campaign drains
+//     candidates without waiting for the compaction cron.
+//   - idle in-window (noCandidates / allSkipped): nothing changed but we
+//     must not let the compaction Period (e.g. 8m) shadow the defrag
+//     MaxDuration window (e.g. 60m). A finishReason of Deadline means the
+//     window is already closed, so idle requeue does not apply there.
+//   - default: the caller's normal compaction interval.
+//
+// Reading the tier off result alone (instead of an extra "campaignActive"
+// parameter) accepts one tiny degeneracy: an idle pass that finished a few
+// ms before wall-clock crossed the deadline will fast-requeue once; the
+// next reconcile then sees the cron has advanced and goes quiet.
 func defragRequeueAfter(result defragStepResult, normalRequeue time.Duration) time.Duration {
 	if normalRequeue <= 0 {
 		normalRequeue = defaultCompactionDuration
 	}
-	if result.evictedNode || result.blockedByEvictedPod || result.blockedBySourceNode {
+	switch {
+	case result.evictedNode,
+		result.abortedNode,
+		result.blockedByEvictedPod,
+		result.blockedBySourceNode:
 		if defragActiveStepRequeue < normalRequeue {
 			return defragActiveStepRequeue
+		}
+	case result.idleStep && result.finishReason != defragFinishReasonDeadline:
+		if defragInWindowIdleRequeue < normalRequeue {
+			return defragInWindowIdleRequeue
 		}
 	}
 	return normalRequeue
@@ -380,19 +487,35 @@ func defragRequeueAfter(result defragStepResult, normalRequeue time.Duration) ti
 // runDefragStep evicts at most one source node within the campaign deadline.
 // Caller must have already run the safety sweep and confirmed guards are
 // clear; this function does not repeat them.
+//
+// Idle steps (no candidates / all skipped) suppress Started/Finished events:
+// reconciles fire ~1/min inside an active campaign window, and emitting
+// every pass would drown out real DefragPodEvicted/DefragAbortNode signals
+// in `kubectl describe gpupool`. Real activity (eviction, abort, deadline)
+// always still produces events via the regular paths.
 func (r *GPUPoolCompactionReconciler) runDefragStep(
 	ctx context.Context,
 	pool *tfv1.GPUPool,
 	runStart time.Time,
 ) defragStepResult {
 	l := log.FromContext(ctx).WithValues("pool", pool.Name, "component", "defrag", "runStart", runStart)
-	r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventStarted,
-		"defrag step started at %s", runStart.Format(time.RFC3339))
 
 	stats := &defragRunStats{StartTime: runStart}
+	startedAnnounced := false
+	announceStart := func() {
+		if startedAnnounced {
+			return
+		}
+		startedAnnounced = true
+		r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventStarted,
+			"defrag step started at %s", runStart.Format(time.RFC3339))
+	}
 	defer func() {
 		stats.EndTime = time.Now()
 		defragLastRunStats.Store(pool.Name, stats)
+		if !startedAnnounced {
+			return
+		}
 		r.Recorder.Eventf(pool, corev1.EventTypeNormal, defragEventFinished,
 			"defrag step finished: candidates=%d processed=%d evicted=%d failed=%d unmovable=%d pdbBlocked=%d missingPdb=%d freshSkip=%d deadline=%t",
 			stats.CandidateNodes, stats.ProcessedNodes, stats.EvictedPods, stats.EvictionFailures,
@@ -406,16 +529,23 @@ func (r *GPUPoolCompactionReconciler) runDefragStep(
 	}
 	stats.CandidateNodes = len(candidates)
 	if len(candidates) == 0 {
-		l.Info("no defrag candidates")
-		return defragStepResult{finishCampaign: true}
+		l.V(4).Info("no defrag candidates")
+		return defragStepResult{
+			finishCampaign: true,
+			finishReason:   defragFinishReasonNoCandidates,
+			idleStep:       true,
+		}
 	}
+
+	// Past this point we will do real work (or at least scan candidates).
+	announceStart()
 
 	maxWorkerPerNode := r.Allocator.MaxWorkerPerNode()
 	result := runDefragCandidateLoop(ctx, candidates, stats, func(cand *defragCandidate) defragCandidateOutcome {
 		return r.processDefragCandidate(ctx, pool, cand, maxWorkerPerNode, stats)
 	})
-	if stats.DeadlineExceeded {
-		l.Info("defrag deadline exceeded during candidate loop", "remaining", len(candidates)-stats.ProcessedNodes)
+	if result.finishReason == defragFinishReasonDeadline {
+		l.Info("defrag deadline exceeded", "remaining", len(candidates)-stats.ProcessedNodes)
 	}
 	return result
 }
@@ -438,7 +568,10 @@ func runDefragCandidateLoop(
 	for _, cand := range candidates {
 		if ctxDone(ctx) {
 			stats.DeadlineExceeded = true
-			return defragStepResult{finishCampaign: true}
+			return defragStepResult{
+				finishCampaign: true,
+				finishReason:   defragFinishReasonDeadline,
+			}
 		}
 		stats.ProcessedNodes++
 		switch process(cand) {
@@ -447,10 +580,26 @@ func runDefragCandidateLoop(
 		case defragCandidateEvicted:
 			return defragStepResult{evictedNode: true}
 		case defragCandidateAborted:
-			return defragStepResult{}
+			return defragStepResult{abortedNode: true}
+		case defragCandidateDeadline:
+			// process(...) already set stats.DeadlineExceeded; close the
+			// campaign so the caller advances LastDefragTime instead of
+			// re-entering the same expired window on the next reconcile.
+			return defragStepResult{
+				finishCampaign: true,
+				finishReason:   defragFinishReasonDeadline,
+			}
 		}
 	}
-	return defragStepResult{finishCampaign: true}
+	// All candidates were skipped. This is "idle" because nothing changed
+	// on cluster: maybeRunDefragStep must not advance LastDefragTime, but
+	// the next reconcile should still come back within the same campaign
+	// window in case a PDB recovers or a fresh pod ages out.
+	return defragStepResult{
+		finishCampaign: true,
+		finishReason:   defragFinishReasonAllSkipped,
+		idleStep:       true,
+	}
 }
 
 // ----- candidate filtering + sorting ------------------------------------
@@ -920,6 +1069,12 @@ const (
 	defragCandidateSkipped defragCandidateOutcome = iota
 	defragCandidateEvicted
 	defragCandidateAborted
+	// defragCandidateDeadline distinguishes "context deadline hit mid-eviction"
+	// from a real abort. The loop must close the campaign with finishReason=
+	// Deadline so the caller advances LastDefragTime; otherwise the next
+	// reconcile would re-enter the same already-expired window and loop on
+	// a no-op until something else moved.
+	defragCandidateDeadline
 )
 
 func (r *GPUPoolCompactionReconciler) processDefragCandidate(
@@ -981,6 +1136,13 @@ func (r *GPUPoolCompactionReconciler) processDefragCandidate(
 
 	if r.evictWorkerPods(ctx, pool, cand, stats, l) {
 		return defragCandidateEvicted
+	}
+	// evictWorkerPods sets stats.DeadlineExceeded when ctx is done; surface
+	// that as a deadline outcome (not an abort) so the loop closes the
+	// campaign properly and we don't emit a misleading "eviction aborted"
+	// event for what is really a timeout.
+	if stats.DeadlineExceeded {
+		return defragCandidateDeadline
 	}
 	r.Recorder.Eventf(pool, corev1.EventTypeWarning, defragEventAbortNode,
 		"node %s: eviction aborted", cand.nodeName)

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -1110,6 +1110,14 @@ func TestRunDefragStep_NoCandidatesFinishesCampaign(t *testing.T) {
 	if result.evictedNode {
 		t.Fatalf("empty defrag step should not evict a node")
 	}
+	// Reason must be noCandidates so the upper layer does NOT advance
+	// LastDefragTime - the window stays open for subsequent reconciles.
+	if result.finishReason != defragFinishReasonNoCandidates {
+		t.Fatalf("finishReason=%v want noCandidates", result.finishReason)
+	}
+	if !result.idleStep {
+		t.Fatalf("no-candidate step must be marked idle to keep events quiet")
+	}
 }
 
 func TestEvaluateDefragGuards_BlockedByActiveEvictedPod(t *testing.T) {
@@ -1327,19 +1335,67 @@ func TestSafetySweepAndGuards_KeepsDefragSourceNodeMarkerWithActiveWorker(t *tes
 	}
 }
 
-func TestDefragRequeueAfter_ContinuesActiveCampaignQuickly(t *testing.T) {
-	result := defragStepResult{evictedNode: true}
-	got := defragRequeueAfter(result, 30*time.Minute)
-	if got <= 0 || got >= 30*time.Minute {
-		t.Fatalf("active defrag campaign should requeue quickly, got %s", got)
-	}
+func TestDefragRequeueAfter_TierSelection(t *testing.T) {
+	const normal = 30 * time.Minute
 
-	if got := defragRequeueAfter(defragStepResult{finishCampaign: true}, 30*time.Minute); got != 30*time.Minute {
-		t.Fatalf("finished campaign should use normal compaction period, got %s", got)
+	cases := []struct {
+		name   string
+		result defragStepResult
+		want   time.Duration
+	}{
+		{
+			name:   "evicted node requeues at active interval",
+			result: defragStepResult{evictedNode: true},
+			want:   defragActiveStepRequeue,
+		},
+		{
+			name:   "aborted node requeues at active interval (retry fast)",
+			result: defragStepResult{abortedNode: true},
+			want:   defragActiveStepRequeue,
+		},
+		{
+			name:   "source-node block requeues at active interval",
+			result: defragStepResult{blockedBySourceNode: true},
+			want:   defragActiveStepRequeue,
+		},
+		{
+			name:   "evicted-pod block requeues at active interval",
+			result: defragStepResult{blockedByEvictedPod: true},
+			want:   defragActiveStepRequeue,
+		},
+		{
+			name: "in-window idle (noCandidates) requeues at idle interval",
+			result: defragStepResult{
+				finishCampaign: true,
+				finishReason:   defragFinishReasonNoCandidates,
+				idleStep:       true,
+			},
+			want: defragInWindowIdleRequeue,
+		},
+		{
+			name: "in-window idle (allSkipped) requeues at idle interval",
+			result: defragStepResult{
+				finishCampaign: true,
+				finishReason:   defragFinishReasonAllSkipped,
+				idleStep:       true,
+			},
+			want: defragInWindowIdleRequeue,
+		},
+		{
+			name: "deadline-finish falls back to normal compaction period",
+			result: defragStepResult{
+				finishCampaign: true,
+				finishReason:   defragFinishReasonDeadline,
+			},
+			want: normal,
+		},
 	}
-
-	if got := defragRequeueAfter(defragStepResult{blockedBySourceNode: true}, 30*time.Minute); got != defragActiveStepRequeue {
-		t.Fatalf("source-node block should requeue quickly, got %s", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := defragRequeueAfter(tc.result, normal); got != tc.want {
+				t.Fatalf("requeue=%s want %s", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -1869,6 +1925,12 @@ func TestRunDefragCandidateLoop_StopsAfterFirstEvictedNode(t *testing.T) {
 	if result.finishCampaign {
 		t.Fatalf("evicting one node should not finish the campaign")
 	}
+	if result.finishReason != defragFinishReasonNone {
+		t.Fatalf("eviction outcome should carry no finishReason, got %v", result.finishReason)
+	}
+	if result.idleStep {
+		t.Fatalf("eviction outcome must not be idle")
+	}
 	if stats.ProcessedNodes != 1 {
 		t.Fatalf("processedNodes=%d want 1", stats.ProcessedNodes)
 	}
@@ -1901,6 +1963,185 @@ func TestRunDefragCandidateLoop_SkipsAndContinuesToNextCandidate(t *testing.T) {
 	}
 	if fmt.Sprint(visited) != "[node-a node-b]" {
 		t.Fatalf("visited=%v", visited)
+	}
+}
+
+func TestRunDefragCandidateLoop_AllSkippedReportsAllSkippedReason(t *testing.T) {
+	candidates := []*defragCandidate{
+		{nodeName: testDefragNodeA},
+		{nodeName: "node-b"},
+	}
+	stats := &defragRunStats{}
+	result := runDefragCandidateLoop(context.Background(), candidates, stats, func(_ *defragCandidate) defragCandidateOutcome {
+		return defragCandidateSkipped
+	})
+	if !result.finishCampaign {
+		t.Fatalf("all-skipped should finish the campaign loop")
+	}
+	if result.finishReason != defragFinishReasonAllSkipped {
+		t.Fatalf("finishReason=%v want allSkipped", result.finishReason)
+	}
+	if !result.idleStep {
+		t.Fatalf("all-skipped must be marked idle (no cluster mutation happened)")
+	}
+	if stats.ProcessedNodes != len(candidates) {
+		t.Fatalf("processedNodes=%d want %d", stats.ProcessedNodes, len(candidates))
+	}
+}
+
+func TestRunDefragCandidateLoop_CtxDoneReportsDeadlineReason(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stats := &defragRunStats{}
+	result := runDefragCandidateLoop(ctx, []*defragCandidate{
+		{nodeName: testDefragNodeA},
+		{nodeName: "node-b"},
+	}, stats, func(_ *defragCandidate) defragCandidateOutcome {
+		t.Fatalf("process should not be invoked when ctx is already done")
+		return defragCandidateSkipped
+	})
+	if !result.finishCampaign {
+		t.Fatalf("ctx-done should finish the campaign loop")
+	}
+	if result.finishReason != defragFinishReasonDeadline {
+		t.Fatalf("finishReason=%v want deadline", result.finishReason)
+	}
+	if !stats.DeadlineExceeded {
+		t.Fatalf("stats.DeadlineExceeded must be set on ctx-done")
+	}
+	if result.idleStep {
+		t.Fatalf("deadline outcome is not idle (campaign actually closed)")
+	}
+}
+
+// TestDecideDefragCampaignProgress_WindowKeepsRetryingUntilDeadline verifies
+// the core regression fix: in-window idle outcomes (noCandidates /
+// allSkipped) MUST NOT advance the anchor, so subsequent reconciles inside
+// the same MaxDuration window keep rescanning instead of going dark for
+// the rest of the window.
+func TestDecideDefragCampaignProgress_WindowKeepsRetryingUntilDeadline(t *testing.T) {
+	campaignStart := time.Date(2026, 5, 25, 1, 0, 0, 0, time.UTC)
+	maxDuration := 60 * time.Minute
+	deadline := campaignStart.Add(maxDuration)
+
+	cases := []struct {
+		name        string
+		result      defragStepResult
+		now         time.Time
+		wantAdvance bool
+		wantReason  defragFinishReason
+	}{
+		{
+			name:        "noCandidates inside window keeps anchor",
+			result:      defragStepResult{finishCampaign: true, finishReason: defragFinishReasonNoCandidates, idleStep: true},
+			now:         campaignStart.Add(5 * time.Minute),
+			wantAdvance: false,
+			wantReason:  defragFinishReasonNone,
+		},
+		{
+			name:        "allSkipped inside window keeps anchor",
+			result:      defragStepResult{finishCampaign: true, finishReason: defragFinishReasonAllSkipped, idleStep: true},
+			now:         campaignStart.Add(30 * time.Minute),
+			wantAdvance: false,
+			wantReason:  defragFinishReasonNone,
+		},
+		{
+			name:        "evictedNode never advances anchor (next reconcile resumes)",
+			result:      defragStepResult{evictedNode: true},
+			now:         campaignStart.Add(15 * time.Minute),
+			wantAdvance: false,
+			wantReason:  defragFinishReasonNone,
+		},
+		{
+			name:        "abortedNode never advances anchor (next reconcile retries)",
+			result:      defragStepResult{abortedNode: true},
+			now:         campaignStart.Add(15 * time.Minute),
+			wantAdvance: false,
+			wantReason:  defragFinishReasonNone,
+		},
+		{
+			name:        "deadline outcome advances anchor",
+			result:      defragStepResult{finishCampaign: true, finishReason: defragFinishReasonDeadline},
+			now:         campaignStart.Add(60 * time.Minute),
+			wantAdvance: true,
+			wantReason:  defragFinishReasonDeadline,
+		},
+		{
+			name:        "wall-clock past deadline advances anchor even on idle outcome",
+			result:      defragStepResult{finishCampaign: true, finishReason: defragFinishReasonAllSkipped, idleStep: true},
+			now:         deadline.Add(time.Second),
+			wantAdvance: true,
+			wantReason:  defragFinishReasonWindowClosed,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotReason, gotAdvance := decideDefragCampaignProgress(tc.result, tc.now, deadline)
+			if gotAdvance != tc.wantAdvance {
+				t.Fatalf("advance=%v want %v (reason=%s)", gotAdvance, tc.wantAdvance, gotReason)
+			}
+			if gotReason != tc.wantReason {
+				t.Fatalf("reason=%s want %s", gotReason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestRunDefragCandidateLoop_DeadlineOutcomeClosesCampaign covers the new
+// defragCandidateDeadline outcome: a candidate process function that
+// reports deadline mid-step (mirroring evictWorkerPods on a cancelled ctx)
+// must yield a finishReason=Deadline step result so the upper layer
+// advances LastDefragTime instead of re-entering the expired window.
+func TestRunDefragCandidateLoop_DeadlineOutcomeClosesCampaign(t *testing.T) {
+	candidates := []*defragCandidate{
+		{nodeName: testDefragNodeA},
+		{nodeName: "node-b"},
+	}
+	stats := &defragRunStats{}
+	calls := 0
+	result := runDefragCandidateLoop(context.Background(), candidates, stats, func(_ *defragCandidate) defragCandidateOutcome {
+		calls++
+		// Simulate evictWorkerPods hitting ctx done mid-eviction. Note we
+		// set stats.DeadlineExceeded ourselves; the real processDefragCandidate
+		// inherits it from evictWorkerPods.
+		stats.DeadlineExceeded = true
+		return defragCandidateDeadline
+	})
+	if calls != 1 {
+		t.Fatalf("deadline outcome must short-circuit after the first candidate, got calls=%d", calls)
+	}
+	if !result.finishCampaign || result.finishReason != defragFinishReasonDeadline {
+		t.Fatalf("deadline outcome must close campaign with reason=deadline, got %+v", result)
+	}
+	if result.idleStep {
+		t.Fatalf("deadline outcome is not idle")
+	}
+	if !stats.DeadlineExceeded {
+		t.Fatalf("stats.DeadlineExceeded must propagate so events report deadline=true")
+	}
+}
+
+// TestAdvanceCampaignAnchor_PersistsLastDefragTime is the integration test
+// that proves the upper layer actually persists pool.Status.LastDefragTime
+// when the campaign progress decision says so - the on-cluster contract
+// the defrag scheduler relies on.
+func TestAdvanceCampaignAnchor_PersistsLastDefragTime(t *testing.T) {
+	pool := newDefragTestPool()
+	r, kubeClient := newDefragControllerTestReconciler(t, pool)
+
+	campaignStart := time.Now().Add(-15 * time.Minute).Truncate(time.Second)
+	r.advanceCampaignAnchor(context.Background(), pool, campaignStart, defragFinishReasonDeadline)
+
+	updated := &tfv1.GPUPool{}
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: pool.Name}, updated); err != nil {
+		t.Fatalf("get pool after advanceCampaignAnchor: %v", err)
+	}
+	if updated.Status.LastDefragTime == nil {
+		t.Fatalf("advanceCampaignAnchor should have persisted LastDefragTime")
+	}
+	if !updated.Status.LastDefragTime.Time.Equal(campaignStart) {
+		t.Fatalf("LastDefragTime=%v want %v", updated.Status.LastDefragTime.Time, campaignStart)
 	}
 }
 


### PR DESCRIPTION
A defrag step that returned finishCampaign=true (noCandidates / allSkipped) was unconditionally persisted as pool.Status.LastDefragTime, which advanced the cron anchor and silenced the rest of the MaxDuration window. With a 60m window and a 5m compaction Period that meant ~1 effective reconcile per campaign instead of ~12, and stuck pods that recovered mid-window were never re-evaluated until the next cron tick.