### PR TITLE
fix(nodediscovery): detect node reboot via job completion time vs node Ready transition

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -59,11 +59,7 @@ const (
 	// enumerated by the latest node discovery run, value is the RFC3339 time it
 	// was first found missing. Cleared automatically when the device reappears.
 	GPUMissingSinceAnnotationKey = Domain + "/gpu-missing-since"
-	// NodeBootIDAnnotationKey records the Kubernetes node boot ID a node-discovery
-	// job was created for, so a node reboot (boot ID change) re-triggers discovery
-	// to refresh GPU resources (e.g. clean up physically removed cards).
-	NodeBootIDAnnotationKey = Domain + "/node-boot-id"
-	WorkloadKey             = Domain + "/workload"
+	WorkloadKey                  = Domain + "/workload"
 
 	GpuPoolKey = Domain + "/gpupool"
 

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -353,14 +353,28 @@ func (r *GPUNodeReconciler) fetchAllOwnedGPUDevices(ctx context.Context, node *t
 	return gpuList.Items, nil
 }
 
-func isJobFinished(job *batchv1.Job) bool {
+// discoveryJobFinishedAt returns when the job finished, or nil if it is still
+// running. Failed jobs have no CompletionTime, so fall back to the Failed
+// condition transition time.
+func discoveryJobFinishedAt(job *batchv1.Job) *metav1.Time {
+	if job.Status.CompletionTime != nil {
+		return job.Status.CompletionTime
+	}
 	for _, c := range job.Status.Conditions {
-		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) &&
-			c.Status == corev1.ConditionTrue {
-			return true
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return &c.LastTransitionTime
 		}
 	}
-	return false
+	return nil
+}
+
+func nodeReadyLastTransition(coreNode *corev1.Node) *metav1.Time {
+	for _, c := range coreNode.Status.Conditions {
+		if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+			return &c.LastTransitionTime
+		}
+	}
+	return nil
 }
 
 func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
@@ -409,12 +423,6 @@ func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
 		},
 	}
 
-	if job.Annotations == nil {
-		job.Annotations = map[string]string{}
-	}
-	currentBootID := coreNode.Status.NodeInfo.BootID
-	job.Annotations[constants.NodeBootIDAnnotationKey] = currentBootID
-
 	if err := r.Get(ctx, client.ObjectKeyFromObject(job), job); err != nil {
 		if errors.IsNotFound(err) {
 			if err := ctrl.SetControllerReference(gpunode, job, r.Scheme); err != nil {
@@ -428,15 +436,17 @@ func (r *GPUNodeReconciler) reconcileNodeDiscoveryJob(
 		}
 	}
 
-	// A finished discovery job from a previous node boot is stale: after a reboot
-	// GPU devices may have changed (e.g. card physically removed), so delete the
-	// old job and let the next reconcile (triggered by the owned-job deletion
-	// event) recreate it to re-run discovery.
-	if currentBootID != "" && isJobFinished(job) &&
-		job.Annotations[constants.NodeBootIDAnnotationKey] != currentBootID {
-		log.Info("node rebooted since last discovery run, deleting stale discovery job to re-trigger it",
-			"node", gpunode.Name, "jobBootID", job.Annotations[constants.NodeBootIDAnnotationKey],
-			"currentBootID", currentBootID)
+	// A discovery job that finished before the node last became Ready ran against
+	// a previous boot (nodes transition NotReady -> Ready across a reboot), so its
+	// results may be stale, e.g. a physically removed card. Delete it and let the
+	// next reconcile (triggered by the owned-job deletion event) recreate it to
+	// re-run discovery. Ready flapping may cause a spurious re-run, which is
+	// harmless since discovery is idempotent.
+	finishedAt := discoveryJobFinishedAt(job)
+	readyAt := nodeReadyLastTransition(coreNode)
+	if finishedAt != nil && readyAt != nil && finishedAt.Before(readyAt) {
+		log.Info("node became Ready after last discovery run, deleting stale discovery job to re-trigger it",
+			"node", gpunode.Name, "jobFinishedAt", finishedAt, "nodeReadySince", readyAt)
 		if err := r.Delete(ctx, job,
 			client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("delete stale node discovery job %w", err)

--- a/internal/controller/gpunode_controller_unit_test.go
+++ b/internal/controller/gpunode_controller_unit_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/constants"
@@ -30,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -70,24 +72,28 @@ func TestGPUNodeReconcileNodeDiscoveryJobIgnoresFailedAttemptsWithoutFailedCondi
 	}
 }
 
-func newBootIDTestCoreNode(bootID string) *corev1.Node {
+func newReadyTestCoreNode(readyTransition time.Time) *corev1.Node {
 	return &corev1.Node{
 		Status: corev1.NodeStatus{
-			NodeInfo: corev1.NodeSystemInfo{BootID: bootID},
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(readyTransition),
+				},
+			},
 		},
 	}
 }
 
-func newFinishedDiscoveryJob(gpuNodeName, bootID string) *batchv1.Job {
+func newCompletedDiscoveryJob(gpuNodeName string, completedAt time.Time) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getDiscoveryJobName(gpuNodeName),
 			Namespace: utils.CurrentNamespace(),
-			Annotations: map[string]string{
-				constants.NodeBootIDAnnotationKey: bootID,
-			},
 		},
 		Status: batchv1.JobStatus{
+			CompletionTime: ptr.To(metav1.NewTime(completedAt)),
 			Conditions: []batchv1.JobCondition{
 				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
 			},
@@ -95,19 +101,21 @@ func newFinishedDiscoveryJob(gpuNodeName, bootID string) *batchv1.Job {
 	}
 }
 
-// A node reboot (boot ID change) must re-trigger node discovery so that GPU
-// resources are refreshed, e.g. a physically removed card gets cleaned up.
+// A discovery job that finished before the node last became Ready ran against a
+// previous boot: it must be deleted so discovery re-runs and refreshes GPU
+// resources, e.g. cleans up a physically removed card.
 func TestGPUNodeReconcileRecreatesDiscoveryJobAfterNodeReboot(t *testing.T) {
 	t.Helper()
 
 	ctx := context.Background()
+	now := time.Now()
 	gpuNode := newNodeDiscoveryTestGPUNode()
-	job := newFinishedDiscoveryJob(gpuNode.Name, "boot-1")
+	job := newCompletedDiscoveryJob(gpuNode.Name, now.Add(-2*time.Hour))
 
 	reconciler, kubeClient := newNodeDiscoveryTestReconciler(t, gpuNode, job)
 
 	if err := reconciler.reconcileNodeDiscoveryJob(ctx, gpuNode, newNodeDiscoveryTestPool(t),
-		newBootIDTestCoreNode("boot-2")); err != nil {
+		newReadyTestCoreNode(now.Add(-time.Hour))); err != nil {
 		t.Fatalf("reconcileNodeDiscoveryJob: %v", err)
 	}
 
@@ -120,9 +128,9 @@ func TestGPUNodeReconcileRecreatesDiscoveryJobAfterNodeReboot(t *testing.T) {
 		t.Fatalf("expected stale discovery job from previous boot to be deleted")
 	}
 
-	// the follow-up reconcile recreates the job stamped with the current boot ID
+	// the follow-up reconcile recreates the job
 	if err := reconciler.reconcileNodeDiscoveryJob(ctx, gpuNode, newNodeDiscoveryTestPool(t),
-		newBootIDTestCoreNode("boot-2")); err != nil {
+		newReadyTestCoreNode(now.Add(-time.Hour))); err != nil {
 		t.Fatalf("reconcileNodeDiscoveryJob recreate: %v", err)
 	}
 	recreated := &batchv1.Job{}
@@ -130,30 +138,49 @@ func TestGPUNodeReconcileRecreatesDiscoveryJobAfterNodeReboot(t *testing.T) {
 		Name: getDiscoveryJobName(gpuNode.Name), Namespace: utils.CurrentNamespace()}, recreated); err != nil {
 		t.Fatalf("expected discovery job recreated after reboot: %v", err)
 	}
-	if recreated.Annotations[constants.NodeBootIDAnnotationKey] != "boot-2" {
-		t.Fatalf("recreated job should be stamped with current boot ID, got %q",
-			recreated.Annotations[constants.NodeBootIDAnnotationKey])
-	}
 }
 
-func TestGPUNodeReconcileKeepsDiscoveryJobWithinSameBoot(t *testing.T) {
+func TestGPUNodeReconcileKeepsDiscoveryJobCompletedAfterNodeReady(t *testing.T) {
 	t.Helper()
 
 	ctx := context.Background()
+	now := time.Now()
 	gpuNode := newNodeDiscoveryTestGPUNode()
-	job := newFinishedDiscoveryJob(gpuNode.Name, "boot-1")
+	// job completed after the node last became Ready: same boot, must be kept
+	job := newCompletedDiscoveryJob(gpuNode.Name, now.Add(-time.Hour))
 
 	reconciler, kubeClient := newNodeDiscoveryTestReconciler(t, gpuNode, job)
 
 	if err := reconciler.reconcileNodeDiscoveryJob(ctx, gpuNode, newNodeDiscoveryTestPool(t),
-		newBootIDTestCoreNode("boot-1")); err != nil {
+		newReadyTestCoreNode(now.Add(-2*time.Hour))); err != nil {
 		t.Fatalf("reconcileNodeDiscoveryJob: %v", err)
 	}
 
 	kept := &batchv1.Job{}
 	if err := kubeClient.Get(ctx, types.NamespacedName{
 		Name: getDiscoveryJobName(gpuNode.Name), Namespace: utils.CurrentNamespace()}, kept); err != nil {
-		t.Fatalf("completed discovery job of the current boot must be kept: %v", err)
+		t.Fatalf("discovery job completed in the current boot must be kept: %v", err)
+	}
+}
+
+func TestGPUNodeReconcileKeepsDiscoveryJobWhenNodeHasNoReadyCondition(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+	gpuNode := newNodeDiscoveryTestGPUNode()
+	job := newCompletedDiscoveryJob(gpuNode.Name, time.Now().Add(-2*time.Hour))
+
+	reconciler, kubeClient := newNodeDiscoveryTestReconciler(t, gpuNode, job)
+
+	if err := reconciler.reconcileNodeDiscoveryJob(ctx, gpuNode, newNodeDiscoveryTestPool(t),
+		&corev1.Node{}); err != nil {
+		t.Fatalf("reconcileNodeDiscoveryJob: %v", err)
+	}
+
+	kept := &batchv1.Job{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{
+		Name: getDiscoveryJobName(gpuNode.Name), Namespace: utils.CurrentNamespace()}, kept); err != nil {
+		t.Fatalf("discovery job must be kept when node Ready condition is absent: %v", err)
 	}
 }
 


### PR DESCRIPTION

Replace the boot ID annotation approach with a zero-intrusion check: a discovery job that finished before the node's Ready condition last transitioned ran against a previous boot, so delete it to re-trigger discovery. Uses only existing fields (Job CompletionTime / Failed condition transition time and Node Ready LastTransitionTime), covers legacy jobs without upgrade churn, and a Ready flap at worst causes one harmless idempotent discovery re-run.