### PR TITLE
fix(hypervisor): attribute soft-mode GPU memory via cgroup pod UID fallback

### DIFF
--- a/internal/controller/providerconfig_controller_test.go
+++ b/internal/controller/providerconfig_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/provider"
 	"github.com/NexusGPU/tensor-fusion/internal/utils"
@@ -69,6 +71,17 @@ var _ = Describe("ProviderConfig controller", func() {
 			Scheme:          k8sClient.Scheme(),
 			ProviderManager: provider.NewManager(k8sClient),
 		}
+
+		// A prior spec's AfterEach deletes these objects, but ProviderConfig and
+		// GPUNode carry finalizers, so deletion completes asynchronously. Wait for
+		// any leftovers to be fully gone before recreating; otherwise Create fails
+		// with "object is being deleted ... already exists".
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName}, &tfv1.ProviderConfig{})
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, &tfv1.GPUNode{})
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}).WithTimeout(30 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 
 		Expect(k8sClient.Create(ctx, &tfv1.ProviderConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: pcName},

--- a/pkg/hypervisor/backend/kubernetes/ns_mapper.go
+++ b/pkg/hypervisor/backend/kubernetes/ns_mapper.go
@@ -5,12 +5,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	"github.com/NexusGPU/tensor-fusion/pkg/hypervisor/framework"
 )
+
+// podUIDCgroupRe matches the Kubernetes pod UID embedded in a cgroup path.
+// Handles both the systemd driver (underscores, e.g.
+// "kubepods-burstable-pode38c7b11_d82c_4169_b866_361c5d7103af.slice") and the
+// cgroupfs driver (dashes, e.g. "kubepods/burstable/pode38c7b11-...-...").
+var podUIDCgroupRe = regexp.MustCompile(`pod([0-9a-fA-F]{8}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{12})`)
 
 // GetWorkerInfoFromHostPID extracts worker information from a process's environment
 // by reading /proc/{hostPID}/environ and /proc/{hostPID}/status
@@ -55,14 +62,38 @@ func GetWorkerInfoFromHostPID(hostPID uint32) (*framework.ProcessMappingInfo, er
 		containerPID = hostPID
 	}
 
+	// Parse the pod UID from the cgroup as an environ-independent fallback.
+	// Some GPU workloads spawn the process that actually holds device memory
+	// with a stripped environment (e.g. vLLM's EngineCore subprocess drops
+	// POD_NAME/POD_NAMESPACE), which would otherwise make this process
+	// unattributable. The cgroup is set by the kubelet and inherited by every
+	// child, so it survives such stripping.
+	podUID := getPodUIDFromCgroup(procDir)
+
 	return &framework.ProcessMappingInfo{
 		Namespace:     namespace,
 		PodName:       podName,
 		ContainerName: containerName,
 		GuestID:       fmt.Sprintf("%s_%s_%s", namespace, podName, containerName),
+		PodUID:        podUID,
 		HostPID:       hostPID,
 		GuestPID:      containerPID,
 	}, nil
+}
+
+// getPodUIDFromCgroup reads /proc/<pid>/cgroup and extracts the Kubernetes pod
+// UID, normalized to the canonical dash-separated form (matching pod.UID, i.e.
+// WorkerInfo.WorkerUID). Returns "" when no pod UID can be found.
+func getPodUIDFromCgroup(procDir string) string {
+	data, err := os.ReadFile(filepath.Join(procDir, "cgroup"))
+	if err != nil {
+		return ""
+	}
+	m := podUIDCgroupRe.FindSubmatch(data)
+	if m == nil {
+		return ""
+	}
+	return strings.ReplaceAll(string(m[1]), "_", "-")
 }
 
 // getContainerPIDFromStatus reads the container PID (NSpid) from /proc/{pid}/status

--- a/pkg/hypervisor/backend/kubernetes/ns_mapper.go
+++ b/pkg/hypervisor/backend/kubernetes/ns_mapper.go
@@ -17,7 +17,10 @@ import (
 // Handles both the systemd driver (underscores, e.g.
 // "kubepods-burstable-pode38c7b11_d82c_4169_b866_361c5d7103af.slice") and the
 // cgroupfs driver (dashes, e.g. "kubepods/burstable/pode38c7b11-...-...").
-var podUIDCgroupRe = regexp.MustCompile(`pod([0-9a-fA-F]{8}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{12})`)
+var podUIDCgroupRe = regexp.MustCompile(
+	`pod([0-9a-fA-F]{8}[-_][0-9a-fA-F]{4}[-_]` +
+		`[0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{12})`,
+)
 
 // GetWorkerInfoFromHostPID extracts worker information from a process's environment
 // by reading /proc/{hostPID}/environ and /proc/{hostPID}/status

--- a/pkg/hypervisor/backend/kubernetes/ns_mapper_test.go
+++ b/pkg/hypervisor/backend/kubernetes/ns_mapper_test.go
@@ -1,0 +1,53 @@
+package kubernetes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetPodUIDFromCgroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		cgroup  string
+		wantUID string
+	}{
+		{
+			name:    "systemd driver (underscores)",
+			cgroup:  "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode38c7b11_d82c_4169_b866_361c5d7103af.slice/cri-containerd-abc123.scope\n",
+			wantUID: "e38c7b11-d82c-4169-b866-361c5d7103af",
+		},
+		{
+			name:    "cgroupfs driver (dashes)",
+			cgroup:  "11:memory:/kubepods/burstable/pode38c7b11-d82c-4169-b866-361c5d7103af/abc123\n",
+			wantUID: "e38c7b11-d82c-4169-b866-361c5d7103af",
+		},
+		{
+			name:    "guaranteed qos (no qos sub-slice)",
+			cgroup:  "0::/kubepods.slice/kubepods-pode38c7b11_d82c_4169_b866_361c5d7103af.slice/cri-containerd-abc.scope\n",
+			wantUID: "e38c7b11-d82c-4169-b866-361c5d7103af",
+		},
+		{
+			name:    "non-pod cgroup yields empty",
+			cgroup:  "0::/system.slice/containerd.service\n",
+			wantUID: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "cgroup"), []byte(tt.cgroup), 0o644); err != nil {
+				t.Fatalf("write cgroup: %v", err)
+			}
+			if got := getPodUIDFromCgroup(dir); got != tt.wantUID {
+				t.Errorf("getPodUIDFromCgroup() = %q, want %q", got, tt.wantUID)
+			}
+		})
+	}
+}
+
+func TestGetPodUIDFromCgroupMissingFile(t *testing.T) {
+	if got := getPodUIDFromCgroup(t.TempDir()); got != "" {
+		t.Errorf("expected empty UID for missing cgroup file, got %q", got)
+	}
+}

--- a/pkg/hypervisor/backend/kubernetes/ns_mapper_test.go
+++ b/pkg/hypervisor/backend/kubernetes/ns_mapper_test.go
@@ -14,7 +14,7 @@ func TestGetPodUIDFromCgroup(t *testing.T) {
 	}{
 		{
 			name:    "systemd driver (underscores)",
-			cgroup:  "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pode38c7b11_d82c_4169_b866_361c5d7103af.slice/cri-containerd-abc123.scope\n",
+			cgroup:  "12:devices:/kubepods-burstable-pode38c7b11_d82c_4169_b866_361c5d7103af.slice\n",
 			wantUID: "e38c7b11-d82c-4169-b866-361c5d7103af",
 		},
 		{

--- a/pkg/hypervisor/framework/framework.go
+++ b/pkg/hypervisor/framework/framework.go
@@ -116,6 +116,13 @@ type ProcessMappingInfo struct {
 	ContainerName string
 	// GuestID is a composite identifier: namespace_podName_containerName
 	GuestID string
+	// PodUID is the Kubernetes pod UID parsed from the process cgroup. It is
+	// environ-independent (the kubelet-created cgroup is inherited by every
+	// child process and cannot be scrubbed by the workload, unlike POD_NAME in
+	// /proc/<pid>/environ). Used as a fallback when Namespace/PodName are empty
+	// because the GPU-holding process stripped its environment (e.g. vLLM's
+	// spawned EngineCore subprocess). Matches WorkerInfo.WorkerUID (== pod.UID).
+	PodUID string
 	// HostPID is the process ID in the host namespace
 	HostPID uint32
 	// GuestPID is the process ID in the container namespace

--- a/pkg/hypervisor/worker/controller.go
+++ b/pkg/hypervisor/worker/controller.go
@@ -177,6 +177,7 @@ func (w *WorkerController) ListWorkers() ([]*api.WorkerInfo, error) {
 func (w *WorkerController) GetWorkerMetrics() (map[string]map[string]map[string]*api.WorkerMetrics, error) {
 	// Step 1: Build worker lookup map: "namespace/podName" -> WorkerUID
 	workerLookup := w.buildWorkerLookupMap()
+	workerUIDs := w.buildWorkerUIDSet()
 
 	// Step 2: Get all process information from device controller
 	processInfos, err := w.deviceController.GetProcessInformation()
@@ -208,19 +209,12 @@ func (w *WorkerController) GetWorkerMetrics() (map[string]map[string]map[string]
 			continue
 		}
 
-		// Skip if namespace or podName is empty (not a TensorFusion worker).
-		// GuestID="" would never fire because GetWorkerInfoFromHostPID builds it
-		// from empty strings as "__", so check the underlying identity fields.
-		if mappingInfo.Namespace == "" || mappingInfo.PodName == "" {
-			continue
-		}
-
-		// Look up WorkerUID using namespace/podName
-		workerKey := mappingInfo.Namespace + "/" + mappingInfo.PodName
-		workerUID, found := workerLookup[workerKey]
+		// Resolve the owning worker by environ identity, falling back to the
+		// cgroup-derived pod UID for processes that stripped POD_NAME/POD_NAMESPACE
+		// from their environment (e.g. vLLM's spawned EngineCore subprocess).
+		workerUID, found := resolveWorkerUID(mappingInfo, workerLookup, workerUIDs)
 		if !found {
-			// Process belongs to a pod not tracked by this hypervisor
-			klog.V(5).Infof("Worker not found for key %s (process %d)", workerKey, hostPID)
+			klog.V(5).Infof("Worker not found for process %d (ns=%q pod=%q podUID=%q)", hostPID, mappingInfo.Namespace, mappingInfo.PodName, mappingInfo.PodUID)
 			continue
 		}
 
@@ -267,6 +261,42 @@ func (w *WorkerController) buildWorkerLookupMap() map[string]string {
 		lookup[key] = worker.WorkerUID
 	}
 	return lookup
+}
+
+// buildWorkerUIDSet returns the set of WorkerUIDs (== pod.UID) currently tracked
+// by this hypervisor. Used to validate cgroup-derived pod UIDs during memory
+// attribution when a process has no usable POD_NAME in its environment.
+func (w *WorkerController) buildWorkerUIDSet() map[string]struct{} {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	set := make(map[string]struct{}, len(w.workers))
+	for _, worker := range w.workers {
+		set[worker.WorkerUID] = struct{}{}
+	}
+	return set
+}
+
+// resolveWorkerUID maps a process to its owning worker UID. It prefers the
+// environ-derived namespace/podName key, then falls back to the cgroup-derived
+// pod UID (environ-independent) for processes that stripped POD_NAME/POD_NAMESPACE
+// from their environment (e.g. vLLM's spawned EngineCore subprocess). Returns
+// ("", false) when the process cannot be attributed to a tracked worker.
+func resolveWorkerUID(mappingInfo *framework.ProcessMappingInfo, workerLookup map[string]string, workerUIDs map[string]struct{}) (string, bool) {
+	if mappingInfo == nil {
+		return "", false
+	}
+	if mappingInfo.Namespace != "" && mappingInfo.PodName != "" {
+		if uid, ok := workerLookup[mappingInfo.Namespace+"/"+mappingInfo.PodName]; ok {
+			return uid, true
+		}
+	}
+	if mappingInfo.PodUID != "" {
+		if _, ok := workerUIDs[mappingInfo.PodUID]; ok {
+			return mappingInfo.PodUID, true
+		}
+	}
+	return "", false
 }
 
 // buildWorkerInfoSnapshots builds a map of worker info snapshots for ERL updates.
@@ -487,12 +517,25 @@ func (w *WorkerController) syncSharedMemoryState() {
 		state.UpdateHeartbeat(now)
 
 		deviceMemoryUsage := memoryByWorkerDevice[workerUID]
+		// Total across every physical GPU this worker's processes touched. Used
+		// as a fallback for single-device pods whose process landed on a GPU
+		// other than the nominally-allocated one (e.g. shared-pool pods can run
+		// on any visible card), so the per-UUID lookup below would otherwise miss.
+		var totalUsage uint64
+		for _, used := range deviceMemoryUsage {
+			totalUsage += used
+		}
+		singleDevice := len(allocation.DeviceInfos) == 1
 		for _, deviceInfo := range allocation.DeviceInfos {
 			if deviceInfo == nil {
 				continue
 			}
 			deviceUUID := strings.ToLower(deviceInfo.UUID)
-			state.SetPodMemoryUsed(int(deviceInfo.Index), deviceMemoryUsage[deviceUUID])
+			used := deviceMemoryUsage[deviceUUID]
+			if used == 0 && singleDevice {
+				used = totalUsage
+			}
+			state.SetPodMemoryUsed(int(deviceInfo.Index), used)
 		}
 	}
 }
@@ -591,6 +634,7 @@ func (w *WorkerController) collectWorkerMemoryUsage(workerLookup map[string]stri
 		return nil
 	}
 
+	workerUIDs := w.buildWorkerUIDSet()
 	result := make(map[string]map[string]uint64)
 	for _, procInfo := range processInfos {
 		hostPID, err := strconv.ParseUint(procInfo.ProcessID, 10, 32)
@@ -603,20 +647,12 @@ func (w *WorkerController) collectWorkerMemoryUsage(workerLookup map[string]stri
 		if err != nil || mappingInfo == nil {
 			continue
 		}
-		// Require real pod identity. GuestID is built via fmt.Sprintf("%s_%s_%s",
-		// ns, pod, ctr), so three empty strings produce "__" (not ""). A caller
-		// hardening check on GuestID == "" therefore never fires for environ-less
-		// processes (LLM servers like sglang scrub /proc/{pid}/environ for
-		// secrecy, leaving mappingInfo with empty Namespace/PodName and
-		// GuestID="__"). Reject on the actual identity fields instead so those
-		// processes' memory is never attributed to the worker whose lookup key
-		// happens to collide with "/".
-		if mappingInfo.Namespace == "" || mappingInfo.PodName == "" {
-			continue
-		}
-
-		workerKey := mappingInfo.Namespace + "/" + mappingInfo.PodName
-		workerUID, found := workerLookup[workerKey]
+		// Resolve the owning worker. Prefer environ-derived namespace/podName,
+		// but fall back to the cgroup-derived pod UID when the GPU-holding
+		// process stripped its environment (e.g. vLLM's spawned EngineCore drops
+		// POD_NAME/POD_NAMESPACE). Without the fallback such a process' memory is
+		// never attributed and the pod's nvidia-smi reports 0.
+		workerUID, found := resolveWorkerUID(mappingInfo, workerLookup, workerUIDs)
 		if !found {
 			continue
 		}

--- a/pkg/hypervisor/worker/controller.go
+++ b/pkg/hypervisor/worker/controller.go
@@ -214,7 +214,10 @@ func (w *WorkerController) GetWorkerMetrics() (map[string]map[string]map[string]
 		// from their environment (e.g. vLLM's spawned EngineCore subprocess).
 		workerUID, found := resolveWorkerUID(mappingInfo, workerLookup, workerUIDs)
 		if !found {
-			klog.V(5).Infof("Worker not found for process %d (ns=%q pod=%q podUID=%q)", hostPID, mappingInfo.Namespace, mappingInfo.PodName, mappingInfo.PodUID)
+			klog.V(5).Infof(
+				"Worker not found for process %d (ns=%q pod=%q podUID=%q)",
+				hostPID, mappingInfo.Namespace, mappingInfo.PodName, mappingInfo.PodUID,
+			)
 			continue
 		}
 
@@ -282,7 +285,11 @@ func (w *WorkerController) buildWorkerUIDSet() map[string]struct{} {
 // pod UID (environ-independent) for processes that stripped POD_NAME/POD_NAMESPACE
 // from their environment (e.g. vLLM's spawned EngineCore subprocess). Returns
 // ("", false) when the process cannot be attributed to a tracked worker.
-func resolveWorkerUID(mappingInfo *framework.ProcessMappingInfo, workerLookup map[string]string, workerUIDs map[string]struct{}) (string, bool) {
+func resolveWorkerUID(
+	mappingInfo *framework.ProcessMappingInfo,
+	workerLookup map[string]string,
+	workerUIDs map[string]struct{},
+) (string, bool) {
 	if mappingInfo == nil {
 		return "", false
 	}

--- a/pkg/hypervisor/worker/resolve_worker_uid_test.go
+++ b/pkg/hypervisor/worker/resolve_worker_uid_test.go
@@ -1,0 +1,61 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/NexusGPU/tensor-fusion/pkg/hypervisor/framework"
+)
+
+func TestResolveWorkerUID(t *testing.T) {
+	lookup := map[string]string{"ns1/pod-a": "uid-a"}
+	uids := map[string]struct{}{"uid-a": {}, "uid-b": {}}
+
+	tests := []struct {
+		name    string
+		mi      *framework.ProcessMappingInfo
+		wantUID string
+		wantOK  bool
+	}{
+		{
+			name:    "environ identity wins",
+			mi:      &framework.ProcessMappingInfo{Namespace: "ns1", PodName: "pod-a", PodUID: "uid-b"},
+			wantUID: "uid-a",
+			wantOK:  true,
+		},
+		{
+			name:    "falls back to cgroup pod UID when environ stripped",
+			mi:      &framework.ProcessMappingInfo{Namespace: "", PodName: "", PodUID: "uid-b"},
+			wantUID: "uid-b",
+			wantOK:  true,
+		},
+		{
+			name:   "unknown pod UID is not attributed",
+			mi:     &framework.ProcessMappingInfo{PodUID: "uid-unknown"},
+			wantOK: false,
+		},
+		{
+			name:   "no identity at all",
+			mi:     &framework.ProcessMappingInfo{},
+			wantOK: false,
+		},
+		{
+			name:   "nil mapping info",
+			mi:     nil,
+			wantOK: false,
+		},
+		{
+			name:    "environ miss falls through to cgroup UID",
+			mi:      &framework.ProcessMappingInfo{Namespace: "ns1", PodName: "pod-unknown", PodUID: "uid-b"},
+			wantUID: "uid-b",
+			wantOK:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotUID, gotOK := resolveWorkerUID(tt.mi, lookup, uids)
+			if gotOK != tt.wantOK || (tt.wantOK && gotUID != tt.wantUID) {
+				t.Errorf("resolveWorkerUID() = (%q, %v), want (%q, %v)", gotUID, gotOK, tt.wantUID, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION

The soft-isolation memory accounting attributed each GPU process to its pod by reading POD_NAME from /proc/<pid>/environ. Workloads that spawn the GPU-holding process with a stripped environment (e.g. vLLM's EngineCore subprocess drops POD_NAME/POD_NAMESPACE) became unattributable, so the pod's shm pod_memory_used stayed 0 and nvidia-smi reported 0 usage.

- ns_mapper: parse the pod UID from /proc/<pid>/cgroup (environ-independent, inherited by every child, cannot be scrubbed) into ProcessMappingInfo.PodUID.
- controller: resolveWorkerUID prefers ns/podName, falls back to the cgroup pod UID (== WorkerUID); single-device pods sum total usage so a process that landed on a non-allocated GPU is still accounted.
- add unit tests for cgroup pod-UID parsing and worker resolution.