### PR TITLE
fix(nodediscovery): clean up stale GPU resources when device is removed

### DIFF
--- a/cmd/nodediscovery/main.go
+++ b/cmd/nodediscovery/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
 	"github.com/NexusGPU/tensor-fusion/internal/utils"
 	"github.com/samber/lo"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -250,6 +251,14 @@ func main() {
 
 	}
 
+	// GPUs owned by this node but absent from the current enumeration (e.g.
+	// physically removed) must be marked missing, otherwise stale GPU CRs keep
+	// polluting scheduling and capacity statistics forever.
+	if err := markMissingGPUs(k8sClient, ctx, gpunode, allDeviceIDs); err != nil {
+		ctrl.Log.Error(err, "failed to mark missing GPUs")
+		os.Exit(1)
+	}
+
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		return patchGPUNodeStatus(k8sClient, ctx, gpunode, totalTFlops, totalVRAM, int32(count), allDeviceIDs)
 	})
@@ -257,6 +266,76 @@ func main() {
 		ctrl.Log.Error(err, "failed to patch status of GPUNode after retries")
 		os.Exit(1)
 	}
+}
+
+// markMissingGPUs cleans up GPU CRs owned by this node whose physical device was
+// not enumerated in the current discovery run: idle GPUs (no running apps, the
+// normal case since ops drain a card before pulling it) are deleted directly,
+// busy GPUs are only marked (phase -> Unknown plus a missing-since annotation)
+// so transient NVML/driver hiccups do not wipe allocation state, and get deleted
+// by a later run once idle.
+func markMissingGPUs(
+	k8sClient client.Client, ctx context.Context,
+	gpunode *tfv1.GPUNode, aliveDeviceIDs []string) error {
+	gpuList := &tfv1.GPUList{}
+	if err := k8sClient.List(ctx, gpuList,
+		client.MatchingLabels{constants.LabelKeyOwner: gpunode.Name}); err != nil {
+		return fmt.Errorf("list GPUs owned by node %s: %w", gpunode.Name, err)
+	}
+
+	alive := make(map[string]struct{}, len(aliveDeviceIDs))
+	for _, id := range aliveDeviceIDs {
+		alive[normalizeGPUIdentifier(id)] = struct{}{}
+	}
+
+	for i := range gpuList.Items {
+		gpu := &gpuList.Items[i]
+		if _, ok := alive[normalizeGPUIdentifier(gpu.Name)]; ok {
+			continue
+		}
+
+		// Cards are always drained before being physically pulled, so an idle
+		// missing GPU has nothing to lose (Available == Capacity): delete it
+		// directly. Even a false positive is harmless, the next discovery run
+		// recreates it identically.
+		if len(gpu.Status.RunningApps) == 0 {
+			ctrl.Log.Info("GPU device not enumerated and has no running apps, deleting directly",
+				"uuid", gpu.Name)
+			if err := k8sClient.Delete(ctx, gpu); err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("delete missing idle GPU %s: %w", gpu.Name, err)
+			}
+			continue
+		}
+
+		// A missing GPU still referenced by running apps: deleting now would reset
+		// allocation accounting on recreate (transient NVML/driver hiccups), so
+		// only mark it. Once its workloads are gone, the next discovery run
+		// deletes it via the idle path above.
+		// Keep the first missing-since timestamp for observability.
+		if _, marked := gpu.Annotations[constants.GPUMissingSinceAnnotationKey]; !marked {
+			patch := client.MergeFrom(gpu.DeepCopy())
+			if gpu.Annotations == nil {
+				gpu.Annotations = map[string]string{}
+			}
+			gpu.Annotations[constants.GPUMissingSinceAnnotationKey] = time.Now().Format(time.RFC3339)
+			if err := k8sClient.Patch(ctx, gpu, patch); err != nil {
+				return fmt.Errorf("mark GPU %s missing: %w", gpu.Name, err)
+			}
+		}
+
+		if gpu.Status.Phase != tfv1.TensorFusionGPUPhaseUnknown {
+			patch := client.MergeFrom(gpu.DeepCopy())
+			gpu.Status.Phase = tfv1.TensorFusionGPUPhaseUnknown
+			if err := k8sClient.Status().Patch(ctx, gpu, patch); err != nil {
+				return fmt.Errorf("update phase of missing GPU %s: %w", gpu.Name, err)
+			}
+		}
+
+		ctrl.Log.Info("GPU device not enumerated in this discovery run but still has running apps, "+
+			"marked as missing, it will be deleted once idle in a future discovery run unless it recovers",
+			"uuid", gpu.Name, "missingSince", gpu.Annotations[constants.GPUMissingSinceAnnotationKey])
+	}
+	return nil
 }
 
 // Use proper patch-based update with retry on conflict
@@ -356,7 +435,9 @@ func createOrUpdateTensorFusionGPU(
 		if gpu.Status.UsedBy == "" {
 			gpu.Status.UsedBy = tfv1.UsedByTensorFusion
 		}
-		if gpu.Status.Phase == "" {
+		if gpu.Status.Phase == "" || gpu.Status.Phase == tfv1.TensorFusionGPUPhaseUnknown {
+			// Unknown means the device was previously marked missing by discovery,
+			// it has recovered now, reset to Pending for the controller to promote.
 			gpu.Status.Phase = tfv1.TensorFusionGPUPhasePending
 		}
 		return k8sClient.Status().Patch(ctx, gpu, client.Merge)

--- a/cmd/nodediscovery/main_test.go
+++ b/cmd/nodediscovery/main_test.go
@@ -11,6 +11,7 @@ import (
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
 	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -441,6 +442,131 @@ func TestPatchGPUNodeStatus_ErrorScenarios(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.expectedErr, "Error message should contain expected text")
 		})
 	}
+}
+
+func newMarkMissingTestGPU(name, owner string, phase tfv1.TensorFusionGPUPhase) *tfv1.GPU {
+	return &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.LabelKeyOwner: owner,
+			},
+			Annotations: map[string]string{
+				constants.LastSyncTimeAnnotationKey: time.Now().Format(time.RFC3339),
+			},
+		},
+		Status: tfv1.GPUStatus{
+			Phase: phase,
+			Capacity: &tfv1.Resource{
+				Tflops: resource.MustParse("100"),
+				Vram:   resource.MustParse("16Gi"),
+			},
+			Available: &tfv1.Resource{
+				Tflops: resource.MustParse("100"),
+				Vram:   resource.MustParse("16Gi"),
+			},
+		},
+	}
+}
+
+func TestMarkMissingGPUs(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = tfv1.AddToScheme(scheme)
+
+	gpuNode := &tfv1.GPUNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testGPUNodeName,
+			OwnerReferences: []metav1.OwnerReference{
+				{Name: "test-gpu-pool"},
+			},
+		},
+	}
+	present := newMarkMissingTestGPU("gpu-present", testGPUNodeName, tfv1.TensorFusionGPUPhaseRunning)
+	missing := newMarkMissingTestGPU("gpu-missing", testGPUNodeName, tfv1.TensorFusionGPUPhaseRunning)
+	otherNodeGPU := newMarkMissingTestGPU("gpu-other-node", "other-gpu-node", tfv1.TensorFusionGPUPhaseRunning)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPU{}).
+		WithObjects(present, missing, otherNodeGPU).Build()
+
+	// a drained card (no running apps) that disappeared: nothing to lose, delete directly
+	busyMissing := newMarkMissingTestGPU("gpu-missing-busy", testGPUNodeName, tfv1.TensorFusionGPUPhaseRunning)
+	busyMissing.Status.RunningApps = []*tfv1.RunningAppDetail{{Name: "app-1", Namespace: "default"}}
+	assert.NoError(t, k8sClient.Create(ctx, busyMissing))
+
+	err := markMissingGPUs(k8sClient, ctx, gpuNode, []string{"gpu-present"})
+	assert.NoError(t, err)
+
+	// an idle missing GPU must be deleted immediately (ops always drain before pulling a card)
+	got := &tfv1.GPU{}
+	err = k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-missing"}, got)
+	assert.True(t, apierrors.IsNotFound(err), "idle missing GPU should be deleted directly, got err=%v", err)
+
+	// a missing GPU still referenced by running apps must be marked, not deleted,
+	// so a transient NVML hiccup cannot wipe allocation accounting
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-missing-busy"}, got))
+	assert.Equal(t, tfv1.TensorFusionGPUPhaseUnknown, got.Status.Phase,
+		"busy missing GPU should be marked Unknown")
+	missingSince := got.Annotations[constants.GPUMissingSinceAnnotationKey]
+	assert.NotEmpty(t, missingSince, "busy missing GPU should carry missing-since annotation")
+	_, err = time.Parse(time.RFC3339, missingSince)
+	assert.NoError(t, err, "missing-since should be a valid RFC3339 timestamp")
+
+	// the GPU still enumerated must be untouched
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-present"}, got))
+	assert.Equal(t, tfv1.TensorFusionGPUPhaseRunning, got.Status.Phase)
+	assert.NotContains(t, got.Annotations, constants.GPUMissingSinceAnnotationKey)
+
+	// GPUs owned by other nodes must not be touched
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-other-node"}, got))
+	assert.Equal(t, tfv1.TensorFusionGPUPhaseRunning, got.Status.Phase)
+	assert.NotContains(t, got.Annotations, constants.GPUMissingSinceAnnotationKey)
+
+	// idempotent: re-marking must keep the original missing-since timestamp
+	err = markMissingGPUs(k8sClient, ctx, gpuNode, []string{"gpu-present"})
+	assert.NoError(t, err)
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-missing-busy"}, got))
+	assert.Equal(t, missingSince, got.Annotations[constants.GPUMissingSinceAnnotationKey],
+		"missing-since must not be refreshed on subsequent runs")
+}
+
+func TestCreateOrUpdateTensorFusionGPU_RecoversMissingGPU(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = tfv1.AddToScheme(scheme)
+
+	gpuNode := &tfv1.GPUNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testGPUNodeName,
+			OwnerReferences: []metav1.OwnerReference{
+				{Name: "test-gpu-pool"},
+			},
+		},
+	}
+	uuid := "gpu-recovered"
+	missingGPU := newMarkMissingTestGPU(uuid, testGPUNodeName, tfv1.TensorFusionGPUPhaseUnknown)
+	missingGPU.Annotations[constants.GPUMissingSinceAnnotationKey] =
+		time.Now().Add(-5 * time.Minute).Format(time.RFC3339)
+	// simulate in-use accounting that must survive recovery
+	missingGPU.Status.Available.Tflops = resource.MustParse("40")
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPU{}).
+		WithObjects(missingGPU).Build()
+
+	memInfo := nvml.Memory_v2{Total: 16 * 1024 * 1024 * 1024}
+	gpu, err := createOrUpdateTensorFusionGPU(
+		k8sClient, ctx, testNodeName, gpuNode, uuid, testDeviceName,
+		memInfo, resource.MustParse("100"), 0, -1, nil)
+	assert.NoError(t, err)
+
+	assert.NotContains(t, gpu.Annotations, constants.GPUMissingSinceAnnotationKey,
+		"missing marker must be cleared when the device reappears")
+	assert.Equal(t, tfv1.TensorFusionGPUPhasePending, gpu.Status.Phase,
+		"recovered GPU should go back to Pending for the controller to promote")
+	assert.Equal(t, resource.MustParse("40"), gpu.Status.Available.Tflops,
+		"existing allocation accounting must be preserved on recovery")
 }
 
 func TestEstimateNvLinkBandwidthMBps(t *testing.T) {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -59,7 +59,11 @@ const (
 	// enumerated by the latest node discovery run, value is the RFC3339 time it
 	// was first found missing. Cleared automatically when the device reappears.
 	GPUMissingSinceAnnotationKey = Domain + "/gpu-missing-since"
-	WorkloadKey                  = Domain + "/workload"
+	// NodeBootIDAnnotationKey records the Kubernetes node boot ID a node-discovery
+	// job was created for, so a node reboot (boot ID change) re-triggers discovery
+	// to refresh GPU resources (e.g. clean up physically removed cards).
+	NodeBootIDAnnotationKey = Domain + "/node-boot-id"
+	WorkloadKey             = Domain + "/workload"
 
 	GpuPoolKey = Domain + "/gpupool"
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -55,7 +55,11 @@ const (
 	InitialGPUNodeSelector      = "nvidia.com/gpu.present=true"
 
 	LastSyncTimeAnnotationKey = Domain + "/last-sync"
-	WorkloadKey               = Domain + "/workload"
+	// GPUMissingSinceAnnotationKey marks a GPU CR whose physical device was not
+	// enumerated by the latest node discovery run, value is the RFC3339 time it
+	// was first found missing. Cleared automatically when the device reappears.
+	GPUMissingSinceAnnotationKey = Domain + "/gpu-missing-since"
+	WorkloadKey                  = Domain + "/workload"
 
 	GpuPoolKey = Domain + "/gpupool"
 

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -328,6 +328,12 @@ func (r *GPUNodeReconciler) syncStatusToGPUDevices(ctx context.Context, node *tf
 	}
 
 	for i := range gpuList {
+		// GPUs marked missing by node discovery must keep their Unknown phase,
+		// otherwise node level sync would put a physically absent GPU back into
+		// scheduling rotation.
+		if utils.IsGPUMissing(&gpuList[i]) {
+			continue
+		}
 		if gpuList[i].Status.Phase != state {
 			patch := client.MergeFrom(gpuList[i].DeepCopy())
 			gpuList[i].Status.Phase = state

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -178,7 +178,7 @@ func (r *GPUNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{RequeueAfter: constants.StatusCheckInterval}, nil
 	}
 
-	if err := r.reconcileNodeDiscoveryJob(ctx, node, poolObj); err != nil {
+	if err := r.reconcileNodeDiscoveryJob(ctx, node, poolObj, coreNode); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -353,10 +353,21 @@ func (r *GPUNodeReconciler) fetchAllOwnedGPUDevices(ctx context.Context, node *t
 	return gpuList.Items, nil
 }
 
+func isJobFinished(job *batchv1.Job) bool {
+	for _, c := range job.Status.Conditions {
+		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) &&
+			c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
 	ctx context.Context,
 	gpunode *tfv1.GPUNode,
 	pool *tfv1.GPUPool,
+	coreNode *corev1.Node,
 ) error {
 	log := log.FromContext(ctx)
 	log.Info("starting node discovery job")
@@ -398,6 +409,12 @@ func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
 		},
 	}
 
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	currentBootID := coreNode.Status.NodeInfo.BootID
+	job.Annotations[constants.NodeBootIDAnnotationKey] = currentBootID
+
 	if err := r.Get(ctx, client.ObjectKeyFromObject(job), job); err != nil {
 		if errors.IsNotFound(err) {
 			if err := ctrl.SetControllerReference(gpunode, job, r.Scheme); err != nil {
@@ -409,6 +426,22 @@ func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
 		} else {
 			return fmt.Errorf("create node discovery job %w", err)
 		}
+	}
+
+	// A finished discovery job from a previous node boot is stale: after a reboot
+	// GPU devices may have changed (e.g. card physically removed), so delete the
+	// old job and let the next reconcile (triggered by the owned-job deletion
+	// event) recreate it to re-run discovery.
+	if currentBootID != "" && isJobFinished(job) &&
+		job.Annotations[constants.NodeBootIDAnnotationKey] != currentBootID {
+		log.Info("node rebooted since last discovery run, deleting stale discovery job to re-trigger it",
+			"node", gpunode.Name, "jobBootID", job.Annotations[constants.NodeBootIDAnnotationKey],
+			"currentBootID", currentBootID)
+		if err := r.Delete(ctx, job,
+			client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("delete stale node discovery job %w", err)
+		}
+		return nil
 	}
 
 	jobFailed := false

--- a/internal/controller/gpunode_controller_unit_test.go
+++ b/internal/controller/gpunode_controller_unit_test.go
@@ -227,6 +227,43 @@ func TestGPUNodeReconcileInitializesEmptyPhaseToPending(t *testing.T) {
 	}
 }
 
+func TestSyncStatusToGPUDevicesSkipsMissingGPUs(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+	gpuNode := newNodeDiscoveryTestGPUNode()
+
+	normalGPU := newNodeDiscoveryTestGPU(gpuNode.Name, tfv1.TensorFusionGPUPhasePending)
+	normalGPU.Name = "gpu-normal"
+
+	missingGPU := newNodeDiscoveryTestGPU(gpuNode.Name, tfv1.TensorFusionGPUPhaseUnknown)
+	missingGPU.Name = "gpu-missing"
+	missingGPU.Annotations = map[string]string{
+		constants.GPUMissingSinceAnnotationKey: "2026-07-13T00:00:00Z",
+	}
+
+	reconciler, kubeClient := newNodeDiscoveryTestReconciler(t, gpuNode, normalGPU, missingGPU)
+
+	if _, err := reconciler.syncStatusToGPUDevices(ctx, gpuNode, tfv1.TensorFusionGPUPhaseRunning); err != nil {
+		t.Fatalf("syncStatusToGPUDevices: %v", err)
+	}
+
+	updated := &tfv1.GPU{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: "gpu-normal"}, updated); err != nil {
+		t.Fatalf("get normal GPU: %v", err)
+	}
+	if updated.Status.Phase != tfv1.TensorFusionGPUPhaseRunning {
+		t.Fatalf("expected normal GPU phase %q, got %q", tfv1.TensorFusionGPUPhaseRunning, updated.Status.Phase)
+	}
+
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: "gpu-missing"}, updated); err != nil {
+		t.Fatalf("get missing GPU: %v", err)
+	}
+	if updated.Status.Phase != tfv1.TensorFusionGPUPhaseUnknown {
+		t.Fatalf("missing GPU phase must stay %q, got %q", tfv1.TensorFusionGPUPhaseUnknown, updated.Status.Phase)
+	}
+}
+
 func newNodeDiscoveryTestReconciler(t *testing.T, objects ...ctrlclient.Object) (*GPUNodeReconciler, ctrlclient.Client) {
 	t.Helper()
 

--- a/internal/controller/gpunode_controller_unit_test.go
+++ b/internal/controller/gpunode_controller_unit_test.go
@@ -56,7 +56,7 @@ func TestGPUNodeReconcileNodeDiscoveryJobIgnoresFailedAttemptsWithoutFailedCondi
 		t.Fatalf("get GPUNode: %v", err)
 	}
 
-	if err := reconciler.reconcileNodeDiscoveryJob(ctx, currentNode, newNodeDiscoveryTestPool(t)); err != nil {
+	if err := reconciler.reconcileNodeDiscoveryJob(ctx, currentNode, newNodeDiscoveryTestPool(t), &corev1.Node{}); err != nil {
 		t.Fatalf("reconcileNodeDiscoveryJob: %v", err)
 	}
 
@@ -67,6 +67,93 @@ func TestGPUNodeReconcileNodeDiscoveryJobIgnoresFailedAttemptsWithoutFailedCondi
 
 	if updatedNode.Status.Phase != tfv1.TensorFusionGPUNodePhasePending {
 		t.Fatalf("expected GPUNode phase %q, got %q", tfv1.TensorFusionGPUNodePhasePending, updatedNode.Status.Phase)
+	}
+}
+
+func newBootIDTestCoreNode(bootID string) *corev1.Node {
+	return &corev1.Node{
+		Status: corev1.NodeStatus{
+			NodeInfo: corev1.NodeSystemInfo{BootID: bootID},
+		},
+	}
+}
+
+func newFinishedDiscoveryJob(gpuNodeName, bootID string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getDiscoveryJobName(gpuNodeName),
+			Namespace: utils.CurrentNamespace(),
+			Annotations: map[string]string{
+				constants.NodeBootIDAnnotationKey: bootID,
+			},
+		},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+// A node reboot (boot ID change) must re-trigger node discovery so that GPU
+// resources are refreshed, e.g. a physically removed card gets cleaned up.
+func TestGPUNodeReconcileRecreatesDiscoveryJobAfterNodeReboot(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+	gpuNode := newNodeDiscoveryTestGPUNode()
+	job := newFinishedDiscoveryJob(gpuNode.Name, "boot-1")
+
+	reconciler, kubeClient := newNodeDiscoveryTestReconciler(t, gpuNode, job)
+
+	if err := reconciler.reconcileNodeDiscoveryJob(ctx, gpuNode, newNodeDiscoveryTestPool(t),
+		newBootIDTestCoreNode("boot-2")); err != nil {
+		t.Fatalf("reconcileNodeDiscoveryJob: %v", err)
+	}
+
+	// the stale job from the previous boot must be deleted so the next reconcile
+	// (triggered by the owned-job deletion event) recreates it
+	stale := &batchv1.Job{}
+	err := kubeClient.Get(ctx, types.NamespacedName{
+		Name: getDiscoveryJobName(gpuNode.Name), Namespace: utils.CurrentNamespace()}, stale)
+	if err == nil {
+		t.Fatalf("expected stale discovery job from previous boot to be deleted")
+	}
+
+	// the follow-up reconcile recreates the job stamped with the current boot ID
+	if err := reconciler.reconcileNodeDiscoveryJob(ctx, gpuNode, newNodeDiscoveryTestPool(t),
+		newBootIDTestCoreNode("boot-2")); err != nil {
+		t.Fatalf("reconcileNodeDiscoveryJob recreate: %v", err)
+	}
+	recreated := &batchv1.Job{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{
+		Name: getDiscoveryJobName(gpuNode.Name), Namespace: utils.CurrentNamespace()}, recreated); err != nil {
+		t.Fatalf("expected discovery job recreated after reboot: %v", err)
+	}
+	if recreated.Annotations[constants.NodeBootIDAnnotationKey] != "boot-2" {
+		t.Fatalf("recreated job should be stamped with current boot ID, got %q",
+			recreated.Annotations[constants.NodeBootIDAnnotationKey])
+	}
+}
+
+func TestGPUNodeReconcileKeepsDiscoveryJobWithinSameBoot(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+	gpuNode := newNodeDiscoveryTestGPUNode()
+	job := newFinishedDiscoveryJob(gpuNode.Name, "boot-1")
+
+	reconciler, kubeClient := newNodeDiscoveryTestReconciler(t, gpuNode, job)
+
+	if err := reconciler.reconcileNodeDiscoveryJob(ctx, gpuNode, newNodeDiscoveryTestPool(t),
+		newBootIDTestCoreNode("boot-1")); err != nil {
+		t.Fatalf("reconcileNodeDiscoveryJob: %v", err)
+	}
+
+	kept := &batchv1.Job{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{
+		Name: getDiscoveryJobName(gpuNode.Name), Namespace: utils.CurrentNamespace()}, kept); err != nil {
+		t.Fatalf("completed discovery job of the current boot must be kept: %v", err)
 	}
 }
 
@@ -98,7 +185,7 @@ func TestGPUNodeReconcileNodeDiscoveryJobMarksNodeFailedOnFailedCondition(t *tes
 		t.Fatalf("get GPUNode: %v", err)
 	}
 
-	if err := reconciler.reconcileNodeDiscoveryJob(ctx, currentNode, newNodeDiscoveryTestPool(t)); err != nil {
+	if err := reconciler.reconcileNodeDiscoveryJob(ctx, currentNode, newNodeDiscoveryTestPool(t), &corev1.Node{}); err != nil {
 		t.Fatalf("reconcileNodeDiscoveryJob: %v", err)
 	}
 

--- a/internal/gpuallocator/node_capacity.go
+++ b/internal/gpuallocator/node_capacity.go
@@ -50,6 +50,11 @@ func RefreshGPUNodeCapacity(
 		if gpu.Status.Available == nil || gpu.Status.Capacity == nil {
 			continue
 		}
+		// GPUs marked missing by node discovery (e.g. physically removed) must not
+		// contribute phantom capacity to node statistics.
+		if utils.IsGPUMissing(&gpu) {
+			continue
+		}
 		node.Status.AvailableVRAM.Add(gpu.Status.Available.Vram)
 		node.Status.AvailableTFlops.Add(gpu.Status.Available.Tflops)
 		node.Status.TotalVRAM.Add(gpu.Status.Capacity.Vram)

--- a/internal/gpuallocator/node_capacity_missing_test.go
+++ b/internal/gpuallocator/node_capacity_missing_test.go
@@ -1,0 +1,80 @@
+package gpuallocator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/constants"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newCapacityTestGPU(name, owner string, phase tfv1.TensorFusionGPUPhase) *tfv1.GPU {
+	return &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.LabelKeyOwner: owner,
+			},
+		},
+		Status: tfv1.GPUStatus{
+			Phase:    phase,
+			GPUModel: "NVIDIA-Test-GPU",
+			Capacity: &tfv1.Resource{
+				Tflops: resource.MustParse("100"),
+				Vram:   resource.MustParse("16Gi"),
+			},
+			Available: &tfv1.Resource{
+				Tflops: resource.MustParse("100"),
+				Vram:   resource.MustParse("16Gi"),
+			},
+		},
+	}
+}
+
+// A GPU marked missing by node discovery must not contribute phantom capacity
+// to GPUNode level Total/Available statistics.
+func TestRefreshGPUNodeCapacityExcludesMissingGPUs(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = tfv1.AddToScheme(scheme)
+
+	nodeName := "capacity-test-node"
+	node := &tfv1.GPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	}
+	pool := &tfv1.GPUPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "capacity-test-pool"},
+	}
+
+	healthyGPU := newCapacityTestGPU("gpu-healthy", nodeName, tfv1.TensorFusionGPUPhaseRunning)
+	missingGPU := newCapacityTestGPU("gpu-missing", nodeName, tfv1.TensorFusionGPUPhaseUnknown)
+	missingGPU.Annotations = map[string]string{
+		constants.GPUMissingSinceAnnotationKey: time.Now().Format(time.RFC3339),
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPU{}, &tfv1.GPUNode{}).
+		WithObjects(node, pool, healthyGPU, missingGPU).Build()
+
+	allocator := NewGpuAllocator(ctx, k8sClient, time.Second)
+
+	_, err := RefreshGPUNodeCapacity(ctx, k8sClient, node, pool, allocator, nil)
+	assert.NoError(t, err)
+
+	expectedTflops := resource.MustParse("100")
+	expectedVram := resource.MustParse("16Gi")
+	assert.Equal(t, expectedTflops.String(), node.Status.TotalTFlops.String(),
+		"missing GPU capacity must be excluded from TotalTFlops")
+	assert.Equal(t, expectedVram.String(), node.Status.TotalVRAM.String(),
+		"missing GPU capacity must be excluded from TotalVRAM")
+	assert.Equal(t, expectedTflops.String(), node.Status.AvailableTFlops.String(),
+		"missing GPU must be excluded from AvailableTFlops")
+	assert.Equal(t, expectedVram.String(), node.Status.AvailableVRAM.String(),
+		"missing GPU must be excluded from AvailableVRAM")
+}

--- a/internal/utils/resource.go
+++ b/internal/utils/resource.go
@@ -14,6 +14,15 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+// IsGPUMissing returns true when the GPU device was marked missing by node
+// discovery (physical device not enumerated on the node while workloads still
+// reference it). Missing GPUs must be excluded from scheduling, phase sync and
+// capacity statistics until they either recover or are deleted by a later
+// discovery run once idle.
+func IsGPUMissing(gpu *tfv1.GPU) bool {
+	return gpu.Annotations[constants.GPUMissingSinceAnnotationKey] != ""
+}
+
 func GPUResourcesFromAnnotations(annotations map[string]string) (*tfv1.Resources, error) {
 	result := tfv1.Resources{}
 	resInfo := []struct {


### PR DESCRIPTION
Previously node discovery only created/updated GPU CRs, so a physically removed GPU kept polluting scheduling and node capacity statistics forever.

- delete GPU CRs directly when the device is no longer enumerated and has no running apps (ops always drain a card before pulling it)
- when a missing GPU is still referenced by running apps (e.g. GPU falling off the bus, transient NVML/driver hiccups), only mark it with Unknown phase and a missing-since annotation so allocation accounting survives recovery; it is deleted by a later discovery run once idle
- exclude missing GPUs from node capacity aggregation and node-level GPU phase sync so a marked GPU cannot re-enter scheduling or report phantom capacity
- clear the missing marker and reset Unknown phase back to Pending when the device reappears, preserving Available accounting