### PR TITLE
fix(controller): don't recreate hypervisor pods on operator restart

### DIFF
--- a/internal/controller/providerconfig_controller.go
+++ b/internal/controller/providerconfig_controller.go
@@ -65,16 +65,38 @@ func (r *ProviderConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	// Update the provider manager cache
+	// Always refresh the in-memory caches: after an operator restart the
+	// ProviderManager is empty and must be repopulated from every ProviderConfig.
 	r.ProviderManager.UpdateProvider(&providerConfig)
 	gpuInfos := r.ProviderManager.GetAllGpuInfos()
 	gpuallocator.LoadPartitionTemplatesFromConfig(gpuInfos)
 	logger.Info("partition templates refreshed", "gpuInfoCount", len(gpuInfos))
 	logger.Info("ProviderConfig synced", "vendor", providerConfig.Spec.Vendor)
 
-	if err := r.restartHypervisorPodsForVendor(ctx, providerConfig.Spec.Vendor); err != nil {
-		logger.Error(err, "failed to restart hypervisor pods", "vendor", providerConfig.Spec.Vendor)
-		return ctrl.Result{}, err
+	// Only bounce hypervisor pods when the spec actually changed since we last
+	// acted on it. On operator restart / informer resync the controller gets a
+	// reconcile for the unchanged object; recreating healthy hypervisor pods
+	// there is disruptive and surprising. The last-acted spec hash is persisted
+	// on the ProviderConfig itself so the comparison survives operator restarts.
+	newHash := utils.GetObjectHash(providerConfig.Spec)
+	oldHash := providerConfig.Annotations[constants.ProviderConfigSpecHashAnnotation]
+
+	if oldHash != "" && oldHash != newHash {
+		if err := r.restartHypervisorPodsForVendor(ctx, providerConfig.Spec.Vendor); err != nil {
+			logger.Error(err, "failed to restart hypervisor pods", "vendor", providerConfig.Spec.Vendor)
+			return ctrl.Result{}, err
+		}
+	}
+
+	if oldHash != newHash {
+		patch := client.MergeFrom(providerConfig.DeepCopy())
+		if providerConfig.Annotations == nil {
+			providerConfig.Annotations = map[string]string{}
+		}
+		providerConfig.Annotations[constants.ProviderConfigSpecHashAnnotation] = newHash
+		if err := r.Patch(ctx, &providerConfig, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("persist provider-config spec hash: %w", err)
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/providerconfig_controller_test.go
+++ b/internal/controller/providerconfig_controller_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/provider"
+	"github.com/NexusGPU/tensor-fusion/internal/utils"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("ProviderConfig controller", func() {
+	// Use a unique vendor + node so the reconcile only ever touches this test's
+	// hypervisor pod, even when specs run in parallel.
+	const vendor = "ProviderConfigTestVendor"
+
+	var (
+		reconciler *ProviderConfigReconciler
+		pcName     = "test-provider-config"
+		nodeName   = "providerconfig-test-node"
+		podName    = utils.BuildHypervisorPodName(nodeName)
+	)
+
+	reconcileOnce := func() {
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: pcName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	hypervisorPodExists := func() bool {
+		pod := &corev1.Pod{}
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: utils.CurrentNamespace(),
+			Name:      podName,
+		}, pod)
+		if err == nil {
+			return pod.DeletionTimestamp.IsZero()
+		}
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		return false
+	}
+
+	BeforeEach(func() {
+		reconciler = &ProviderConfigReconciler{
+			Client:          k8sClient,
+			Scheme:          k8sClient.Scheme(),
+			ProviderManager: provider.NewManager(k8sClient),
+		}
+
+		Expect(k8sClient.Create(ctx, &tfv1.ProviderConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: pcName},
+			Spec:       tfv1.ProviderConfigSpec{Vendor: vendor},
+		})).To(Succeed())
+
+		Expect(k8sClient.Create(ctx, &tfv1.GPUNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   nodeName,
+				Labels: map[string]string{constants.AcceleratorLabelVendor: vendor},
+			},
+		})).To(Succeed())
+
+		Expect(k8sClient.Create(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: utils.CurrentNamespace(),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "hypervisor", Image: "test"}},
+			},
+		})).To(Succeed())
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, &tfv1.ProviderConfig{ObjectMeta: metav1.ObjectMeta{Name: pcName}})
+		_ = k8sClient.Delete(ctx, &tfv1.GPUNode{ObjectMeta: metav1.ObjectMeta{Name: nodeName}})
+		_ = k8sClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: podName, Namespace: utils.CurrentNamespace(),
+		}}, client.GracePeriodSeconds(0))
+	})
+
+	It("does not recreate hypervisor pods on reconcile when the spec is unchanged", func() {
+		// First reconcile adopts the current state: it records the spec hash but
+		// must NOT delete the already-running hypervisor pod.
+		reconcileOnce()
+		Expect(hypervisorPodExists()).To(BeTrue(), "pod should survive the initial adopt reconcile")
+
+		pc := &tfv1.ProviderConfig{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pcName}, pc)).To(Succeed())
+		Expect(pc.Annotations).To(HaveKey(constants.ProviderConfigSpecHashAnnotation))
+
+		// A second reconcile with the unchanged spec (mimicking an operator
+		// restart / informer resync) must leave the pod alone.
+		reconcileOnce()
+		Expect(hypervisorPodExists()).To(BeTrue(), "pod should survive a no-op resync reconcile")
+	})
+
+	It("recreates hypervisor pods when the spec actually changes", func() {
+		reconcileOnce() // adopt + record hash
+		Expect(hypervisorPodExists()).To(BeTrue())
+
+		pc := &tfv1.ProviderConfig{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pcName}, pc)).To(Succeed())
+		pc.Spec.InUseResourceNames = append(pc.Spec.InUseResourceNames, "changed-resource")
+		Expect(k8sClient.Update(ctx, pc)).To(Succeed())
+
+		reconcileOnce()
+		Eventually(hypervisorPodExists).Should(BeFalse(), "pod should be deleted after a real spec change")
+	})
+})

--- a/internal/controller/tensorfusionconnection_controller_test.go
+++ b/internal/controller/tensorfusionconnection_controller_test.go
@@ -55,12 +55,19 @@ var _ = Describe("TensorFusionConnection Controller", func() {
 		}
 
 		var tfEnv *TensorFusionEnv
+		var schedulerCancel context.CancelFunc
 		BeforeEach(func() {
 			tfEnv = NewTensorFusionEnvBuilder().
 				AddPoolWithNodeCount(1).SetGpuCountPerNode(2).
 				Build()
 			cfg := tfEnv.GetConfig()
-			go mockSchedulerLoop(ctx, cfg)
+			// Derive a cancellable context so the mock scheduler goroutine is
+			// stopped in AfterEach instead of leaking for the whole suite. Leaked
+			// loops list every pod every 50ms and starve later specs on
+			// CPU-constrained CI, which surfaced as flaky worker-reselection.
+			var schedulerCtx context.Context
+			schedulerCtx, schedulerCancel = context.WithCancel(ctx)
+			go mockSchedulerLoop(schedulerCtx, cfg)
 			pool := tfEnv.GetGPUPool(0)
 			// Create workload first
 			workload := createTensorFusionWorkload(pool.Name, workloadNamespacedName, 2)
@@ -84,6 +91,12 @@ var _ = Describe("TensorFusionConnection Controller", func() {
 		})
 
 		AfterEach(func() {
+			// Stop this spec's mock scheduler goroutine so it does not leak
+			// across specs and starve later ones under constrained CI CPU.
+			if schedulerCancel != nil {
+				schedulerCancel()
+			}
+
 			// Clean up connection
 			connection := &tfv1.TensorFusionConnection{}
 			err := k8sClient.Get(ctx, typeNamespacedName, connection)

--- a/internal/controller/tensorfusionworkload_controller_test.go
+++ b/internal/controller/tensorfusionworkload_controller_test.go
@@ -42,6 +42,7 @@ import (
 
 var _ = Describe("TensorFusionWorkload Controller", func() {
 	var tfEnv *TensorFusionEnv
+	var schedulerCancel context.CancelFunc
 	key := client.ObjectKey{Name: "mock", Namespace: "default"}
 
 	BeforeEach(func() {
@@ -49,9 +50,17 @@ var _ = Describe("TensorFusionWorkload Controller", func() {
 			AddPoolWithNodeCount(1).SetGpuCountPerNode(5).
 			Build()
 		cfg := tfEnv.GetConfig()
-		go mockSchedulerLoop(ctx, cfg)
+		// Stop the mock scheduler goroutine in AfterEach instead of leaking it
+		// for the whole suite; leaked loops list every pod every 50ms and
+		// starve later specs on CPU-constrained CI.
+		var schedulerCtx context.Context
+		schedulerCtx, schedulerCancel = context.WithCancel(ctx)
+		go mockSchedulerLoop(schedulerCtx, cfg)
 	})
 	AfterEach(func() {
+		if schedulerCancel != nil {
+			schedulerCancel()
+		}
 		cleanupWorkload(key)
 		tfEnv.Cleanup()
 	})

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -286,6 +286,12 @@ var (
 
 	// Short troubleshooting hint (e.g. eviction error snippet); not parsed.
 	DefragEvictSkipNodeReasonAnnotation = Domain + "/defrag-evict-skip-reason"
+
+	// ProviderConfigSpecHashAnnotation records the spec hash the ProviderConfig
+	// controller last acted on. Used to bounce hypervisor pods only when the
+	// spec actually changes, so an operator restart / informer resync (which
+	// replays the unchanged object) does not needlessly recreate them.
+	ProviderConfigSpecHashAnnotation = Domain + "/provider-config-hash"
 )
 
 const (


### PR DESCRIPTION
ProviderConfigReconciler unconditionally deleted every matching vendor's hypervisor pod on each reconcile. On operator restart the informer replays an initial event for every existing ProviderConfig, so all hypervisor pods (Ascend / MooreThreads / NVIDIA) were needlessly recreated even though nothing changed.

Persist the spec hash the controller last acted on as an annotation on the ProviderConfig, and only bounce hypervisor pods when that hash actually changes. Cache refresh (provider manager + partition templates) still runs every reconcile, since the in-memory caches must be repopulated after a restart. A missing annotation is treated as adopt-without-restart so a fresh rollout of this fix doesn't trigger one extra round of restarts.

Verified on the dev cluster: deleting the operator pod no longer recreates hypervisor pods (UIDs unchanged), while a real ProviderConfig spec change and a node isolation-mode label change still restart the affected pods.