### PR TITLE
fix: port nominated-pod requeue (#716) and missing-metrics fix (#723) to main

### DIFF
--- a/cmd/sched/setup.go
+++ b/cmd/sched/setup.go
@@ -24,8 +24,12 @@ import (
 
 	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator"
 	"github.com/NexusGPU/tensor-fusion/internal/scheduler/expander"
+	"github.com/NexusGPU/tensor-fusion/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	k8sVer "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/component-base/configz"
@@ -50,6 +54,9 @@ const (
 	configName             = "componentconfig"
 	clientConnectionCfgKey = "clientConnection"
 	kubeConfigCfgKey       = "kubeconfig"
+
+	nominatedPodRequeueWatchdogIntervalEnv     = "NOMINATED_POD_REQUEUE_WATCHDOG_INTERVAL"
+	defaultNominatedPodRequeueWatchdogInterval = 10 * time.Minute
 )
 
 func SetupScheduler(
@@ -219,10 +226,112 @@ func RunScheduler(ctx context.Context,
 			<-mgr.Elected()
 		}
 		logger.Info("Starting scheduling cycle")
+		startNominatedPodRequeueWatchdog(
+			ctx,
+			sched,
+			cc.PodMaxInUnschedulablePodsDuration,
+		)
 		sched.Run(ctx)
 		cc.EventBroadcaster.Shutdown()
 	}()
 	return nil
+}
+
+func startNominatedPodRequeueWatchdog(
+	ctx context.Context,
+	sched *scheduler.Scheduler,
+	podMaxInUnschedulablePodsDuration time.Duration,
+) {
+	if sched == nil || sched.SchedulingQueue == nil {
+		return
+	}
+
+	logger := klog.FromContext(ctx)
+	interval := nominatedPodRequeueWatchdogInterval(logger)
+	threshold := podMaxInUnschedulablePodsDuration + time.Minute
+	if threshold <= time.Minute {
+		threshold = 6 * time.Minute
+	}
+	logger.Info("Starting nominated TensorFusion pod requeue watchdog",
+		"interval", interval,
+		"threshold", threshold,
+	)
+
+	go func() {
+		firstObserved := map[types.UID]time.Time{}
+		wait.UntilWithContext(ctx, func(ctx context.Context) {
+			now := time.Now()
+			pods, summary := sched.SchedulingQueue.PendingPods()
+			seen := map[types.UID]struct{}{}
+			podsToActivate := map[string]*corev1.Pod{}
+
+			for _, pod := range pods {
+				if pod == nil {
+					continue
+				}
+				seen[pod.UID] = struct{}{}
+
+				if !shouldWatchNominatedPod(pod) {
+					delete(firstObserved, pod.UID)
+					continue
+				}
+
+				firstSeenAt, ok := firstObserved[pod.UID]
+				if !ok {
+					firstObserved[pod.UID] = now
+					continue
+				}
+				if now.Sub(firstSeenAt) < threshold {
+					continue
+				}
+
+				podsToActivate[string(pod.UID)] = pod
+				firstObserved[pod.UID] = now
+			}
+
+			for uid := range firstObserved {
+				if _, ok := seen[uid]; !ok {
+					delete(firstObserved, uid)
+				}
+			}
+
+			if len(podsToActivate) == 0 {
+				return
+			}
+			logger.Info("Force activating nominated TensorFusion pods left in scheduling queue",
+				"count", len(podsToActivate),
+				"threshold", threshold,
+				"summary", summary,
+			)
+			sched.SchedulingQueue.Activate(logger, podsToActivate)
+		}, interval)
+	}()
+}
+
+func nominatedPodRequeueWatchdogInterval(logger klog.Logger) time.Duration {
+	raw := os.Getenv(nominatedPodRequeueWatchdogIntervalEnv)
+	if raw == "" {
+		return defaultNominatedPodRequeueWatchdogInterval
+	}
+
+	interval, err := time.ParseDuration(raw)
+	if err != nil || interval <= 0 {
+		logger.Info("Invalid nominated pod requeue watchdog interval, using default",
+			"env", nominatedPodRequeueWatchdogIntervalEnv,
+			"value", raw,
+			"default", defaultNominatedPodRequeueWatchdogInterval,
+			"error", err,
+		)
+		return defaultNominatedPodRequeueWatchdogInterval
+	}
+	return interval
+}
+
+func shouldWatchNominatedPod(pod *corev1.Pod) bool {
+	return pod.Spec.NodeName == "" &&
+		pod.DeletionTimestamp == nil &&
+		pod.Status.NominatedNodeName != "" &&
+		utils.IsTensorFusionWorker(pod)
 }
 
 func getRecorderFactory(cc *schedulerserverconfig.CompletedConfig) profile.RecorderFactory {

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -162,9 +162,13 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 				gpuStore, _, _ := r.Allocator.GetAllocationInfo()
 				metrics.SetGPUAllocationMetrics(gpuStore, pod)
 				metrics.SetWorkerMetricsByWorkload(pod, gpuStore)
-			} else {
+			} else if r.Allocator.IsReady() {
 				metrics.RemoveGPUAllocationMetrics(pod.Name)
 				metrics.RemoveWorkerMetrics(pod.Name, time.Now())
+			} else {
+				return ctrl.Result{
+					RequeueAfter: time.Second,
+				}, nil
 			}
 		}
 		shouldReturn, err := r.handleWorkerPodFinalizer(ctx, pod)

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -156,27 +156,9 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	if pod.Labels[constants.LabelComponent] == constants.ComponentWorker {
-		r.IndexAllocator.ReconcileLockState(pod)
-		if pod.DeletionTimestamp.IsZero() {
-			if r.Allocator.HasAllocation(req.NamespacedName) {
-				gpuStore, _, _ := r.Allocator.GetAllocationInfo()
-				metrics.SetGPUAllocationMetrics(gpuStore, pod)
-				metrics.SetWorkerMetricsByWorkload(pod, gpuStore)
-			} else if r.Allocator.IsReady() {
-				metrics.RemoveGPUAllocationMetrics(pod.Name)
-				metrics.RemoveWorkerMetrics(pod.Name, time.Now())
-			} else {
-				return ctrl.Result{
-					RequeueAfter: time.Second,
-				}, nil
-			}
-		}
-		shouldReturn, err := r.handleWorkerPodFinalizer(ctx, pod)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		if shouldReturn {
-			return ctrl.Result{}, nil
+		res, handled, err := r.reconcileWorkerPod(ctx, req.NamespacedName, pod)
+		if handled || err != nil {
+			return res, err
 		}
 	}
 
@@ -206,6 +188,36 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// reconcileWorkerPod handles worker-pod lock state, allocation metrics and the
+// GPU cleanup finalizer. The returned bool reports whether Reconcile should
+// return the given result immediately (terminal step or requeue) instead of
+// continuing.
+func (r *PodReconciler) reconcileWorkerPod(
+	ctx context.Context, namespacedName types.NamespacedName, pod *corev1.Pod,
+) (ctrl.Result, bool, error) {
+	r.IndexAllocator.ReconcileLockState(pod)
+	if pod.DeletionTimestamp.IsZero() {
+		if r.Allocator.HasAllocation(namespacedName) {
+			gpuStore, _, _ := r.Allocator.GetAllocationInfo()
+			metrics.SetGPUAllocationMetrics(gpuStore, pod)
+			metrics.SetWorkerMetricsByWorkload(pod, gpuStore)
+		} else if r.Allocator.IsReady() {
+			metrics.RemoveGPUAllocationMetrics(pod.Name)
+			metrics.RemoveWorkerMetrics(pod.Name, time.Now())
+		} else {
+			return ctrl.Result{RequeueAfter: time.Second}, true, nil
+		}
+	}
+	shouldReturn, err := r.handleWorkerPodFinalizer(ctx, pod)
+	if err != nil {
+		return ctrl.Result{}, true, err
+	}
+	if shouldReturn {
+		return ctrl.Result{}, true, nil
+	}
+	return ctrl.Result{}, false, nil
 }
 
 func (r *PodReconciler) handleWorkerPodFinalizer(ctx context.Context, pod *corev1.Pod) (bool, error) {

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -2750,7 +2750,6 @@ func (s *GpuAllocator) reconcileAllocationState() {
 			s.markGPUDirtyLocked(gpuKey)
 		}
 	}
-
 	// reconcile quota store state
 	s.quotaStore.ReconcileQuotaStore(ctx, s.uniqueAllocation)
 	log.FromContext(ctx).Info("Quota store data reconciled")


### PR DESCRIPTION
##what
把v1分支的两个修复cherry-pick回main：
- #716 `fix: requeue stale nominated TensorFusion pods` - `cmd/sched/setup.go`, 修复stale nominated pod 导致´ pod 一直pendding 
- #723 `fix: Resolve the issue of missing metrics`  - 
- `internal/controller/pod_controller.go` - `internal/gpuallocator/gpuallocator.go`,恢复丢失指标。
两个commit 都干净cherry-pick 到origin/main