### PR TITLE
 chore(chart): bump components to 2.11.3, sync RBAC, and make install work out-of-the-box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
-	cp -r config/crd/bases/* ./charts/tensor-fusion/crds/
+	cp -r config/crd/bases/* ./charts/tensor-fusion/crds/ && \
+	bash hack/sync-helm-rbac.sh
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/charts/tensor-fusion/Chart.yaml
+++ b/charts/tensor-fusion/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.5
+version: 1.7.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.48.6"
+appVersion: "1.58.5"

--- a/charts/tensor-fusion/templates/provider-config-nvidia.yaml
+++ b/charts/tensor-fusion/templates/provider-config-nvidia.yaml
@@ -18,6 +18,10 @@ spec:
     extraEnv:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with $cfg.deviceMount }}
+    deviceMount:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   devicePluginDetection:
     resourceNamePrefixes:
       - nvidia.com/gpu

--- a/charts/tensor-fusion/templates/rbac-hypervisor.yaml
+++ b/charts/tensor-fusion/templates/rbac-hypervisor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tensor-fusion-hypervisor-role
 rules:
 - apiGroups:
-  - ""
+  - ''
   resources:
   - nodes
   - pods

--- a/charts/tensor-fusion/templates/rbac.yaml
+++ b/charts/tensor-fusion/templates/rbac.yaml
@@ -4,11 +4,20 @@ metadata:
   name: {{ include "tensor-fusion.fullname" . }}-role
 rules:
 - apiGroups:
-  - ""
+  - ''
+  resources:
+  - bindings
+  - endpoints
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - ''
   resources:
   - configmaps
   - events
   - namespaces
+  - pods/finalizers
   verbs:
   - create
   - get
@@ -17,24 +26,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - create
-- apiGroups:
-  - ""
+  - ''
   resourceNames:
   - kube-scheduler
   resources:
@@ -43,7 +35,7 @@ rules:
   - get
   - update
 - apiGroups:
-  - ""
+  - ''
   resources:
   - nodes
   - pods
@@ -56,13 +48,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - bindings
-  verbs:
-  - create
-- apiGroups:
-  - ""
+  - ''
   resources:
   - nodes/finalizers
   - pods/binding
@@ -73,24 +59,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - ""
-  resources:
-  - pods/eviction
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - pods/finalizers
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
+  - ''
   resources:
   - nodes/status
   - pods/status
@@ -99,16 +68,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - ""
-  resources:
-  - replicationcontrollers
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
+  - ''
   resources:
   - persistentvolumeclaims
   - persistentvolumes
@@ -119,22 +79,10 @@ rules:
   - update
   - watch
 - apiGroups:
-  - storage.k8s.io
+  - ''
   resources:
-  - csinodes
-  - csidrivers
-  - csistoragecapacities
-  - storageclasses
-  - volumeattachments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  - extensions
-  resources:
-  - replicasets
+  - replicationcontrollers
+  - services
   verbs:
   - get
   - list
@@ -155,13 +103,26 @@ rules:
   - update
   - watch
 - apiGroups:
-  - policy
+  - apps
+  - extensions
   resources:
-  - poddisruptionbudgets
+  - replicasets
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups:
   - batch
   resources:
@@ -185,6 +146,19 @@ rules:
 - apiGroups:
   - coordination.k8s.io
   resources:
+  - leasecandidates
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - create
@@ -206,75 +180,22 @@ rules:
   - update
   - watch
 - apiGroups:
-  - coordination.k8s.io
+  - events.k8s.io
   resources:
-  - leasecandidates
+  - events
   verbs:
   - create
-  - delete
-  - deletecollection
   - get
   - list
   - patch
   - update
   - watch
 - apiGroups:
-  - tensor-fusion.ai
+  - karpenter.sh
   resources:
-  - gpunodeclasses
-  - gpunodes
-  - gpupools
-  - gpuresourcequotas
-  - gpus
-  - providerconfigs
-  - schedulingconfigtemplates
-  - tensorfusionclusters
-  - tensorfusionconnections
-  - tensorfusionworkloads
-  - workloadprofiles
-  - gpunodeclaims
+  - '*'
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - tensor-fusion.ai
-  resources:
-  - gpunodeclasses/finalizers
-  - gpunodes/finalizers
-  - gpupools/finalizers
-  - gpuresourcequotas/finalizers
-  - gpus/finalizers
-  - schedulingconfigtemplates/finalizers
-  - tensorfusionclusters/finalizers
-  - tensorfusionconnections/finalizers
-  - tensorfusionworkloads/finalizers
-  - workloadprofiles/finalizers
-  - gpunodeclaims/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - tensor-fusion.ai
-  resources:
-  - gpunodeclasses/status
-  - gpunodes/status
-  - gpupools/status
-  - gpuresourcequotas/status
-  - gpus/status
-  - schedulingconfigtemplates/status
-  - tensorfusionclusters/status
-  - tensorfusionconnections/status
-  - tensorfusionworkloads/status
-  - workloadprofiles/status
-  - gpunodeclaims/status
-  verbs:
-  - get
-  - patch
-  - update
+  - '*'
 - apiGroups:
   - karpenter.sh
   resources:
@@ -288,30 +209,20 @@ rules:
   - update
   - watch
 - apiGroups:
-  - karpenter.*
+  - policy
   resources:
-  - '*'
+  - poddisruptionbudgets
   verbs:
-  - '*'
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - resource.k8s.io
   resources:
   - deviceclasses
   - devicetaintrules
-  - resourceclaims
   - resourceslices
+  - resourceclaims
   verbs:
   - get
   - list
@@ -320,12 +231,6 @@ rules:
   - resource.k8s.io
   resources:
   - resourceclaims
-  verbs:
-  - patch
-  - update
-- apiGroups:
-  - resource.k8s.io
-  resources:
   - resourceclaims/status
   verbs:
   - get
@@ -338,8 +243,77 @@ rules:
   resources:
   - resourceclaims/binding
   verbs:
-  - update
   - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  - csinodes
+  - csistoragecapacities
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tensor-fusion.ai
+  resources:
+  - gpunodeclaims
+  - gpunodeclasses
+  - gpunodes
+  - gpupools
+  - gpuresourcequotas
+  - gpus
+  - providerconfigs
+  - schedulingconfigtemplates
+  - tensorfusionclusters
+  - tensorfusionconnections
+  - tensorfusionworkloads
+  - workloadprofiles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tensor-fusion.ai
+  resources:
+  - gpunodeclaims/finalizers
+  - gpunodeclasses/finalizers
+  - gpunodes/finalizers
+  - gpupools/finalizers
+  - gpuresourcequotas/finalizers
+  - gpus/finalizers
+  - schedulingconfigtemplates/finalizers
+  - tensorfusionclusters/finalizers
+  - tensorfusionconnections/finalizers
+  - tensorfusionworkloads/finalizers
+  - workloadprofiles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - tensor-fusion.ai
+  resources:
+  - gpunodeclaims/status
+  - gpunodeclasses/status
+  - gpunodes/status
+  - gpupools/status
+  - gpuresourcequotas/status
+  - gpus/status
+  - schedulingconfigtemplates/status
+  - tensorfusionclusters/status
+  - tensorfusionconnections/status
+  - tensorfusionworkloads/status
+  - workloadprofiles/status
+  verbs:
+  - get
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/tensor-fusion/templates/tensorfusioncluster.yaml
+++ b/charts/tensor-fusion/templates/tensorfusioncluster.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.cluster.enabled }}
+{{- $c := .Values.cluster }}
+{{- $nv := .Values.providerConfigs.nvidia }}
+# SchedulingConfigTemplate referenced by the default pool below. Values mirror a
+# known-good production config (auto-freeze TTLs per QoS, ERL parameters,
+# NodeCompactGPULowLoad placement). Tune via override files as needed.
+apiVersion: tensor-fusion.ai/v1
+kind: SchedulingConfigTemplate
+metadata:
+  name: {{ $c.schedulingConfigTemplateName | default "tf-scheduling-config" }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  placement:
+    mode: NodeCompactGPULowLoad
+    allowUsingLocalGPU: true
+    gpuFilters:
+      - type: avoidTooMuchConnectionsOnSameGPU
+        params:
+          connectionNum: 150
+      - type: avoidDifferentZone
+        params:
+          topologyKey: topology.kubernetes.io/zone
+  reBalancer:
+    interval: 20m
+    reBalanceCoolDownTime: 5m
+    threshold:
+      matchAny:
+        tflopsTotalLimitExceededRatio: 1.5
+        vramSwitchPerMinute: 5
+  hypervisor:
+    autoFreezeAndResume:
+      autoFreeze:
+        - qos: low
+          enable: true
+          freezeToMemTTL: 1m
+          freezeToDiskTTL: 1h
+        - qos: medium
+          enable: true
+          freezeToMemTTL: 2m
+          freezeToDiskTTL: 2h
+        - qos: high
+          enable: true
+          freezeToMemTTL: 1d
+          freezeToDiskTTL: 1w
+        - qos: critical
+          enable: true
+          freezeToMemTTL: 1w
+          freezeToDiskTTL: 4w
+      intelligenceWarmup:
+        enable: true
+        model: smart-warmup-v1
+        historyDataPeriod: 1y
+        predictionPeriod: 1m
+    elasticRateLimitParameters:
+      kp: '0.12'
+      ki: '0.4'
+      kd: '1.0'
+      filterAlpha: '0.30'
+      burstWindow: '0.5'
+      integralDecayFactor: '0.85'
+      capacityMin: '150'
+      capacityMax: '6000'
+      minRefillRate: '80'
+      maxRefillRate: '12000'
+---
+apiVersion: tensor-fusion.ai/v1
+kind: TensorFusionCluster
+metadata:
+  name: {{ $c.name | default "tensor-fusion" }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  gpuPools:
+    - name: {{ $c.pool.name | default "shared" }}
+      isDefault: true
+      specTemplate:
+        capacityConfig:
+          {{- toYaml $c.pool.capacityConfig | nindent 10 }}
+        componentConfig:
+          # Only the hypervisor image is set here — client / worker images are
+          # resolved from the NVIDIA ProviderConfig (single source of truth).
+          hypervisor:
+            image: {{ $c.hypervisorImage | quote }}
+        nodeManagerConfig:
+          defaultVendor: NVIDIA
+          nodeSelector:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ $c.pool.nodeSelectorKey | default "nvidia.com/gpu.present" }}
+                    operator: In
+                    values:
+                      - "true"
+        schedulingConfigTemplate: {{ $c.schedulingConfigTemplateName | default "tf-scheduling-config" }}
+{{- end }}

--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -31,7 +31,7 @@ controller:
   image:
     repository: tensorfusion/tensor-fusion-operator
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "2.11.3"
+    tag: "latest"
   # This is for setting Kubernetes Annotations to a Pod.
   # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ 
   

--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -31,7 +31,7 @@ controller:
   image:
     repository: tensorfusion/tensor-fusion-operator
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "1.48.6"
+    tag: "2.11.3"
   # This is for setting Kubernetes Annotations to a Pod.
   # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ 
   
@@ -651,7 +651,62 @@ providerConfigs:
         placementOffset: 4
         isolationGroupSharing: exclusive
 
-    extraEnv: []
+    # NVIDIA_MIG_CONFIG_DEVICES / NVIDIA_MIG_MONITOR_DEVICES are required on
+    # MIG-enabled nodes: the NVIDIA Container Runtime only injects the per-GI
+    # capability files under /proc/driver/nvidia/capabilities/ when these are set,
+    # otherwise the hypervisor may fail to start on a MIG node and NVML MIG
+    # (GpuInstance / ComputeInstance) queries fail. The operator also auto-injects
+    # them when privilegedHypervisor=true, but they are set explicitly here so MIG
+    # support does not silently depend on that path.
+    # (TF_ENABLE_LOG / TF_LOG_LEVEL=debug are intentionally omitted — debug only.)
+    extraEnv:
+      - name: NVIDIA_MIG_CONFIG_DEVICES
+        value: all
+      - name: NVIDIA_MIG_MONITOR_DEVICES
+        value: all
+    # Optional device mount policy for the hypervisor (spec.hypervisor.deviceMount).
+    # Empty ({}) = builtin default device mounting, which is correct for almost all
+    # clusters. Only set this for special setups that need to filter/override which
+    # device nodes the hypervisor mounts (CEL rules). Fields:
+    #   deviceMountRule / partitionedDeviceMountRule (CEL expressions), sharedDevices ([]).
+    # Example:
+    #   deviceMount:
+    #     deviceMountRule: "false"      # mount none of the base device nodes
+    #     sharedDevices: []
+    deviceMount: {}
+
+# Optional, opt-in default TensorFusionCluster (+ its SchedulingConfigTemplate)
+# created by the chart so a fresh `helm install` is usable out of the box with a
+# single NVIDIA shared GPU pool. Both CRs carry helm.sh/resource-policy: keep, so
+# uninstalling the chart will NOT delete the cluster or its pools.
+# Disable this if you manage TensorFusionCluster / SchedulingConfigTemplate
+# out-of-band (kubectl apply).
+cluster:
+  enabled: true
+  name: tensor-fusion
+  # Hypervisor image is NOT part of ProviderConfig — it can only be set on the
+  # pool, so it lives here. Client / worker images are NOT repeated: they come
+  # from providerConfigs.nvidia.images.remoteClient / remoteWorker (single source).
+  hypervisorImage: tensorfusion/tensor-fusion-hypervisor:latest
+  schedulingConfigTemplateName: tf-scheduling-config
+  pool:
+    name: shared
+    # GPU node label the default pool selects on.
+    nodeSelectorKey: nvidia.com/gpu.present
+    capacityConfig:
+      maxResources:
+        tflops: "100"
+        vram: "100Gi"
+      minResources:
+        tflops: "20"
+        vram: "10Gi"
+      warmResources:
+        tflops: "10"
+        vram: "5Gi"
+      oversubscription:
+        tflopsOversellRatio: 2000
+        vramExpandToHostDisk: 60
+        vramExpandToHostMem: 50
 
 alert:
   enabled: true

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -1,0 +1,456 @@
+# TensorFusion Kubernetes 安装说明
+
+本文档说明如何在 Kubernetes 集群中安装 TensorFusion 控制面，并完成最小业务 Pod 验证。
+
+适用假设：
+
+- 使用本仓库 Helm chart 安装，chart 路径为 `charts/tensor-fusion`。
+- Helm release 名称使用 `tensor-fusion-sys`，系统命名空间使用 `tensor-fusion-sys`。
+- 集群已有 GPU 节点，节点能被 `nvidia.com/gpu.present=true` 这类 label 选中。
+- 执行安装的账号具备创建 CRD、ClusterRole、MutatingWebhookConfiguration、Namespace 的权限。
+
+## 1. 前置条件
+
+安装前确认基础工具和集群状态：
+
+```bash
+kubectl version --client=true
+helm version
+kubectl get nodes -o wide
+kubectl get nodes --show-labels | grep -E 'nvidia.com/gpu.present=true|gpu.present=true'
+```
+
+GPU 节点需要满足：
+
+- NVIDIA 驱动正常。
+- 容器运行时能挂载 GPU 设备。
+- GPU 节点带有 TensorFusion 可识别的 label。默认 Helm 参数 `initialGpuNodeLabelSelector` 是 `nvidia.com/gpu.present=true`。
+- 如果使用 remote 模式，client Pod 到 worker Pod 所在节点的网络需要可达。
+
+## 2. 安装控制面
+
+### 2.1 默认安装
+
+默认 values 会安装：
+
+- TensorFusion CRD、RBAC、controller。
+- Mutating admission webhook。
+- TensorFusion scheduler 配置。
+- GreptimeDB standalone。
+- Alertmanager。
+- cluster-agent、vector sidecar。
+
+从仓库根目录执行：
+
+```bash
+helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
+  -n tensor-fusion-sys \
+  --create-namespace
+```
+
+如果集群拉取海外镜像不稳定，使用国内镜像 values：
+
+```bash
+helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
+  -n tensor-fusion-sys \
+  --create-namespace \
+  -f charts/tensor-fusion/values-cn.yaml
+```
+
+### 2.2 生产环境安装
+
+生产环境建议使用外部高可用 GreptimeDB，而不是 chart 内置 standalone。
+
+`charts/tensor-fusion/values-production.yaml` 只会设置 `greptime.installStandalone=false`，不会自动填充外部 GreptimeDB 地址和凭据。需要额外传入 `greptime.host`、`greptime.port`、`greptime.db`，如果使用云 Greptime，还要设置 `greptime.isCloud=true`、`greptime.user`、`greptime.password`。
+
+示例：
+
+```bash
+helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
+  -n tensor-fusion-sys \
+  --create-namespace \
+  -f charts/tensor-fusion/values-production.yaml \
+  --set greptime.installStandalone=false \
+  --set greptime.isCloud=true \
+  --set greptime.host='<greptime-host>' \
+  --set greptime.port=5001 \
+  --set greptime.db='public' \
+  --set greptime.user='<greptime-user>' \
+  --set greptime.password='<greptime-password>'
+```
+
+如果外部 Greptime 不需要账号密码，则保持 `greptime.isCloud=false`，并设置可访问的 host、port、db。
+
+### 2.3 常用 Helm 参数
+
+| 参数 | 说明 | 默认值 |
+| --- | --- | --- |
+| `initialGpuNodeLabelSelector` | controller 初始扫描 GPU 节点的 label selector | `nvidia.com/gpu.present=true` |
+| `controller.image.repository` | operator 镜像仓库 | `tensorfusion/tensor-fusion-operator` |
+| `controller.image.tag` | operator 镜像 tag | `2.11.3` |
+| `controller.replicaCount` | controller 副本数 | `1` |
+| `greptime.installStandalone` | 是否安装内置 GreptimeDB standalone | `true` |
+| `greptime.host` | GreptimeDB MySQL endpoint host | `greptimedb-standalone.greptimedb.svc.cluster.local` |
+| `alert.enabled` | 是否安装 alertmanager | `true` |
+| `controller.admissionWebhooks.failurePolicy` | webhook 失败策略 | `Ignore` |
+
+### 2.4 指定组件版本
+
+Chart 默认使用浮动 tag：hypervisor / vgpu-provider / client / worker 默认 `latest`，operator 默认为 chart 内固定的 `controller.image.tag`。生产环境建议**固定版本**，通过 `--set` 覆盖对应 values 键：
+
+```bash
+helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
+  -n tensor-fusion-sys --create-namespace \
+  --set controller.image.tag=2.11.3 \
+  --set cluster.hypervisorImage=tensorfusion/tensor-fusion-hypervisor:2.11.3 \
+  --set providerConfigs.nvidia.images.middleware=tensorfusion/vgpu-provider-nvidia:1.3.5 \
+  --set providerConfigs.nvidia.images.remoteClient=tensorfusion/tensor-fusion-client:v2.15.1 \
+  --set providerConfigs.nvidia.images.remoteWorker=tensorfusion/tensor-fusion-worker:v2.15.1
+```
+
+各组件对应的 values 键：
+
+| 组件 | values 键 | 说明 |
+| --- | --- | --- |
+| operator | `controller.image.repository` + `controller.image.tag` | 仓库与 tag 分开两个键 |
+| hypervisor | `cluster.hypervisorImage` | **完整镜像**（含仓库+tag），默认 `...tensor-fusion-hypervisor:latest` |
+| vgpu-provider | `providerConfigs.nvidia.images.middleware` | 默认 `...vgpu-provider-nvidia:latest` |
+| client | `providerConfigs.nvidia.images.remoteClient` | 默认 `...tensor-fusion-client:latest` |
+| worker | `providerConfigs.nvidia.images.remoteWorker` | 默认 `...tensor-fusion-worker:latest` |
+
+> 注意：`cluster.hypervisorImage` 传的是完整镜像引用（`仓库:tag`），而 operator 用 `repository` + `tag` 两个独立键。
+
+若通过 Helm 仓库（而非本地 chart 路径）安装，可用 `--version` 固定 **chart 版本**（与镜像 tag 相互独立）：
+
+```bash
+helm repo add tensor-fusion https://nexusgpu.github.io/tensor-fusion
+helm repo update
+helm install tensor-fusion-sys tensor-fusion/tensor-fusion --version 1.7.7 \
+  -n tensor-fusion-sys --create-namespace
+```
+
+## 3. 验证控制面
+
+安装后检查系统组件：
+
+```bash
+kubectl get pods -n tensor-fusion-sys -o wide
+kubectl get pods -n greptimedb -o wide
+kubectl get crd | grep tensor-fusion.ai
+kubectl get mutatingwebhookconfiguration | grep tensor-fusion
+```
+
+检查 controller 日志：
+
+```bash
+kubectl logs -n tensor-fusion-sys deploy/tensor-fusion-sys-controller -c controller --tail=100
+```
+
+正常情况下，controller Pod 至少包含 `controller` 和 `vector` 容器；如果 values 中配置了 `agent.agentId`，还会有 `cluster-agent`。
+
+## 4. 创建 TensorFusionCluster 和 GPUPool
+
+控制面安装完成后，需要创建 TensorFusionCluster 或 GPUPool，TensorFusion 才能发现和管理 GPU 资源。
+
+注意：
+
+- `config/samples/v1_tensorfusioncluster.yaml` 和 `config/samples/v1_gpupool.yaml` 当前是 TODO stub，不能直接用于安装。
+- `GPUPool.spec.componentConfig` 需要使用当前发行版本对应的完整配置，至少要包含 worker、hypervisor、client 等组件镜像和 patch 配置。
+- 使用 TensorFusionCluster 创建 pool 时，实际 GPUPool 名称通常是 `<cluster-name>-<pool-name>`。
+- 如果希望业务 Pod 不显式写 `tensor-fusion.ai/gpupool`，需要在 TensorFusionCluster 的 pool 定义中设置 `isDefault: true`。
+
+建议使用平台生成的、与当前版本匹配的 TensorFusionCluster/GPUPool YAML。下面只展示结构，不建议原样 apply：
+
+```yaml
+apiVersion: tensor-fusion.ai/v1
+kind: TensorFusionCluster
+metadata:
+  name: tensor-fusion
+spec:
+  gpuPools:
+    - name: shared
+      isDefault: true
+      specTemplate:
+        defaultUsingLocalGPU: false
+        nodeManagerConfig:
+          provisioningMode: AutoSelect
+          nodeSelector:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values:
+                      - "true"
+        capacityConfig:
+          oversubscription:
+            tflopsOversellRatio: 500
+            vramExpandToHostMem: 50
+            vramExpandToHostDisk: 70
+        componentConfig:
+          worker:
+            image: "<tensor-fusion-worker-image>"
+            podTemplate: {}
+          hypervisor:
+            image: "<tensor-fusion-hypervisor-image>"
+            vectorImage: "<vector-image>"
+            podTemplate: {}
+          nodeDiscovery:
+            image: "<tensor-fusion-node-discovery-image>"
+            podTemplate: {}
+          client:
+            remoteModeImage: "<tensor-fusion-client-image>"
+            embeddedModeImage: "<tensor-fusion-client-image>"
+            operatorEndpoint: "http://tensor-fusion-sys.tensor-fusion-sys:8080"
+            patchToPod: {}
+            patchToContainer: {}
+```
+
+应用真实配置后检查资源：
+
+```bash
+kubectl get tensorfusioncluster
+kubectl get gpupool
+kubectl get gpunode,gpu -o wide
+kubectl describe gpupool <gpupool-name>
+```
+
+## 5. 部署业务 Pod 验证
+
+业务 Pod 必须满足以下条件，webhook 才会注入 TensorFusion client：
+
+- Pod label 有 `tensor-fusion.ai/enabled: "true"`。
+- 至少设置一个资源请求 annotation：`tensor-fusion.ai/tflops-request`、`tensor-fusion.ai/compute-percent-request` 或 `tensor-fusion.ai/vram-request`。
+- 多容器 Pod 必须设置 `tensor-fusion.ai/inject-container`。
+
+示例 Deployment：
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tensor-fusion-smoke
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tensor-fusion-smoke
+  template:
+    metadata:
+      labels:
+        app: tensor-fusion-smoke
+        tensor-fusion.ai/enabled: "true"
+      annotations:
+        tensor-fusion.ai/gpupool: "<gpupool-name>"
+        tensor-fusion.ai/inject-container: "pytorch"
+        tensor-fusion.ai/isolation: "shared"
+        tensor-fusion.ai/is-local-gpu: "false"
+        tensor-fusion.ai/gpu-count: "1"
+        tensor-fusion.ai/tflops-request: "10"
+        tensor-fusion.ai/vram-request: "1Gi"
+    spec:
+      containers:
+        - name: pytorch
+          image: pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime
+          command: ["sh", "-c", "sleep infinity"]
+```
+
+部署并检查：
+
+```bash
+kubectl apply -f smoke.yaml
+kubectl get pod -l app=tensor-fusion-smoke -o wide
+kubectl describe pod -l app=tensor-fusion-smoke
+kubectl get tensorfusionworkload,tensorfusionconnection -A
+kubectl get pods -A -l tensor-fusion.ai/component=worker -o wide
+```
+
+进入业务容器检查 CUDA/NVML 注入：
+
+```bash
+POD=$(kubectl get pod -l app=tensor-fusion-smoke -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -it "$POD" -c pytorch -- nvidia-smi
+kubectl exec -it "$POD" -c pytorch -- sh -lc 'ldd "$(which nvidia-smi)" | grep -E "tensor-fusion|nvidia-ml|cuda"'
+```
+
+如果容器里配置了 `http_proxy` 或 `https_proxy`，本地服务探测建议使用：
+
+```bash
+curl --noproxy "*" http://127.0.0.1:8000/v1/models
+```
+
+## 6. 常见 workload annotation
+
+| Annotation | 说明 |
+| --- | --- |
+| `tensor-fusion.ai/gpupool` | 指定 GPUPool。未指定时依赖默认 pool。 |
+| `tensor-fusion.ai/is-local-gpu` | `true` 表示业务 Pod 调度到 GPU 节点本地用卡；`false` 表示 remote 模式。 |
+| `tensor-fusion.ai/isolation` | `shared`、`soft`、`hard`、`partitioned`。 |
+| `tensor-fusion.ai/gpu-count` | 请求 GPU 数量。 |
+| `tensor-fusion.ai/gpu-indices` | 指定 GPU index，是硬过滤条件。指定后 `gpu-count` 按 index 数量计算。 |
+| `tensor-fusion.ai/tflops-request` | 调度用 TFLOPs 请求，推荐优先使用。 |
+| `tensor-fusion.ai/compute-percent-request` | 按百分比请求算力。与 TFLOPs request 互斥。 |
+| `tensor-fusion.ai/vram-request` | 调度用显存请求。 |
+| `tensor-fusion.ai/inject-container` | 多容器 Pod 中指定要注入的容器，多个容器用逗号分隔。 |
+
+`shared` 模式是整卡共享、无运行时 TFLOPs 限制的模式，但调度阶段仍需要资源请求 annotation，用于 TensorFusion 选择 GPU 和记录分配。
+
+## 7. 排障
+
+### 7.1 Pod Pending
+
+先看 Kubernetes 调度事件：
+
+```bash
+kubectl describe pod <pod-name>
+kubectl get nodes -o wide
+kubectl get nodes --show-labels
+```
+
+常见原因：
+
+- 节点 taint 未配置 toleration。
+- Pod 的 nodeSelector、nodeAffinity 和 GPU 节点不匹配。
+- GPUPool 的 nodeSelector 没选中节点。
+- `tensor-fusion.ai/gpu-indices` 指定的卡不存在或已被其他 workload 占用。
+- GPU 资源请求超过 pool 中可用资源。
+
+继续检查 TensorFusion 资源：
+
+```bash
+kubectl get gpupool,gpunode,gpu -o wide
+kubectl describe gpupool <gpupool-name>
+kubectl describe gpu <gpu-name>
+kubectl logs -n tensor-fusion-sys deploy/tensor-fusion-sys-controller -c controller --tail=200
+```
+
+### 7.2 CUDA/NVML driver 库路径异常
+
+如果出现 `nvidia-smi` 报 `NVML Function Not Found`，或者 worker 日志中出现类似
+`Assertion failed, cuInit_fn != nullptr`，先确认宿主机和出错容器内实际存在的 driver 库路径。
+
+宿主机上检查 NVIDIA driver 是否正常，以及 driver 库安装在哪个目录：
+
+```bash
+nvidia-smi
+ldconfig -p | grep -E 'libcuda.so.1|libnvidia-ml.so.1'
+ls -l \
+  /usr/lib64/libcuda.so.1 \
+  /usr/lib64/libnvidia-ml.so.1 \
+  /usr/lib/x86_64-linux-gnu/libcuda.so.1 \
+  /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1 2>/dev/null
+```
+
+`/usr/lib64` 常见于 RHEL/CentOS/Rocky/openEuler/Kylin 系，`/usr/lib/x86_64-linux-gnu`
+常见于 Debian/Ubuntu 系。Pod 中最终能看到哪些路径，还取决于 NVIDIA container runtime 的挂载结果和容器镜像自身的发行版。
+
+然后在出错的 Pod 容器内确认实际链接和可用路径：
+
+```bash
+ldd "$(which nvidia-smi)" | grep -E 'tensor-fusion|nvidia-ml|cuda'
+cat /etc/ld.so.preload 2>/dev/null || true
+ldconfig -p 2>/dev/null | grep -E 'libcuda.so.1|libnvidia-ml.so.1' || true
+ls -l \
+  /usr/lib64/libcuda.so.1 \
+  /usr/lib64/libnvidia-ml.so.1 \
+  /usr/lib/x86_64-linux-gnu/libcuda.so.1 \
+  /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1 \
+  /usr/local/nvidia/lib64/libcuda.so.1 \
+  /usr/local/nvidia/lib64/libnvidia-ml.so.1 2>/dev/null
+```
+
+如果需要全量查找：
+
+```bash
+find /usr /lib /lib64 /usr/local \( -name 'libcuda.so*' -o -name 'libnvidia-ml.so*' \) 2>/dev/null
+```
+
+如果 TensorFusion worker 需要显式指定 driver 库路径，使用出错容器内真实存在的稳定 `.so.1` symlink：
+
+```yaml
+env:
+  - name: TF_CUDA_LIB_PATH
+    value: <container-visible-libcuda.so.1-path>
+  - name: TF_NVML_LIB_PATH
+    value: <container-visible-libnvidia-ml.so.1-path>
+```
+
+不要固定到类似 `/usr/lib64/libnvidia-ml.so.580.126.09` 或
+`/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.535.216.01` 这样的版本号路径。驱动升级后，版本号文件可能变化，`.so.1` symlink 才会跟随当前驱动。
+
+如果日志是 `cuInit_fn != nullptr`，重点检查 `TF_CUDA_LIB_PATH` 指向的 `libcuda.so.1` 是否在出错容器内存在，并且包含 `cuInit` 符号：
+
+```bash
+readelf -Ws <container-visible-libcuda.so.1-path> 2>/dev/null | grep ' cuInit'
+```
+
+如果宿主机有 driver 库但 Pod 内没有，优先排查 NVIDIA container runtime、NVIDIA device plugin 和 Pod 是否真正分配到了 GPU 设备。如果 Pod 内有正确库但仍报错，确认这些环境变量注入到了真正崩溃的 worker 容器，而不是只注入到了业务容器。
+
+### 7.3 Pod 被 Evicted
+
+如果事件里出现 `The node was low on resource: memory`，说明是节点内存压力驱逐，不是 GPU 调度失败。
+
+检查：
+
+```bash
+kubectl describe pod <pod-name>
+kubectl top pod <pod-name> --containers
+kubectl top node <node-name>
+```
+
+处理方式：
+
+- 给业务容器设置合理的 memory request 和 limit。
+- remote 模式下，模型加载期间 client 侧可能有额外内存峰值，需要按实际压测结果预留。
+- 避免在低内存节点上启动大模型。
+
+### 7.4 vLLM 启动后本地 curl 无返回
+
+先确认端口是否监听：
+
+```bash
+ps -ef | grep -E 'vllm|EngineCore|APIServer' | grep -v grep
+ss -lntp | grep 8000
+tail -n 100 /tmp/vllm.log
+```
+
+如果 `curl` 被代理环境变量影响，使用：
+
+```bash
+curl --noproxy "*" -v --max-time 10 http://127.0.0.1:8000/v1/models
+```
+
+如果日志里有 CUDA OOM，降低 `--gpu-memory-utilization`、减小 `--max-model-len`，或释放同一张 GPU 上其他进程。
+
+## 8. 升级、回滚、卸载
+
+升级前建议备份当前 Helm values 和关键 CR：
+
+```bash
+TS=$(date +%Y%m%d-%H%M%S)
+mkdir -p "backup-${TS}"
+helm -n tensor-fusion-sys get values tensor-fusion-sys -o yaml > "backup-${TS}/values.yaml"
+kubectl get tensorfusioncluster,gpupool,gpunode,gpu,workloadprofile,tensorfusionworkload,tensorfusionconnection -A -o yaml \
+  > "backup-${TS}/tf-state.yaml"
+```
+
+升级：
+
+```bash
+helm upgrade tensor-fusion-sys ./charts/tensor-fusion \
+  -n tensor-fusion-sys \
+  -f <your-values.yaml>
+```
+
+更详细的升级和回滚流程见仓库根目录：
+
+- `upgrade.md`
+- `rollback.md`
+
+卸载会删除 TensorFusion CR、控制面、webhook、CRD 等资源。确认不再需要后执行：
+
+```bash
+NAMESPACE=tensor-fusion-sys HELM_RELEASE=tensor-fusion-sys ./scripts/uninstall.sh
+```
+
+卸载前建议先备份业务和 TensorFusion CR 状态。

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -87,7 +87,7 @@ helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
 | --- | --- | --- |
 | `initialGpuNodeLabelSelector` | controller 初始扫描 GPU 节点的 label selector | `nvidia.com/gpu.present=true` |
 | `controller.image.repository` | operator 镜像仓库 | `tensorfusion/tensor-fusion-operator` |
-| `controller.image.tag` | operator 镜像 tag | `2.11.3` |
+| `controller.image.tag` | operator 镜像 tag | `latest` |
 | `controller.replicaCount` | controller 副本数 | `1` |
 | `greptime.installStandalone` | 是否安装内置 GreptimeDB standalone | `true` |
 | `greptime.host` | GreptimeDB MySQL endpoint host | `greptimedb-standalone.greptimedb.svc.cluster.local` |
@@ -96,7 +96,7 @@ helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
 
 ### 2.4 指定组件版本
 
-Chart 默认使用浮动 tag：hypervisor / vgpu-provider / client / worker 默认 `latest`，operator 默认为 chart 内固定的 `controller.image.tag`。生产环境建议**固定版本**，通过 `--set` 覆盖对应 values 键：
+Chart 默认所有组件镜像都使用浮动 tag `latest`（operator / hypervisor / vgpu-provider / client / worker）。生产环境建议**固定版本**，通过 `--set` 覆盖对应 values 键：
 
 ```bash
 helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
@@ -123,7 +123,7 @@ helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
 若通过 Helm 仓库（而非本地 chart 路径）安装，可用 `--version` 固定 **chart 版本**（与镜像 tag 相互独立）：
 
 ```bash
-helm repo add tensor-fusion https://nexusgpu.github.io/tensor-fusion
+helm repo add tensor-fusion https://helm.tensor-fusion.ai
 helm repo update
 helm install tensor-fusion-sys tensor-fusion/tensor-fusion --version 1.7.7 \
   -n tensor-fusion-sys --create-namespace

--- a/hack/sync-helm-rbac.sh
+++ b/hack/sync-helm-rbac.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Sync the operator ClusterRole rules from the controller-gen output
+# (config/rbac/role.yaml) into the Helm chart template. `make manifests` only
+# copies CRDs to the chart, not RBAC, so the chart's rbac.yaml drifts behind the
+# generated role. Run this after `make manifests` to keep them in sync.
+set -euo pipefail
+ROLE=config/rbac/role.yaml
+CHART=charts/tensor-fusion/templates/rbac.yaml
+rules=$(python3 -c "import yaml;d=yaml.safe_load(open('$ROLE'));print(yaml.dump({'rules':d['rules']},default_flow_style=False,sort_keys=False),end='')")
+header=$(sed -n '1,/^rules:/p' "$CHART" | sed '$d')
+tail=$(sed -n '/^---/,$p' "$CHART")
+{ printf '%s\n' "$header"; printf '%s\n' "$rules"; printf '%s\n' "$tail"; } > "$CHART.tmp" && mv "$CHART.tmp" "$CHART"
+echo "synced operator RBAC: config/rbac/role.yaml -> $CHART"


### PR DESCRIPTION
## Summary

Upgrades the Helm chart to the current component versions and closes several gaps
that made a fresh `helm install` non-functional out of the box.

- **Version bump**: chart `1.7.5 ->1.7.7`, appVersion `1.48.6 -> 1.58.5`
  - operator & hypervisor `2.11.3`
  - tensor-fusion-client / tensor-fusion-worker `v2.15.1`
  - vgpu-provider-nvidia `1.3.5`
- **RBAC sync + automation**: chart operator RBAC had drifted behind
  `config/rbac/role.yaml` because `make manifests` only copied CRDs. RBAC is now
  regenerated from `config/rbac/role.yaml` (byte-identical) and a
  `hack/sync-helm-rbac.sh` step keeps it in sync on every `make manifests`.
  Hypervisor RBAC synced with the deployed role.
- **Out-of-the-box install**: `helm install` previously left the operator idle
  (control plane only, no GPU pool). Added an opt-in default `TensorFusionCluster`
  (+ its `SchedulingConfigTemplate`) with one NVIDIA pool. Both carry
  `helm.sh/resource-policy: keep` so uninstall never deletes them.
  Toggle via `cluster.enabled` (default `true`).
- **NVIDIA hypervisor MIG env by default**: `NVIDIA_MIG_CONFIG_DEVICES` /
  `NVIDIA_MIG_MONITOR_DEVICES` are required on MIG-enabled nodes for the NVIDIA
  Container Runtime to inject the per-GI capability files; without them the
  hypervisor can fail to start on a MIG node. Set explicitly on the nvidia
  ProviderConfig (debug env intentionally omitted).
- **Optional `deviceMount` passthrough** on the nvidia ProviderConfig for clusters
  needing a custom CEL device-mount rule (default empty = builtin behavior).

## Why

The deployed operator/hypervisor were already on `2.11.3` with updated CRDs, but
the published chart lagged (`1.48.6`) and a clean install did not produce a
working cluster.

## Validation

- `helm lint` clean; rendered manifests validated against installed CRDs via
  server-side dry-run.
- **Real cluster (upgrade path)**: `helm upgrade` on the dev cluster with
  `cluster.enabled=false` (to preserve the hand-built multi-vendor 3-pool
  cluster)  - operator `2.11.3` healthy, RBAC synced, existing pools untouched;
  `vllm-shared-remote-nolimit` workload runs (business + remote worker Running,
  remote-GPU handshake OK).
- **Clean-room fresh install** (throwaway minikube): operator + CRDs + RBAC +
  webhooks + greptime up, default `TensorFusionCluster` reconciled into a
  `GPUPool`. One-to-one diff vs the deployed cluster: all CRDs, ClusterRoles,
  bindings, webhooks, priorityclasses, ServiceAccounts, services and all 4
  managed ConfigMaps are byte-identical. Expected-only deltas: ascend/mthreads
  ProviderConfigs (multi-vendor, not shipped by default), the nvidia
  ProviderConfig being a newer/superset `hardwareMetadata`, and leader-election
  runtime state.

## Notes

- `helm upgrade` does **not** re-apply CRDs (Helm skips `crds/` on upgrade). If a
  future bump changes CRD schema, run `kubectl apply -f charts/tensor-fusion/crds/`.

