### PR TITLE
fix: port v1 fixes to main (defrag #734, inflight/pending #713, stale-GPU cleanup #736) + not-ready hypervisor gate

### DIFF
--- a/charts/tensor-fusion/Chart.yaml
+++ b/charts/tensor-fusion/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.8
+version: 1.7.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tensor-fusion/templates/rbac-hypervisor.yaml
+++ b/charts/tensor-fusion/templates/rbac-hypervisor.yaml
@@ -28,6 +28,9 @@ rules:
   - create
   - update
   - patch
+  # delete is required to clean up GPU resources whose physical device was
+  # removed (OnRemove and the stale-GPU reconciliation on discovery).
+  - delete
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/charts/tensor-fusion/templates/rbac.yaml
+++ b/charts/tensor-fusion/templates/rbac.yaml
@@ -222,7 +222,6 @@ rules:
   - deviceclasses
   - devicetaintrules
   - resourceslices
-  - resourceclaims
   verbs:
   - get
   - list

--- a/charts/tensor-fusion/values.schema.json
+++ b/charts/tensor-fusion/values.schema.json
@@ -476,6 +476,10 @@
             "type": "string"
           }
         },
+        "maxInFlightNodes": {
+          "type": "integer",
+          "description": "Cap on how many nodes the auto-expander may provision concurrently, defaults to 15 when unset or <= 0"
+        },
         "alertRules": {
           "type": "array",
           "description": "Alerting rules",

--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -861,8 +861,13 @@ dynamicConfig:
   # you can map label keys to other measure tags
   metricsExtraPodLabels: {}
   preemptClusterWideFromEnv: true
+
+  # Cap on how many nodes the auto-expander may provision concurrently.
+  # Defaults to 15 when unset or <= 0.
+  maxInFlightNodes: 15
+
   # alert rules
-  alertRules:    
+  alertRules:
     # Worker TFlops throttled alert
     - name: WorkerTFlopsThrottled
       query: |

--- a/config/samples/dynamic-config.yaml
+++ b/config/samples/dynamic-config.yaml
@@ -5,7 +5,12 @@ metricsFormat: influx
 
 autoScalingInterval: 10s
 preemptClusterWideFromEnv: true
-alertRules:    
+
+# Cap on how many nodes the auto-expander may provision concurrently.
+# Defaults to 15 when unset or <= 0.
+maxInFlightNodes: 15
+
+alertRules:
   # Worker TFlops throttled alert
   - name: WorkerTFlopsThrottled
     query: |

--- a/internal/autoscaler/autoscaler_suite_test.go
+++ b/internal/autoscaler/autoscaler_suite_test.go
@@ -722,6 +722,15 @@ func (b *TensorFusionEnvBuilder) Build() *TensorFusionEnv {
 			}
 			Expect(k8sClient.Create(ctx, coreNode)).To(Succeed())
 
+			// Mark the node Ready so reconcileHypervisorPod's not-ready gate
+			// allows hypervisor pod creation; a real node backing a GPUNode is
+			// always Ready (envtest has no kubelet to post this on its own).
+			nodePatch := client.MergeFrom(coreNode.DeepCopy())
+			coreNode.Status.Conditions = []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			}
+			Expect(k8sClient.Status().Patch(ctx, coreNode, nodePatch)).To(Succeed())
+
 			// generate gpus for gpunode
 			gpuNode := b.GetGPUNode(poolIndex, nodeIndex)
 			gpuCount := b.poolNodeMap[poolIndex][nodeIndex]

--- a/internal/config/global_config.go
+++ b/internal/config/global_config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,6 +21,10 @@ type GlobalConfig struct {
 	// HypervisorMaxCrashCount is the container RestartCount threshold that triggers
 	// a hypervisor pod recreation. Set to 0 to disable. nil uses the default.
 	HypervisorMaxCrashCount *int32 `yaml:"hypervisorMaxCrashCount"`
+
+	// MaxInFlightNodes caps how many nodes the auto-expander may provision
+	// concurrently. If nil or <= 0, falls back to DefaultMaxInFlightNodes.
+	MaxInFlightNodes *int `yaml:"maxInFlightNodes"`
 }
 
 type AutoMigrationConfig struct {
@@ -38,18 +43,22 @@ type AutoMigrationRules struct {
 	PodSelector       *metav1.LabelSelector `yaml:"podSelector"`
 }
 
-var globalConfig *GlobalConfig
+// globalConfig is read from the scheduler hot path (e.g. GetMaxInFlightNodes)
+// while a config-watch goroutine updates it via SetGlobalConfig, so it must be
+// accessed atomically to avoid data races.
+var globalConfig atomic.Pointer[GlobalConfig]
 
 func GetGlobalConfig() *GlobalConfig {
-	if globalConfig == nil {
+	cfg := globalConfig.Load()
+	if cfg == nil {
 		fmt.Println("[WARN] trying to get global config before initialized")
 		return &GlobalConfig{}
 	}
-	return globalConfig
+	return cfg
 }
 
 func SetGlobalConfig(config *GlobalConfig) {
-	globalConfig = config
+	globalConfig.Store(config)
 }
 
 const (
@@ -68,7 +77,21 @@ const (
 
 	// DefaultHypervisorMaxCrashCount is used when HypervisorMaxCrashCount is unset.
 	DefaultHypervisorMaxCrashCount int32 = 5
+
+	// DefaultMaxInFlightNodes is the fallback cap on concurrently
+	// provisioning nodes when MaxInFlightNodes is not configured.
+	DefaultMaxInFlightNodes = 15
 )
+
+// GetMaxInFlightNodes returns the configured cap on concurrently provisioning
+// nodes for the auto-expander, or the default value when not configured.
+func GetMaxInFlightNodes() int {
+	cfg := GetGlobalConfig()
+	if cfg.MaxInFlightNodes == nil || *cfg.MaxInFlightNodes <= 0 {
+		return DefaultMaxInFlightNodes
+	}
+	return *cfg.MaxInFlightNodes
+}
 
 // GetGPUOperatorNamespace returns the configured GPU operator namespace or default value
 func GetGPUOperatorNamespace() string {

--- a/internal/config/global_config_test.go
+++ b/internal/config/global_config_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"testing"
+
+	"k8s.io/utils/ptr"
+)
+
+func TestGetMaxInFlightNodes(t *testing.T) {
+	original := globalConfig.Load()
+	t.Cleanup(func() { globalConfig.Store(original) })
+
+	tests := []struct {
+		name  string
+		value *int
+		want  int
+	}{
+		{name: "unset falls back to default", value: nil, want: DefaultMaxInFlightNodes},
+		{name: "zero falls back to default", value: ptr.To(0), want: DefaultMaxInFlightNodes},
+		{name: "negative falls back to default", value: ptr.To(-3), want: DefaultMaxInFlightNodes},
+		{name: "configured value wins", value: ptr.To(42), want: 42},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetGlobalConfig(&GlobalConfig{MaxInFlightNodes: tt.value})
+			if got := GetMaxInFlightNodes(); got != tt.want {
+				t.Fatalf("GetMaxInFlightNodes() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -368,6 +368,25 @@ func isNodeReady(node *corev1.Node) bool {
 	return false
 }
 
+// removeStuckHypervisorPodOnNotReadyNode deletes a hypervisor pod that never
+// reached Running on a NotReady node; a Running pod is left alone (k8s NoExecute
+// eviction handles it, and it may be only a transient blip). Returns nil so the
+// caller skips creation. Recovery re-triggers reconcile via the Node watch.
+func (r *GPUNodeReconciler) removeStuckHypervisorPodOnNotReadyNode(
+	ctx context.Context, node *tfv1.GPUNode, currentPod *corev1.Pod, podExists bool,
+) error {
+	log := log.FromContext(ctx)
+	if podExists && currentPod.Status.Phase != corev1.PodRunning && currentPod.DeletionTimestamp.IsZero() {
+		log.Info("node is not ready, deleting non-running hypervisor pod",
+			"node", node.Name, "pod", currentPod.Name, "podPhase", currentPod.Status.Phase)
+		if err := r.Delete(ctx, currentPod); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete hypervisor pod on not-ready node: %w", err)
+		}
+	}
+	log.V(1).Info("node is not ready, skip hypervisor pod reconciliation", "node", node.Name)
+	return nil
+}
+
 func (r *GPUNodeReconciler) reconcileHypervisorPod(
 	ctx context.Context,
 	node *tfv1.GPUNode,
@@ -405,15 +424,7 @@ func (r *GPUNodeReconciler) reconcileHypervisorPod(
 	// is intentionally NOT gated here: a cordoned node is still healthy and its
 	// hypervisor must keep running.
 	if !isNodeReady(k8sNode) {
-		if podExists && currentPod.Status.Phase != corev1.PodRunning && currentPod.DeletionTimestamp.IsZero() {
-			log.Info("node is not ready, deleting non-running hypervisor pod",
-				"node", node.Name, "pod", currentPod.Name, "podPhase", currentPod.Status.Phase)
-			if err := r.Delete(ctx, currentPod); err != nil && !errors.IsNotFound(err) {
-				return "", fmt.Errorf("failed to delete hypervisor pod on not-ready node: %w", err)
-			}
-		}
-		log.V(1).Info("node is not ready, skip hypervisor pod reconciliation", "node", node.Name)
-		return "", nil
+		return "", r.removeStuckHypervisorPodOnNotReadyNode(ctx, node, currentPod, podExists)
 	}
 
 	// Check hypervisor prerequisites (e.g., device plugin pod for NVIDIA)

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -146,6 +146,28 @@ func (r *GPUNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
+	// Ensure the GPUNode never sits with an empty phase during the inflight window
+	// (before node-discovery completes / when discovery fails), so phase-based
+	// monitoring can observe it. New GPUNodes are born Pending in the NodeReconciler,
+	// this is a safety net for pre-existing nodes with empty phase. Placed before the
+	// driver-upgrade gate below, since it requeues early.
+	if node.Status.Phase == "" {
+		nodePhaseChanged, gpuList, err := r.syncNodeAndOwnedGPUPhases(
+			ctx, node,
+			tfv1.TensorFusionGPUNodePhasePending,
+			tfv1.TensorFusionGPUPhasePending,
+		)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to initialize GPUNode phase to Pending: %w", err)
+		}
+		if nodePhaseChanged {
+			metrics.SetNodeMetrics(node, poolObj, nil)
+		}
+		if len(gpuList) > 0 {
+			metrics.SetGPUMetrics(gpuList, node.Name, poolObj.Name)
+		}
+	}
+
 	// Check if the node is undergoing NVIDIA GPU driver upgrade
 	if isNodeUnderGPUDriverUpgrade(coreNode) {
 		log.Info("Node is undergoing GPU driver upgrade, skip reconciling",
@@ -306,6 +328,12 @@ func (r *GPUNodeReconciler) syncStatusToGPUDevices(ctx context.Context, node *tf
 	}
 
 	for _, gpu := range gpuList {
+		// GPUs marked missing by hypervisor discovery must keep their Unknown
+		// phase, otherwise node level sync would put a physically absent GPU
+		// back into scheduling rotation.
+		if utils.IsGPUMissing(&gpu) {
+			continue
+		}
 		if gpu.Status.Phase != state {
 			patch := client.MergeFrom(gpu.DeepCopy())
 			gpu.Status.Phase = state
@@ -323,6 +351,21 @@ func (r *GPUNodeReconciler) fetchAllOwnedGPUDevices(ctx context.Context, node *t
 		return nil, fmt.Errorf("failed to list GPUs: %w", err)
 	}
 	return gpuList.Items, nil
+}
+
+// isNodeReady reports whether the core Kubernetes node's Ready condition is
+// True. A NotReady node (Ready False/Unknown, e.g. unreachable) must not get a
+// hypervisor pod created on it.
+func isNodeReady(node *corev1.Node) bool {
+	if node == nil {
+		return false
+	}
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (r *GPUNodeReconciler) reconcileHypervisorPod(
@@ -351,6 +394,26 @@ func (r *GPUNodeReconciler) reconcileHypervisorPod(
 		}
 	} else {
 		podExists = true
+	}
+
+	// A NotReady node cannot run a hypervisor pod: creating one just leaves it
+	// Pending on the dead node forever (the pod tolerates the not-ready /
+	// unreachable taints to survive transient blips). Skip creation and clean
+	// up any pod that never reached Running; a Running pod is left alone in case
+	// the node is only briefly unreachable. Recovery re-triggers this reconcile
+	// via the core Node watch in SetupWithManager. Cordon (spec.Unschedulable)
+	// is intentionally NOT gated here: a cordoned node is still healthy and its
+	// hypervisor must keep running.
+	if !isNodeReady(k8sNode) {
+		if podExists && currentPod.Status.Phase != corev1.PodRunning && currentPod.DeletionTimestamp.IsZero() {
+			log.Info("node is not ready, deleting non-running hypervisor pod",
+				"node", node.Name, "pod", currentPod.Name, "podPhase", currentPod.Status.Phase)
+			if err := r.Delete(ctx, currentPod); err != nil && !errors.IsNotFound(err) {
+				return "", fmt.Errorf("failed to delete hypervisor pod on not-ready node: %w", err)
+			}
+		}
+		log.V(1).Info("node is not ready, skip hypervisor pod reconciliation", "node", node.Name)
+		return "", nil
 	}
 
 	// Check hypervisor prerequisites (e.g., device plugin pod for NVIDIA)

--- a/internal/controller/gpunode_controller_missing_test.go
+++ b/internal/controller/gpunode_controller_missing_test.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newMissingSyncTestGPU(name, owner string, phase tfv1.TensorFusionGPUPhase) *tfv1.GPU {
+	return &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.LabelKeyOwner: owner,
+			},
+		},
+		Status: tfv1.GPUStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func TestSyncStatusToGPUDevicesSkipsMissingGPUs(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+	s := runtime.NewScheme()
+	if err := tfv1.AddToScheme(s); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	gpuNode := &tfv1.GPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "missing-sync-test-node"},
+	}
+
+	normalGPU := newMissingSyncTestGPU("gpu-normal", gpuNode.Name, tfv1.TensorFusionGPUPhasePending)
+
+	missingGPU := newMissingSyncTestGPU("gpu-missing", gpuNode.Name, tfv1.TensorFusionGPUPhaseUnknown)
+	missingGPU.Annotations = map[string]string{
+		constants.GPUMissingSinceAnnotationKey: "2026-07-13T00:00:00Z",
+	}
+
+	kubeClient := fake.NewClientBuilder().WithScheme(s).
+		WithStatusSubresource(&tfv1.GPU{}).
+		WithObjects(gpuNode, normalGPU, missingGPU).Build()
+	reconciler := &GPUNodeReconciler{Client: kubeClient, Scheme: s}
+
+	if _, err := reconciler.syncStatusToGPUDevices(ctx, gpuNode, tfv1.TensorFusionGPUPhaseRunning); err != nil {
+		t.Fatalf("syncStatusToGPUDevices: %v", err)
+	}
+
+	updated := &tfv1.GPU{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: "gpu-normal"}, updated); err != nil {
+		t.Fatalf("get normal GPU: %v", err)
+	}
+	if updated.Status.Phase != tfv1.TensorFusionGPUPhaseRunning {
+		t.Fatalf("expected normal GPU phase %q, got %q", tfv1.TensorFusionGPUPhaseRunning, updated.Status.Phase)
+	}
+
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: "gpu-missing"}, updated); err != nil {
+		t.Fatalf("get missing GPU: %v", err)
+	}
+	if updated.Status.Phase != tfv1.TensorFusionGPUPhaseUnknown {
+		t.Fatalf("missing GPU phase must stay %q, got %q", tfv1.TensorFusionGPUPhaseUnknown, updated.Status.Phase)
+	}
+}

--- a/internal/controller/gpunode_controller_unit_test.go
+++ b/internal/controller/gpunode_controller_unit_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestGPUNodeReconcileInitializesEmptyPhaseToPending covers the safety net for
+// pre-existing GPUNodes with an empty phase: the reconciler must set it to
+// Pending before any early-return gate (here the driver-upgrade gate), so the
+// inflight window is never invisible to phase-based monitoring.
+func TestGPUNodeReconcileInitializesEmptyPhaseToPending(t *testing.T) {
+	ctx := context.Background()
+
+	pool := &tfv1.GPUPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+	}
+	// GPUNode in the inflight window: no status set yet (empty phase, no GPUs discovered).
+	gpuNode := &tfv1.GPUNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "node-1",
+			Finalizers: []string{constants.Finalizer},
+			Labels: map[string]string{
+				fmt.Sprintf(constants.GPUNodePoolIdentifierLabelFormat, pool.Name): "true",
+			},
+		},
+	}
+	// Driver-upgrade label makes Reconcile requeue right after the empty-phase
+	// safety net, proving the phase is initialized by the safety net itself and
+	// not by any later reconcile step.
+	coreNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gpuNode.Name,
+			Labels: map[string]string{
+				constants.NvidiaGPUDriverUpgradeStateLabel: "upgrade-in-progress",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := tfv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add TensorFusion scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core/v1 scheme: %v", err)
+	}
+
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPUNode{}, &tfv1.GPU{}).
+		WithObjects(pool, gpuNode, coreNode).
+		Build()
+
+	reconciler := &GPUNodeReconciler{
+		Client: kubeClient,
+		Scheme: scheme,
+	}
+
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: gpuNode.Name}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	updatedNode := &tfv1.GPUNode{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: gpuNode.Name}, updatedNode); err != nil {
+		t.Fatalf("get updated GPUNode: %v", err)
+	}
+	if updatedNode.Status.Phase != tfv1.TensorFusionGPUNodePhasePending {
+		t.Fatalf("expected GPUNode phase %q, got %q", tfv1.TensorFusionGPUNodePhasePending, updatedNode.Status.Phase)
+	}
+}
+
+// TestIsNodeReady pins the gate signal used by reconcileHypervisorPod: only a
+// Ready=True node may get a hypervisor pod. Ready False/Unknown, a missing
+// Ready condition, and a nil node must all read as not-ready so no pod is
+// created on a dead node. Cordon (spec.Unschedulable) is deliberately not part
+// of this signal.
+func TestIsNodeReady(t *testing.T) {
+	nodeWith := func(status corev1.ConditionStatus) *corev1.Node {
+		return &corev1.Node{Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{
+			{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+			{Type: corev1.NodeReady, Status: status},
+		}}}
+	}
+	cases := []struct {
+		name string
+		node *corev1.Node
+		want bool
+	}{
+		{"ready", nodeWith(corev1.ConditionTrue), true},
+		{"not-ready", nodeWith(corev1.ConditionFalse), false},
+		{"unknown", nodeWith(corev1.ConditionUnknown), false},
+		{"no-ready-condition", &corev1.Node{}, false},
+		{"nil", nil, false},
+		{"cordoned-but-ready", &corev1.Node{
+			Spec:   corev1.NodeSpec{Unschedulable: true},
+			Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}},
+		}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isNodeReady(c.node); got != c.want {
+				t.Fatalf("isNodeReady(%s) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -1031,7 +1031,7 @@ func (r *GPUPoolCompactionReconciler) processDefragCandidate(
 	}
 	cand.workerPods = refreshedPods
 
-	canRelocate, simErr := r.simulateJointPlacement(ctx, pool, cand, maxWorkerPerNode)
+	canRelocate, placementDiag, simErr := r.simulateJointPlacement(ctx, pool, cand, maxWorkerPerNode)
 	if simErr != nil {
 		l.Error(simErr, "joint placement simulation errored; abort candidate")
 		r.Recorder.Eventf(pool, nil, corev1.EventTypeWarning, defragEventAbortNode, defragEventAbortNode,
@@ -1040,8 +1040,15 @@ func (r *GPUPoolCompactionReconciler) processDefragCandidate(
 	}
 	if !canRelocate {
 		stats.UnmovableNodes++
+		if placementDiag != nil {
+			l.Info("defrag joint placement rejected candidate", "diagnostics", placementDiag.logFields())
+		}
+		summary := "current TF workers cannot be jointly placed on other nodes"
+		if placementDiag != nil {
+			summary = placementDiag.summary()
+		}
 		r.Recorder.Eventf(pool, nil, corev1.EventTypeNormal, defragEventSkipUnschedulable, defragEventSkipUnschedulable,
-			"node %s skipped: current TF workers cannot be jointly placed on other nodes", cand.nodeName)
+			"node %s skipped: %s", cand.nodeName, summary)
 		return defragCandidateSkipped
 	}
 
@@ -1089,10 +1096,10 @@ func (r *GPUPoolCompactionReconciler) simulateJointPlacement(
 	pool *tfv1.GPUPool,
 	cand *defragCandidate,
 	maxWorkerPerNode int,
-) (bool, error) {
+) (bool, *defragPlacementDiagnostics, error) {
 	fitAPI, ok := any(r.Scheduler).(schedulerFitPodAPI)
 	if !ok {
-		return false, errors.New("scheduler vendor patch missing: run scripts/patch-scheduler.sh")
+		return false, nil, errors.New("scheduler vendor patch missing: run scripts/patch-scheduler.sh")
 	}
 	profileName := constants.SchedulerName
 	if len(cand.workerPods) > 0 && cand.workerPods[0].Spec.SchedulerName != "" {
@@ -1100,36 +1107,39 @@ func (r *GPUPoolCompactionReconciler) simulateJointPlacement(
 	}
 	schedFramework := r.Scheduler.Profiles[profileName]
 	if schedFramework == nil {
-		return false, fmt.Errorf("scheduler framework not found for scheduler %q", profileName)
+		return false, nil, fmt.Errorf("scheduler framework not found for scheduler %q", profileName)
 	}
 	if err := fitAPI.UpdateNodeInfoSnapshot(ctx); err != nil {
-		return false, fmt.Errorf("refresh scheduler snapshot before defrag simulation: %w", err)
+		return false, nil, fmt.Errorf("refresh scheduler snapshot before defrag simulation: %w", err)
 	}
 
-	budget := buildDefragNodeBudgets(
+	budget, accounting, exclusions := buildDefragNodeBudgets(
 		pool.Name,
 		cand.nodeName,
 		r.Allocator.GetNodeGpuStore(),
 		r.Allocator.GetNodeWorkerStoreSnapshot(),
 		schedFramework.SnapshotSharedLister().NodeInfos(),
 	)
+	diag := newDefragPlacementDiagnostics(cand.nodeName, profileName, sortedBudgetNodes(budget))
+	diag.BudgetNodes = accounting
+	diag.ExcludedNodes = exclusions
 	if len(budget) == 0 {
-		return false, nil
+		return false, diag, nil
 	}
 
 	for _, srcPod := range cand.workerPods {
 		if ctxDone(ctx) {
-			return false, ctx.Err()
+			return false, diag, ctx.Err()
 		}
-		placed, err := r.placeSinglePod(ctx, fitAPI, srcPod, budget, maxWorkerPerNode, cand.utilizationScore)
+		placed, err := r.placeSinglePod(ctx, fitAPI, srcPod, budget, maxWorkerPerNode, cand.utilizationScore, diag)
 		if err != nil {
-			return false, err
+			return false, diag, err
 		}
 		if !placed {
-			return false, nil
+			return false, diag, nil
 		}
 	}
-	return true, nil
+	return true, diag, nil
 }
 
 // placeSinglePod intersects scheduler-feasible nodes with the local budget
@@ -1144,8 +1154,12 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 	budget map[string]*nodeBudget,
 	maxWorkerPerNode int,
 	sourceUtilization float64,
+	diag *defragPlacementDiagnostics,
 ) (bool, error) {
 	podCopy := cloneAsUnscheduledWorker(pod)
+	if diag != nil {
+		diag.startPod(podCopy)
+	}
 
 	fwkInstance := r.Scheduler.Profiles[podCopy.Spec.SchedulerName]
 	if fwkInstance == nil {
@@ -1164,6 +1178,13 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 	feasible, _, _, _, err := fitAPI.FindNodesThatFitPod(ctx, fwkInstance, state, podCopy)
 	if err != nil {
 		return false, fmt.Errorf("find feasible nodes: %w", err)
+	}
+	if diag != nil {
+		diag.setFeasibleNodes(feasible)
+		for _, reason := range schedulerSimulationFilterReasons(state) {
+			diag.addSchedulerDetail(reason)
+		}
+		diag.markBudgetNotFeasible(budget, feasible)
 	}
 	if len(feasible) == 0 {
 		return false, nil
@@ -1194,10 +1215,16 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 		}
 		nb, ok := budget[tgt]
 		if !ok {
+			if diag != nil {
+				diag.reject(tgt, "not-in-budget", "scheduler feasible node is not a defrag budget target")
+			}
 			continue
 		}
 
 		if !targetAcceptsAnotherWorker(nb, maxWorkerPerNode) {
+			if diag != nil {
+				diag.reject(tgt, "max-worker-per-node", fmt.Sprintf("workerCount=%d max=%d", nb.workerCount, maxWorkerPerNode))
+			}
 			continue
 		}
 		// Monotonicity gate: workers may only flow toward at-least-as-
@@ -1206,15 +1233,28 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 		if targetUtil < sourceUtilization {
 			log.FromContext(ctx).V(5).Info("defrag reject lower-utilization target",
 				"target", tgt, "targetUtil", targetUtil, "sourceUtil", sourceUtilization)
+			if diag != nil {
+				diag.reject(tgt, "monotonicity", fmt.Sprintf("targetUtil=%.2f sourceUtil=%.2f", targetUtil, sourceUtilization))
+			}
 			continue
 		}
 		candidateInfo := cloneNodeInfoWithVirtualPod(nb.nodeInfo, podInfo)
-		if candidateInfo == nil || !fitsVirtualNodeAllocatable(candidateInfo) {
+		if ok, reason := virtualNodeAllocatableReason(candidateInfo); !ok {
+			if diag != nil {
+				diag.reject(tgt, "virtual-node-resource", reason)
+			}
 			continue
 		}
 		// Re-run filters on the virtualized snapshot so resource plugins
 		// see capacity already consumed by prior simulated placements.
-		if status := fwkInstance.RunFilterPluginsWithNominatedPods(ctx, state.Clone(), podCopy, candidateInfo); status != nil && !status.IsSuccess() {
+		virtualState := state.Clone()
+		if status := fwkInstance.RunFilterPluginsWithNominatedPods(ctx, virtualState, podCopy, candidateInfo); status != nil && !status.IsSuccess() {
+			if diag != nil {
+				diag.reject(tgt, "scheduler-filter", status.Message())
+				for _, reason := range schedulerSimulationFilterReasons(virtualState) {
+					diag.addSchedulerDetail(reason)
+				}
+			}
 			continue
 		}
 
@@ -1224,11 +1264,25 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 		}
 		filtered, _, ferr := r.Allocator.Filter(req, gpuList, true /* isSimulateSchedule */)
 		if ferr != nil || len(filtered) == 0 || uint(len(filtered)) < req.Count {
+			if diag != nil {
+				reason := fmt.Sprintf("filtered=%d required=%d", len(filtered), req.Count)
+				if ferr != nil {
+					reason = ferr.Error()
+				}
+				diag.reject(tgt, "allocator-filter", reason)
+			}
 			continue
 		}
 
-		selected, serr := r.Allocator.Select(req, filtered)
+		selected, serr := r.Allocator.SelectFromStore(req, filtered, map[string]map[string]*tfv1.GPU{tgt: nb.gpus})
 		if serr != nil || len(selected) != int(req.Count) {
+			if diag != nil {
+				reason := fmt.Sprintf("selected=%d required=%d", len(selected), req.Count)
+				if serr != nil {
+					reason = serr.Error()
+				}
+				diag.reject(tgt, "allocator-select", reason)
+			}
 			continue
 		}
 
@@ -1271,6 +1325,286 @@ func targetAcceptsAnotherWorker(nb *nodeBudget, maxWorkerPerNode int) bool {
 		return true
 	}
 	return nb.workerCount < maxWorkerPerNode
+}
+
+type defragPlacementDiagnostics struct {
+	SourceNode     string
+	Profile        string
+	BudgetTargets  []string
+	BudgetNodes    []defragBudgetNodeAccounting
+	ExcludedNodes  []defragNodeExclusion
+	PodDiagnostics []*defragPodPlacementDiagnostic
+}
+
+// defragBudgetNodeAccounting is the per-target GPU tally as the budget saw it.
+// Free==0 while Dirty>0 is the tell-tale sign that unreported GPU status (not
+// real occupancy) is what blocked a relocation.
+type defragBudgetNodeAccounting struct {
+	Node  string
+	Total int
+	Used  int
+	Free  int
+	Dirty int
+}
+
+// defragNodeExclusion records a target node that never entered the budget, so
+// "230-113 not in budget" can be read back as a concrete reason instead of a
+// silent gap.
+type defragNodeExclusion struct {
+	Node   string
+	Reason string
+}
+
+type defragPodPlacementDiagnostic struct {
+	Pod              string
+	Request          string
+	FeasibleNodes    []string
+	SchedulerDetails []string
+	Rejections       []defragTargetRejection
+	SelectedTarget   string
+}
+
+type defragTargetRejection struct {
+	Target string
+	Stage  string
+	Reason string
+}
+
+func newDefragPlacementDiagnostics(sourceNode, profile string, budgetTargets []string) *defragPlacementDiagnostics {
+	return &defragPlacementDiagnostics{
+		SourceNode:    sourceNode,
+		Profile:       profile,
+		BudgetTargets: append([]string(nil), budgetTargets...),
+	}
+}
+
+func (d *defragPlacementDiagnostics) startPod(pod *corev1.Pod) {
+	if d == nil || pod == nil {
+		return
+	}
+	pd := &defragPodPlacementDiagnostic{
+		Pod:     pod.Namespace + "/" + pod.Name,
+		Request: defragPodRequestSummary(pod),
+	}
+	d.PodDiagnostics = append(d.PodDiagnostics, pd)
+}
+
+func (d *defragPlacementDiagnostics) currentPod() *defragPodPlacementDiagnostic {
+	if d == nil || len(d.PodDiagnostics) == 0 {
+		return nil
+	}
+	return d.PodDiagnostics[len(d.PodDiagnostics)-1]
+}
+
+func (d *defragPlacementDiagnostics) setFeasibleNodes(nodes []fwk.NodeInfo) {
+	pd := d.currentPod()
+	if pd == nil {
+		return
+	}
+	pd.FeasibleNodes = nodeInfoNames(nodes)
+}
+
+func (d *defragPlacementDiagnostics) reject(target, stage, reason string) {
+	pd := d.currentPod()
+	if pd == nil {
+		d.startPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "unknown", Name: "unknown"}})
+		pd = d.currentPod()
+	}
+	pd.Rejections = append(pd.Rejections, defragTargetRejection{
+		Target: target,
+		Stage:  stage,
+		Reason: truncateDiagnostic(reason, 180),
+	})
+}
+
+// markBudgetNotFeasible records each budget target the scheduler did not return
+// as feasible. This is the earliest place a dirty/unreported GPU shows up: the
+// scheduler resource filter drops the node before defrag ever scores it, so
+// without this the node just silently vanishes from the rejection trail.
+func (d *defragPlacementDiagnostics) markBudgetNotFeasible(budget map[string]*nodeBudget, feasible []fwk.NodeInfo) {
+	if d == nil || len(budget) == 0 {
+		return
+	}
+	// feasible==0 is already reported as "feasible=0"; per-node rejects here
+	// would just duplicate that signal once per budget node and bloat the log.
+	if len(feasible) == 0 {
+		return
+	}
+	feasibleSet := make(map[string]struct{}, len(feasible))
+	for _, info := range feasible {
+		if info != nil && info.Node() != nil {
+			feasibleSet[info.Node().Name] = struct{}{}
+		}
+	}
+	for _, node := range sortedBudgetNodes(budget) {
+		if _, ok := feasibleSet[node]; !ok {
+			d.reject(node, "scheduler-infeasible", "in budget but scheduler did not return node as feasible")
+		}
+	}
+}
+
+func (d *defragPlacementDiagnostics) addSchedulerDetail(reason string) {
+	pd := d.currentPod()
+	if pd == nil || reason == "" {
+		return
+	}
+	pd.SchedulerDetails = append(pd.SchedulerDetails, truncateDiagnostic(reason, 180))
+}
+
+func (d *defragPlacementDiagnostics) summary() string {
+	if d == nil {
+		return "current TF workers cannot be jointly placed on other nodes"
+	}
+	pd := d.currentPod()
+	if pd == nil {
+		msg := fmt.Sprintf("current TF workers cannot be jointly placed; feasible=0 budgetTargets=%d", len(d.BudgetTargets))
+		if exc := d.exclusionSummary(); exc != "" {
+			msg += " excluded=" + exc
+		}
+		return msg
+	}
+	parts := []string{
+		fmt.Sprintf("pod=%s", pd.Pod),
+		fmt.Sprintf("feasible=%d", len(pd.FeasibleNodes)),
+		fmt.Sprintf("budgetTargets=%d", len(d.BudgetTargets)),
+	}
+	rejects := make([]string, 0, min(4, len(pd.Rejections)))
+	for i, rej := range pd.Rejections {
+		if i >= 4 {
+			break
+		}
+		rejects = append(rejects, fmt.Sprintf("%s:%s(%s)", rej.Target, rej.Stage, rej.Reason))
+	}
+	if len(rejects) > 0 {
+		parts = append(parts, "topRejects="+strings.Join(rejects, ","))
+	} else if len(pd.SchedulerDetails) > 0 {
+		parts = append(parts, "scheduler="+strings.Join(pd.SchedulerDetails[:min(2, len(pd.SchedulerDetails))], ","))
+	} else {
+		parts = append(parts, "reason=no feasible defrag target")
+	}
+	if acct := d.budgetAccountingSummary(); acct != "" {
+		parts = append(parts, "budget="+acct)
+	}
+	if exc := d.exclusionSummary(); exc != "" {
+		parts = append(parts, "excluded="+exc)
+	}
+	return truncateDiagnostic(strings.Join(parts, " "), 900)
+}
+
+// budgetAccountingSummary renders up to 4 target GPU tallies, e.g.
+// "node-b(t=8,u=4,f=0,d=4)". Free=0 with Dirty>0 points at unreported GPU
+// status rather than real occupancy.
+func (d *defragPlacementDiagnostics) budgetAccountingSummary() string {
+	if d == nil || len(d.BudgetNodes) == 0 {
+		return ""
+	}
+	out := make([]string, 0, min(4, len(d.BudgetNodes)))
+	for i, a := range d.BudgetNodes {
+		if i >= 4 {
+			break
+		}
+		out = append(out, fmt.Sprintf("%s(t=%d,u=%d,f=%d,d=%d)", a.Node, a.Total, a.Used, a.Free, a.Dirty))
+	}
+	return strings.Join(out, ",")
+}
+
+func (d *defragPlacementDiagnostics) exclusionSummary() string {
+	if d == nil || len(d.ExcludedNodes) == 0 {
+		return ""
+	}
+	out := make([]string, 0, min(4, len(d.ExcludedNodes)))
+	for i, e := range d.ExcludedNodes {
+		if i >= 4 {
+			break
+		}
+		out = append(out, fmt.Sprintf("%s(%s)", e.Node, e.Reason))
+	}
+	return strings.Join(out, ",")
+}
+
+func (d *defragPlacementDiagnostics) logFields() map[string]any {
+	if d == nil {
+		return nil
+	}
+	return map[string]any{
+		"sourceNode":     d.SourceNode,
+		"profile":        d.Profile,
+		"budgetTargets":  d.BudgetTargets,
+		"budgetNodes":    d.BudgetNodes,
+		"excludedNodes":  d.ExcludedNodes,
+		"podDiagnostics": d.PodDiagnostics,
+	}
+}
+
+func defragPodRequestSummary(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	parts := []string{}
+	if v := pod.Annotations[constants.GpuPoolKey]; v != "" {
+		parts = append(parts, "pool="+v)
+	}
+	if v := pod.Annotations[constants.GpuCountAnnotation]; v != "" {
+		parts = append(parts, "gpuCount="+v)
+	}
+	if v := pod.Annotations[constants.ComputeRequestAnnotation]; v != "" {
+		parts = append(parts, "computePercent="+v)
+	}
+	if v := pod.Annotations[constants.TFLOPSRequestAnnotation]; v != "" {
+		parts = append(parts, "tflops="+v)
+	}
+	if v := pod.Annotations[constants.VRAMRequestAnnotation]; v != "" {
+		parts = append(parts, "vram="+v)
+	}
+	return strings.Join(parts, " ")
+}
+
+func sortedBudgetNodes(budget map[string]*nodeBudget) []string {
+	nodes := make([]string, 0, len(budget))
+	for node := range budget {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+	return nodes
+}
+
+func nodeInfoNames(nodes []fwk.NodeInfo) []string {
+	names := make([]string, 0, len(nodes))
+	for _, info := range nodes {
+		if info == nil || info.Node() == nil || info.Node().Name == "" {
+			continue
+		}
+		names = append(names, info.Node().Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func schedulerSimulationFilterReasons(state fwk.CycleState) []string {
+	if state == nil {
+		return nil
+	}
+	data, err := state.Read(fwk.StateKey(constants.SchedulerSimulationKey))
+	if err != nil || data == nil {
+		return nil
+	}
+	detail, ok := data.(*gpuallocator.SimulateSchedulingFilterDetail)
+	if !ok || detail == nil {
+		return nil
+	}
+	out := make([]string, 0, len(detail.FilterStageDetails))
+	for _, fd := range detail.FilterStageDetails {
+		out = append(out, fmt.Sprintf("%s before=%d after=%d diff=%d", fd.FilterName, len(fd.Before), len(fd.After), fd.Diff))
+	}
+	return out
+}
+
+func truncateDiagnostic(s string, maxLen int) string {
+	s = strings.TrimSpace(s)
+	if maxLen <= 0 || len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
 }
 
 // applyGPUPlacementToBudget subtracts req from each selected GPU and bumps
@@ -1316,29 +1650,34 @@ func cloneNodeInfoWithVirtualPod(nodeInfo fwk.NodeInfo, podInfo fwk.PodInfo) fwk
 }
 
 func fitsVirtualNodeAllocatable(nodeInfo fwk.NodeInfo) bool {
+	ok, _ := virtualNodeAllocatableReason(nodeInfo)
+	return ok
+}
+
+func virtualNodeAllocatableReason(nodeInfo fwk.NodeInfo) (bool, string) {
 	if nodeInfo == nil {
-		return false
+		return false, "nodeInfo is nil"
 	}
 	requested := nodeInfo.GetRequested()
 	allocatable := nodeInfo.GetAllocatable()
 	if requested.GetMilliCPU() > allocatable.GetMilliCPU() {
-		return false
+		return false, fmt.Sprintf("cpu requested=%dm allocatable=%dm", requested.GetMilliCPU(), allocatable.GetMilliCPU())
 	}
 	if requested.GetMemory() > allocatable.GetMemory() {
-		return false
+		return false, fmt.Sprintf("memory requested=%d allocatable=%d", requested.GetMemory(), allocatable.GetMemory())
 	}
 	if requested.GetEphemeralStorage() > allocatable.GetEphemeralStorage() {
-		return false
+		return false, fmt.Sprintf("ephemeral-storage requested=%d allocatable=%d", requested.GetEphemeralStorage(), allocatable.GetEphemeralStorage())
 	}
 	if allocatable.GetAllowedPodNumber() > 0 && len(nodeInfo.GetPods()) > allocatable.GetAllowedPodNumber() {
-		return false
+		return false, fmt.Sprintf("pods requested=%d allocatable=%d", len(nodeInfo.GetPods()), allocatable.GetAllowedPodNumber())
 	}
 	for name, qty := range requested.GetScalarResources() {
 		if qty > allocatable.GetScalarResources()[name] {
-			return false
+			return false, fmt.Sprintf("%s requested=%d allocatable=%d", name, qty, allocatable.GetScalarResources()[name])
 		}
 	}
-	return true
+	return true, ""
 }
 
 func buildDefragNodeBudgets(
@@ -1347,8 +1686,13 @@ func buildDefragNodeBudgets(
 	nodeGpuStore map[string]map[string]*tfv1.GPU,
 	nodeWorkerStore map[string]map[types.NamespacedName]struct{},
 	nodeInfoLister fwk.NodeInfoLister,
-) map[string]*nodeBudget {
+) (map[string]*nodeBudget, []defragBudgetNodeAccounting, []defragNodeExclusion) {
 	budget := make(map[string]*nodeBudget, len(nodeGpuStore))
+	var accounting []defragBudgetNodeAccounting
+	var exclusions []defragNodeExclusion
+	exclude := func(node, reason string) {
+		exclusions = append(exclusions, defragNodeExclusion{Node: node, Reason: reason})
+	}
 	for nodeName, gpus := range nodeGpuStore {
 		if nodeName == sourceNode {
 			continue
@@ -1357,15 +1701,22 @@ func buildDefragNodeBudgets(
 		if err != nil {
 			// Allocator state can briefly outlive scheduler cache for
 			// deleted nodes; drop only this target, not the candidate.
+			exclude(nodeName, "not in scheduler snapshot: "+err.Error())
 			continue
 		}
-		if node := nodeInfo.Node(); node == nil ||
-			node.Labels[constants.NodeDeletionMark] == constants.TrueStringValue ||
-			node.Labels[constants.DefragSourceNodeLabel] == constants.TrueStringValue {
+		if node := nodeInfo.Node(); node == nil {
+			exclude(nodeName, "nil node in scheduler snapshot")
+			continue
+		} else if node.Labels[constants.NodeDeletionMark] == constants.TrueStringValue {
+			exclude(nodeName, "deletion-marked")
+			continue
+		} else if node.Labels[constants.DefragSourceNodeLabel] == constants.TrueStringValue {
+			exclude(nodeName, "defrag-source-marked")
 			continue
 		}
 
 		copied := make(map[string]*tfv1.GPU, len(gpus))
+		dirty := 0
 		for name, g := range gpus {
 			if g == nil {
 				continue
@@ -1373,18 +1724,33 @@ func buildDefragNodeBudgets(
 			if g.Labels[constants.GpuPoolKey] != poolName {
 				continue
 			}
+			if g.Status.Available == nil || g.Status.Capacity == nil {
+				// Present but unreported: excluded from the tally by
+				// countPoolGPUUsage and dropped by the resource filter, so a
+				// free-but-dirty GPU silently shrinks placeable capacity.
+				dirty++
+			}
 			copied[name] = g.DeepCopy()
 		}
 		if len(copied) == 0 {
+			exclude(nodeName, "no pool GPUs (label mismatch)")
 			continue
 		}
+		total, used := countPoolGPUUsage(copied, poolName)
 		// Skip fully empty target nodes: relocating onto one swaps which
 		// machine is occupied without reducing total occupancy. Strategy
 		// #1 owns reclaiming empty nodes, defrag stays out of its way.
-		total, used := countPoolGPUUsage(copied, poolName)
 		if used == 0 {
+			exclude(nodeName, fmt.Sprintf("empty node (t=%d,u=0,f=%d,d=%d)", total, total, dirty))
 			continue
 		}
+		accounting = append(accounting, defragBudgetNodeAccounting{
+			Node:  nodeName,
+			Total: total,
+			Used:  used,
+			Free:  total - used,
+			Dirty: dirty,
+		})
 		budget[nodeName] = &nodeBudget{
 			gpus:        copied,
 			workerCount: len(nodeWorkerStore[nodeName]),
@@ -1393,7 +1759,7 @@ func buildDefragNodeBudgets(
 			usedGPUs:    used,
 		}
 	}
-	return budget
+	return budget, accounting, exclusions
 }
 
 func (r *GPUPoolCompactionReconciler) currentNodeWorkerPods(ctx context.Context, nodeName string) ([]*corev1.Pod, error) {

--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -1196,105 +1196,24 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 	}
 	podInfo, _ := framework.NewPodInfo(podCopy)
 
-	type fitCandidate struct {
-		node     string
-		selected []*tfv1.GPU
-		nodeInfo fwk.NodeInfo
-	}
-	var best *fitCandidate
+	var best *defragFitCandidate
 	var bestScore int
 
 	for _, info := range feasible {
-		node := info.Node()
-		if node == nil {
+		cand := r.evalDefragTarget(ctx, fwkInstance, state, info, budget, req, podCopy, podInfo, maxWorkerPerNode, sourceUtilization, diag)
+		if cand == nil {
 			continue
 		}
-		tgt := node.Name
-		if tgt == "" {
-			continue
-		}
-		nb, ok := budget[tgt]
-		if !ok {
-			if diag != nil {
-				diag.reject(tgt, "not-in-budget", "scheduler feasible node is not a defrag budget target")
-			}
-			continue
-		}
-
-		if !targetAcceptsAnotherWorker(nb, maxWorkerPerNode) {
-			if diag != nil {
-				diag.reject(tgt, "max-worker-per-node", fmt.Sprintf("workerCount=%d max=%d", nb.workerCount, maxWorkerPerNode))
-			}
-			continue
-		}
-		// Monotonicity gate: workers may only flow toward at-least-as-
-		// loaded targets, evaluated against the dynamic budget.
-		targetUtil := budgetUtilizationPercent(nb)
-		if targetUtil < sourceUtilization {
-			log.FromContext(ctx).V(5).Info("defrag reject lower-utilization target",
-				"target", tgt, "targetUtil", targetUtil, "sourceUtil", sourceUtilization)
-			if diag != nil {
-				diag.reject(tgt, "monotonicity", fmt.Sprintf("targetUtil=%.2f sourceUtil=%.2f", targetUtil, sourceUtilization))
-			}
-			continue
-		}
-		candidateInfo := cloneNodeInfoWithVirtualPod(nb.nodeInfo, podInfo)
-		if ok, reason := virtualNodeAllocatableReason(candidateInfo); !ok {
-			if diag != nil {
-				diag.reject(tgt, "virtual-node-resource", reason)
-			}
-			continue
-		}
-		// Re-run filters on the virtualized snapshot so resource plugins
-		// see capacity already consumed by prior simulated placements.
-		virtualState := state.Clone()
-		if status := fwkInstance.RunFilterPluginsWithNominatedPods(ctx, virtualState, podCopy, candidateInfo); status != nil && !status.IsSuccess() {
-			if diag != nil {
-				diag.reject(tgt, "scheduler-filter", status.Message())
-				for _, reason := range schedulerSimulationFilterReasons(virtualState) {
-					diag.addSchedulerDetail(reason)
-				}
-			}
-			continue
-		}
-
-		gpuList := make([]*tfv1.GPU, 0, len(nb.gpus))
-		for _, g := range nb.gpus {
-			gpuList = append(gpuList, g)
-		}
-		filtered, _, ferr := r.Allocator.Filter(req, gpuList, true /* isSimulateSchedule */)
-		if ferr != nil || len(filtered) == 0 || uint(len(filtered)) < req.Count {
-			if diag != nil {
-				reason := fmt.Sprintf("filtered=%d required=%d", len(filtered), req.Count)
-				if ferr != nil {
-					reason = ferr.Error()
-				}
-				diag.reject(tgt, "allocator-filter", reason)
-			}
-			continue
-		}
-
-		selected, serr := r.Allocator.SelectFromStore(req, filtered, map[string]map[string]*tfv1.GPU{tgt: nb.gpus})
-		if serr != nil || len(selected) != int(req.Count) {
-			if diag != nil {
-				reason := fmt.Sprintf("selected=%d required=%d", len(selected), req.Count)
-				if serr != nil {
-					reason = serr.Error()
-				}
-				diag.reject(tgt, "allocator-select", reason)
-			}
-			continue
-		}
-
+		nb := budget[cand.node]
 		// Score the budget copies so tie-breaks reflect simulated state.
 		score := 0
-		for _, g := range selected {
+		for _, g := range cand.selected {
 			if orig, ok := nb.gpus[g.Name]; ok {
 				score += defragCompactScorer.Score(orig, false)
 			}
 		}
 		if best == nil || score > bestScore {
-			best = &fitCandidate{node: tgt, selected: selected, nodeInfo: candidateInfo}
+			best = cand
 			bestScore = score
 		}
 	}
@@ -1308,6 +1227,99 @@ func (r *GPUPoolCompactionReconciler) placeSinglePod(
 	nb.nodeInfo = best.nodeInfo
 	nb.workerCount++
 	return true, nil
+}
+
+type defragFitCandidate struct {
+	node     string
+	selected []*tfv1.GPU
+	nodeInfo fwk.NodeInfo
+}
+
+// evalDefragTarget evaluates one scheduler-feasible node as a relocation target
+// for podCopy against the simulated budget, returning the fit (with its selected
+// GPUs) or nil when the node is rejected. Rejections are recorded on diag (which
+// tolerates a nil receiver).
+func (r *GPUPoolCompactionReconciler) evalDefragTarget(
+	ctx context.Context,
+	fwkInstance framework.Framework,
+	state fwk.CycleState,
+	info fwk.NodeInfo,
+	budget map[string]*nodeBudget,
+	req *tfv1.AllocRequest,
+	podCopy *corev1.Pod,
+	podInfo fwk.PodInfo,
+	maxWorkerPerNode int,
+	sourceUtilization float64,
+	diag *defragPlacementDiagnostics,
+) *defragFitCandidate {
+	node := info.Node()
+	if node == nil {
+		return nil
+	}
+	tgt := node.Name
+	if tgt == "" {
+		return nil
+	}
+	nb, ok := budget[tgt]
+	if !ok {
+		diag.reject(tgt, "not-in-budget", "scheduler feasible node is not a defrag budget target")
+		return nil
+	}
+
+	if !targetAcceptsAnotherWorker(nb, maxWorkerPerNode) {
+		diag.reject(tgt, "max-worker-per-node", fmt.Sprintf("workerCount=%d max=%d", nb.workerCount, maxWorkerPerNode))
+		return nil
+	}
+	// Monotonicity gate: workers may only flow toward at-least-as-
+	// loaded targets, evaluated against the dynamic budget.
+	targetUtil := budgetUtilizationPercent(nb)
+	if targetUtil < sourceUtilization {
+		log.FromContext(ctx).V(5).Info("defrag reject lower-utilization target",
+			"target", tgt, "targetUtil", targetUtil, "sourceUtil", sourceUtilization)
+		diag.reject(tgt, "monotonicity", fmt.Sprintf("targetUtil=%.2f sourceUtil=%.2f", targetUtil, sourceUtilization))
+		return nil
+	}
+	candidateInfo := cloneNodeInfoWithVirtualPod(nb.nodeInfo, podInfo)
+	if ok, reason := virtualNodeAllocatableReason(candidateInfo); !ok {
+		diag.reject(tgt, "virtual-node-resource", reason)
+		return nil
+	}
+	// Re-run filters on the virtualized snapshot so resource plugins
+	// see capacity already consumed by prior simulated placements.
+	virtualState := state.Clone()
+	if status := fwkInstance.RunFilterPluginsWithNominatedPods(ctx, virtualState, podCopy, candidateInfo); status != nil && !status.IsSuccess() {
+		diag.reject(tgt, "scheduler-filter", status.Message())
+		for _, reason := range schedulerSimulationFilterReasons(virtualState) {
+			diag.addSchedulerDetail(reason)
+		}
+		return nil
+	}
+
+	gpuList := make([]*tfv1.GPU, 0, len(nb.gpus))
+	for _, g := range nb.gpus {
+		gpuList = append(gpuList, g)
+	}
+	filtered, _, ferr := r.Allocator.Filter(req, gpuList, true /* isSimulateSchedule */)
+	if ferr != nil || len(filtered) == 0 || uint(len(filtered)) < req.Count {
+		reason := fmt.Sprintf("filtered=%d required=%d", len(filtered), req.Count)
+		if ferr != nil {
+			reason = ferr.Error()
+		}
+		diag.reject(tgt, "allocator-filter", reason)
+		return nil
+	}
+
+	selected, serr := r.Allocator.SelectFromStore(req, filtered, map[string]map[string]*tfv1.GPU{tgt: nb.gpus})
+	if serr != nil || len(selected) != int(req.Count) {
+		reason := fmt.Sprintf("selected=%d required=%d", len(selected), req.Count)
+		if serr != nil {
+			reason = serr.Error()
+		}
+		diag.reject(tgt, "allocator-select", reason)
+		return nil
+	}
+
+	return &defragFitCandidate{node: tgt, selected: selected, nodeInfo: candidateInfo}
 }
 
 // targetAcceptsAnotherWorker mirrors CheckQuotaAndFilter
@@ -1405,6 +1417,9 @@ func (d *defragPlacementDiagnostics) setFeasibleNodes(nodes []fwk.NodeInfo) {
 }
 
 func (d *defragPlacementDiagnostics) reject(target, stage, reason string) {
+	if d == nil {
+		return
+	}
 	pd := d.currentPod()
 	if pd == nil {
 		d.startPod(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "unknown", Name: "unknown"}})

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -1016,8 +1016,82 @@ func TestFitsVirtualNodeAllocatable_RejectsOversubscribedCPU(t *testing.T) {
 	}
 }
 
+func TestVirtualNodeAllocatableReason_ReportsCPU(t *testing.T) {
+	nodeInfo := newFrameworkNodeInfo(
+		"node-b",
+		nil,
+		corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("8Gi"),
+			corev1.ResourcePods:   resource.MustParse("4"),
+		},
+	)
+	firstPodInfo, _ := framework.NewPodInfo(newSchedulerTestPod("ns1", "worker-1", "1500m", "1Gi"))
+	nodeInfo.AddPodInfo(firstPodInfo)
+	secondPodInfo, _ := framework.NewPodInfo(newSchedulerTestPod("ns1", "worker-2", "1500m", "1Gi"))
+
+	ok, reason := virtualNodeAllocatableReason(cloneNodeInfoWithVirtualPod(nodeInfo, secondPodInfo))
+
+	if ok {
+		t.Fatal("expected virtual node to be oversubscribed")
+	}
+	if !strings.Contains(reason, "cpu") || !strings.Contains(reason, "requested=") || !strings.Contains(reason, "allocatable=") {
+		t.Fatalf("reason %q does not explain CPU pressure", reason)
+	}
+}
+
+func TestDefragPlacementDiagnosticsSummaryIncludesTopRejects(t *testing.T) {
+	diag := newDefragPlacementDiagnostics("node-source", "profile-a", []string{"node-a", "node-b"})
+	diag.startPod(newDefragWorkerPod("worker-a", "node-source", time.Now()))
+	diag.setFeasibleNodes([]fwk.NodeInfo{
+		newFrameworkNodeInfo("node-a", nil, nil),
+		newFrameworkNodeInfo("node-b", nil, nil),
+	})
+	diag.reject("node-a", "virtual-node-resource", "cpu requested=3000m allocatable=2000m")
+	diag.reject("node-b", "allocator-select", "select GPU: insufficient GPUs")
+
+	summary := diag.summary()
+
+	for _, want := range []string{
+		"pod=ns1/worker-a",
+		"feasible=2",
+		"budgetTargets=2",
+		"node-a:virtual-node-resource(cpu requested=3000m allocatable=2000m)",
+		"node-b:allocator-select(select GPU: insufficient GPUs)",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary %q missing %q", summary, want)
+		}
+	}
+}
+
+func TestApplyGPUPlacementToBudgetConsumesVirtualGPU(t *testing.T) {
+	gpu := gpuWithUsageOnNode("target-gpu-0", "node-target", "100", "10Gi")
+	nb := &nodeBudget{
+		gpus:      map[string]*tfv1.GPU{gpu.Name: gpu.DeepCopy()},
+		totalGPUs: 1,
+		usedGPUs:  0,
+	}
+	req := &tfv1.AllocRequest{
+		Count: 1,
+		Request: tfv1.Resource{
+			Tflops: resource.MustParse("100"),
+			Vram:   resource.MustParse("1Gi"),
+		},
+	}
+
+	applyGPUPlacementToBudget(nb, []*tfv1.GPU{gpu.DeepCopy()}, req)
+
+	if nb.usedGPUs != 1 {
+		t.Fatalf("usedGPUs=%d, want 1 after fully-free GPU is consumed", nb.usedGPUs)
+	}
+	if got := nb.gpus[gpu.Name].Status.Available.Tflops; !got.IsZero() {
+		t.Fatalf("available TFLOPs=%s, want exhausted virtual budget", got.String())
+	}
+}
+
 func TestBuildDefragNodeBudgets_SkipsDeletionMarkedNodes(t *testing.T) {
-	budgets := buildDefragNodeBudgets(
+	budgets, _, _ := buildDefragNodeBudgets(
 		"pool-a",
 		"",
 		map[string]map[string]*tfv1.GPU{
@@ -1063,7 +1137,7 @@ func TestBuildDefragNodeBudgets_SkipsDeletionMarkedNodes(t *testing.T) {
 }
 
 func TestBuildDefragNodeBudgets_SkipsMissingSchedulerNodeInfo(t *testing.T) {
-	budgets := buildDefragNodeBudgets(
+	budgets, _, _ := buildDefragNodeBudgets(
 		"pool-a",
 		"source-node",
 		map[string]map[string]*tfv1.GPU{
@@ -2599,7 +2673,7 @@ func TestBuildDefragNodeBudgets_DropsEmptyTarget(t *testing.T) {
 		empty:  newFrameworkNodeInfo(empty, nil, nil),
 	}}
 
-	budgets := buildDefragNodeBudgets(pool, source, nodeGpuStore, nil, lister)
+	budgets, _, _ := buildDefragNodeBudgets(pool, source, nodeGpuStore, nil, lister)
 
 	if _, ok := budgets[source]; ok {
 		t.Fatalf("source node must not appear in budgets, got %v", budgets)
@@ -2613,6 +2687,64 @@ func TestBuildDefragNodeBudgets_DropsEmptyTarget(t *testing.T) {
 	}
 	if nb.totalGPUs != 2 || nb.usedGPUs != 1 {
 		t.Fatalf("buddy budget total/used = %d/%d, want 2/1", nb.totalGPUs, nb.usedGPUs)
+	}
+}
+
+func TestBuildDefragNodeBudgets_ReportsDirtyFreeAndExclusions(t *testing.T) {
+	// The smoking gun we want to read off production: a target with used GPUs
+	// plus a free-but-unreported (Available==nil) GPU. The dirty card must be
+	// tallied so "Free=0,Dirty>0" is visible, and a fully-empty node must
+	// surface an exclusion reason instead of vanishing silently.
+	const pool = "pool-a"
+	source := "node-source"
+	buddy := "node-buddy"
+	empty := "node-empty"
+
+	dirty := gpuFullyFreeOnNode("buddy-gpu-dirty", buddy)
+	dirty.Status.Available = nil // present in store but status never reported
+
+	nodeGpuStore := map[string]map[string]*tfv1.GPU{
+		source: {"src-gpu-0": gpuWithUsageOnNode("src-gpu-0", source, "50", "5Gi")},
+		buddy: {
+			"buddy-gpu-0":     gpuWithUsageOnNode("buddy-gpu-0", buddy, "60", "8Gi"),
+			"buddy-gpu-dirty": dirty,
+		},
+		empty: {"empty-gpu-0": gpuFullyFreeOnNode("empty-gpu-0", empty)},
+	}
+	lister := &fakeNodeInfoLister{infos: map[string]fwk.NodeInfo{
+		source: newFrameworkNodeInfo(source, nil, nil),
+		buddy:  newFrameworkNodeInfo(buddy, nil, nil),
+		empty:  newFrameworkNodeInfo(empty, nil, nil),
+	}}
+
+	_, accounting, exclusions := buildDefragNodeBudgets(pool, source, nodeGpuStore, nil, lister)
+
+	var buddyAcct *defragBudgetNodeAccounting
+	for i := range accounting {
+		if accounting[i].Node == buddy {
+			buddyAcct = &accounting[i]
+		}
+	}
+	if buddyAcct == nil {
+		t.Fatalf("buddy accounting missing, got %+v", accounting)
+	}
+	// Only the healthy used GPU counts toward the tally; the dirty free GPU is
+	// invisible to placement, so Free must be 0 while Dirty is 1.
+	if buddyAcct.Total != 1 || buddyAcct.Used != 1 || buddyAcct.Free != 0 || buddyAcct.Dirty != 1 {
+		t.Fatalf("buddy accounting = %+v, want total=1 used=1 free=0 dirty=1", *buddyAcct)
+	}
+
+	foundEmpty := false
+	for _, e := range exclusions {
+		if e.Node == empty {
+			foundEmpty = true
+			if !strings.Contains(e.Reason, "empty node") {
+				t.Fatalf("empty exclusion reason %q missing 'empty node'", e.Reason)
+			}
+		}
+	}
+	if !foundEmpty {
+		t.Fatalf("empty node exclusion missing, got %+v", exclusions)
 	}
 }
 
@@ -2633,7 +2765,7 @@ func TestBuildDefragNodeBudgets_SkipsExcludedNodeLabels(t *testing.T) {
 			constants.DefragSourceNodeLabel: constants.TrueStringValue,
 		}, nil),
 	}}
-	budgets := buildDefragNodeBudgets(pool, source, nodeGpuStore, nil, lister)
+	budgets, _, _ := buildDefragNodeBudgets(pool, source, nodeGpuStore, nil, lister)
 	if _, ok := budgets[marked]; ok {
 		t.Fatalf("DefragSourceNodeLabel must keep node out of budgets, got %v", budgets)
 	}

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -239,6 +239,8 @@ func TestSubtractGPURequest_SafelyIgnoresBadInput(t *testing.T) {
 const (
 	testDefragNodeA         = "node-a"
 	testEvictionSubresource = "eviction"
+	testDefragNodeSource    = "node-source"
+	testDefragNodeBuddy     = "node-buddy"
 )
 
 // Re-declared as var (not const) because constants.Domain is a var in main.
@@ -1004,11 +1006,11 @@ func TestFitsVirtualNodeAllocatable_RejectsOversubscribedCPU(t *testing.T) {
 			corev1.ResourcePods:   resource.MustParse("4"),
 		},
 	)
-	firstPod := newSchedulerTestPod("ns1", "worker-1", "1500m", "1Gi")
+	firstPod := newSchedulerTestPod("worker-1")
 	firstPodInfo, _ := framework.NewPodInfo(firstPod)
 	nodeInfo.AddPodInfo(firstPodInfo)
 
-	secondPod := newSchedulerTestPod("ns1", "worker-2", "1500m", "1Gi")
+	secondPod := newSchedulerTestPod("worker-2")
 	secondPodInfo, _ := framework.NewPodInfo(secondPod)
 	virtual := cloneNodeInfoWithVirtualPod(nodeInfo, secondPodInfo)
 	if fitsVirtualNodeAllocatable(virtual) {
@@ -1026,9 +1028,9 @@ func TestVirtualNodeAllocatableReason_ReportsCPU(t *testing.T) {
 			corev1.ResourcePods:   resource.MustParse("4"),
 		},
 	)
-	firstPodInfo, _ := framework.NewPodInfo(newSchedulerTestPod("ns1", "worker-1", "1500m", "1Gi"))
+	firstPodInfo, _ := framework.NewPodInfo(newSchedulerTestPod("worker-1"))
 	nodeInfo.AddPodInfo(firstPodInfo)
-	secondPodInfo, _ := framework.NewPodInfo(newSchedulerTestPod("ns1", "worker-2", "1500m", "1Gi"))
+	secondPodInfo, _ := framework.NewPodInfo(newSchedulerTestPod("worker-2"))
 
 	ok, reason := virtualNodeAllocatableReason(cloneNodeInfoWithVirtualPod(nodeInfo, secondPodInfo))
 
@@ -1041,8 +1043,8 @@ func TestVirtualNodeAllocatableReason_ReportsCPU(t *testing.T) {
 }
 
 func TestDefragPlacementDiagnosticsSummaryIncludesTopRejects(t *testing.T) {
-	diag := newDefragPlacementDiagnostics("node-source", "profile-a", []string{"node-a", "node-b"})
-	diag.startPod(newDefragWorkerPod("worker-a", "node-source", time.Now()))
+	diag := newDefragPlacementDiagnostics(testDefragNodeSource, "profile-a", []string{"node-a", "node-b"})
+	diag.startPod(newDefragWorkerPod("worker-a", testDefragNodeSource, time.Now()))
 	diag.setFeasibleNodes([]fwk.NodeInfo{
 		newFrameworkNodeInfo("node-a", nil, nil),
 		newFrameworkNodeInfo("node-b", nil, nil),
@@ -2461,10 +2463,10 @@ func newFrameworkNodeInfo(name string, labels map[string]string, allocatable cor
 	return info
 }
 
-func newSchedulerTestPod(namespace, name, cpu, memory string) *corev1.Pod {
+func newSchedulerTestPod(name string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
+			Namespace: "ns1",
 			Name:      name,
 		},
 		Spec: corev1.PodSpec{
@@ -2472,8 +2474,8 @@ func newSchedulerTestPod(namespace, name, cpu, memory string) *corev1.Pod {
 				Name: "main",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse(cpu),
-						corev1.ResourceMemory: resource.MustParse(memory),
+						corev1.ResourceCPU:    resource.MustParse("1500m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -2650,8 +2652,8 @@ func TestBuildDefragNodeBudgets_DropsEmptyTarget(t *testing.T) {
 	// pool node. The empty node MUST be filtered so defrag does not waste
 	// a disruption shuffling workers onto a previously empty machine.
 	const pool = "pool-a"
-	source := "node-source"
-	buddy := "node-buddy"
+	source := testDefragNodeSource
+	buddy := testDefragNodeBuddy
 	empty := "node-empty"
 
 	nodeGpuStore := map[string]map[string]*tfv1.GPU{
@@ -2696,8 +2698,8 @@ func TestBuildDefragNodeBudgets_ReportsDirtyFreeAndExclusions(t *testing.T) {
 	// tallied so "Free=0,Dirty>0" is visible, and a fully-empty node must
 	// surface an exclusion reason instead of vanishing silently.
 	const pool = "pool-a"
-	source := "node-source"
-	buddy := "node-buddy"
+	source := testDefragNodeSource
+	buddy := testDefragNodeBuddy
 	empty := "node-empty"
 
 	dirty := gpuFullyFreeOnNode("buddy-gpu-dirty", buddy)
@@ -2753,7 +2755,7 @@ func TestBuildDefragNodeBudgets_SkipsExcludedNodeLabels(t *testing.T) {
 	// filtered out independently of the new emptiness gate. A node
 	// labelled as source-marker also having real usage must NOT leak in.
 	const pool = "pool-a"
-	source := "node-source"
+	source := testDefragNodeSource
 	marked := "node-marked"
 	nodeGpuStore := map[string]map[string]*tfv1.GPU{
 		source: {"src": gpuWithUsageOnNode("src", source, "50", "5Gi")},
@@ -2836,7 +2838,7 @@ func TestApplyGPUPlacementToBudget_TracksUsedGPUTransition(t *testing.T) {
 	// Validates the dynamic-util commit path: only fully-free -> partially
 	// used transitions bump usedGPUs. A second placement onto the same GPU
 	// must NOT double-count.
-	node := "node-buddy"
+	node := testDefragNodeBuddy
 	freeGPU := gpuFullyFreeOnNode("g-free", node)
 	usedGPU := gpuWithUsageOnNode("g-used", node, "50", "5Gi") // half-used baseline
 

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -127,6 +127,13 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			if e := r.Create(ctx, gpuNode); e != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to create GPUNode: %w", e)
 			}
+			// Initialize phase to Pending right away so the GPUNode never sits with
+			// an empty phase during the inflight window (before node-discovery runs),
+			// which would otherwise be invisible to phase-based monitoring.
+			gpuNode.Status.Phase = tfv1.TensorFusionGPUNodePhasePending
+			if e := r.Status().Update(ctx, gpuNode); e != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to initialize GPUNode status to Pending: %w", e)
+			}
 		} else {
 			return ctrl.Result{}, fmt.Errorf("failed to get GPUNode: %w", err)
 		}

--- a/internal/controller/node_controller_unit_test.go
+++ b/internal/controller/node_controller_unit_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestNodeReconcileInitializesGPUNodePhaseToPending covers the real new-node path:
+// when the NodeReconciler creates a GPUNode it must initialize the phase to Pending
+// so the inflight window never exposes an empty phase to monitoring.
+func TestNodeReconcileInitializesGPUNodePhaseToPending(t *testing.T) {
+	ctx := context.Background()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"gpu": "true"},
+		},
+	}
+	pool := &tfv1.GPUPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+		Spec: tfv1.GPUPoolSpec{
+			NodeManagerConfig: &tfv1.NodeManagerConfig{
+				ProvisioningMode: tfv1.ProvisioningModeAutoSelect,
+				NodeSelector: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{Key: "gpu", Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := tfv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add TensorFusion scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core/v1 scheme: %v", err)
+	}
+
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPUNode{}).
+		WithObjects(node, pool).
+		Build()
+
+	reconciler := &NodeReconciler{
+		Client: kubeClient,
+		Scheme: scheme,
+	}
+
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: node.Name}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	gpuNode := &tfv1.GPUNode{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: node.Name}, gpuNode); err != nil {
+		t.Fatalf("get created GPUNode: %v", err)
+	}
+	if gpuNode.Status.Phase != tfv1.TensorFusionGPUNodePhasePending {
+		t.Fatalf("expected GPUNode phase %q, got %q", tfv1.TensorFusionGPUNodePhasePending, gpuNode.Status.Phase)
+	}
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -740,6 +740,15 @@ func (b *TensorFusionEnvBuilder) Build() *TensorFusionEnv {
 			}
 			Expect(k8sClient.Create(ctx, coreNode)).To(Succeed())
 
+			// Mark the node Ready so reconcileHypervisorPod's not-ready gate
+			// allows hypervisor pod creation; a real node backing a GPUNode is
+			// always Ready (envtest has no kubelet to post this on its own).
+			nodePatch := client.MergeFrom(coreNode.DeepCopy())
+			coreNode.Status.Conditions = []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			}
+			Expect(k8sClient.Status().Patch(ctx, coreNode, nodePatch)).To(Succeed())
+
 			// generate gpus for gpunode
 			gpuNode := b.GetGPUNode(poolIndex, nodeIndex)
 			gpuCount := b.poolNodeMap[poolIndex][nodeIndex]

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -907,6 +907,17 @@ func (s *GpuAllocator) buildPreemptFilterRegistry(req *tfv1.AllocRequest) *filte
 }
 
 func (s *GpuAllocator) Select(req *tfv1.AllocRequest, filteredGPUs []*tfv1.GPU) ([]*tfv1.GPU, error) {
+	return s.SelectFromStore(req, filteredGPUs, s.GetNodeGpuStore())
+}
+
+// SelectFromStore selects GPUs using the supplied node GPU store for strategy
+// node-level scoring. Defrag dry-runs pass their virtual budget here so
+// filtering and selection observe the same simulated state.
+func (s *GpuAllocator) SelectFromStore(
+	req *tfv1.AllocRequest,
+	filteredGPUs []*tfv1.GPU,
+	nodeGpuStore map[string]map[string]*tfv1.GPU,
+) ([]*tfv1.GPU, error) {
 	pool := &tfv1.GPUPool{}
 	if err := s.Get(s.ctx, client.ObjectKey{Name: req.PoolName}, pool); err != nil {
 		return nil, fmt.Errorf("get pool %s: %w", req.PoolName, err)
@@ -921,7 +932,7 @@ func (s *GpuAllocator) Select(req *tfv1.AllocRequest, filteredGPUs []*tfv1.GPU) 
 
 	strategy := NewStrategy(schedulingConfigTemplate.Spec.Placement.Mode, &config.GPUFitConfig{
 		MaxWorkerPerNode: s.maxWorkerPerNode,
-	}, s.GetNodeGpuStore())
+	}, nodeGpuStore)
 	selectedGPUs, err := strategy.SelectGPUs(cloneGPUSlice(filteredGPUs), req.Count)
 	if err != nil {
 		return nil, fmt.Errorf("select GPU: %w", err)

--- a/internal/gpuallocator/node_capacity.go
+++ b/internal/gpuallocator/node_capacity.go
@@ -49,6 +49,11 @@ func RefreshGPUNodeCapacity(
 		if gpu.Status.Available == nil || gpu.Status.Capacity == nil {
 			continue
 		}
+		// GPUs marked missing by hypervisor discovery (e.g. physically removed)
+		// must not contribute phantom capacity to node statistics.
+		if utils.IsGPUMissing(&gpu) {
+			continue
+		}
 		node.Status.AvailableVRAM.Add(gpu.Status.Available.Vram)
 		node.Status.AvailableTFlops.Add(gpu.Status.Available.Tflops)
 		node.Status.TotalVRAM.Add(gpu.Status.Capacity.Vram)

--- a/internal/gpuallocator/node_capacity_missing_test.go
+++ b/internal/gpuallocator/node_capacity_missing_test.go
@@ -1,0 +1,80 @@
+package gpuallocator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newCapacityMissingTestGPU(name, owner string, phase tfv1.TensorFusionGPUPhase) *tfv1.GPU {
+	return &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.LabelKeyOwner: owner,
+			},
+		},
+		Status: tfv1.GPUStatus{
+			Phase:    phase,
+			GPUModel: "NVIDIA-Test-GPU",
+			Capacity: &tfv1.Resource{
+				Tflops: resource.MustParse("100"),
+				Vram:   resource.MustParse("16Gi"),
+			},
+			Available: &tfv1.Resource{
+				Tflops: resource.MustParse("100"),
+				Vram:   resource.MustParse("16Gi"),
+			},
+		},
+	}
+}
+
+// A GPU marked missing by hypervisor discovery must not contribute phantom
+// capacity to GPUNode level Total/Available statistics.
+func TestRefreshGPUNodeCapacityExcludesMissingGPUs(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = tfv1.AddToScheme(scheme)
+
+	nodeName := "capacity-missing-test-node"
+	node := &tfv1.GPUNode{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	}
+	pool := &tfv1.GPUPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "capacity-missing-test-pool"},
+	}
+
+	healthyGPU := newCapacityMissingTestGPU("gpu-healthy", nodeName, tfv1.TensorFusionGPUPhaseRunning)
+	missingGPU := newCapacityMissingTestGPU("gpu-missing", nodeName, tfv1.TensorFusionGPUPhaseUnknown)
+	missingGPU.Annotations = map[string]string{
+		constants.GPUMissingSinceAnnotationKey: time.Now().Format(time.RFC3339),
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPU{}, &tfv1.GPUNode{}).
+		WithObjects(node, pool, healthyGPU, missingGPU).Build()
+
+	allocator := NewGpuAllocator(ctx, nil, k8sClient, time.Second)
+
+	_, err := RefreshGPUNodeCapacity(ctx, k8sClient, node, pool, allocator, nil)
+	assert.NoError(t, err)
+
+	expectedTflops := resource.MustParse("100")
+	expectedVram := resource.MustParse("16Gi")
+	assert.Equal(t, expectedTflops.String(), node.Status.TotalTFlops.String(),
+		"missing GPU capacity must be excluded from TotalTFlops")
+	assert.Equal(t, expectedVram.String(), node.Status.TotalVRAM.String(),
+		"missing GPU capacity must be excluded from TotalVRAM")
+	assert.Equal(t, expectedTflops.String(), node.Status.AvailableTFlops.String(),
+		"missing GPU must be excluded from AvailableTFlops")
+	assert.Equal(t, expectedVram.String(), node.Status.AvailableVRAM.String(),
+		"missing GPU must be excluded from AvailableVRAM")
+}

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/config"
 	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator"
 	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator/filter"
 	"github.com/NexusGPU/tensor-fusion/internal/utils"
@@ -30,7 +31,6 @@ import (
 )
 
 const (
-	MaxInFlightNodes           = 15
 	WaitingInFlightNodesPeriod = 20 * time.Second
 )
 
@@ -193,7 +193,7 @@ func (e *NodeExpander) ProcessExpansion(ctx context.Context, pod *corev1.Pod) er
 		e.logger.Info("Pod already in pre-schedule state, skipping expansion check and wait for expansion", "pod", klog.KObj(pod))
 		return nil
 	}
-	if inFlightCount >= MaxInFlightNodes {
+	if inFlightCount >= config.GetMaxInFlightNodes() {
 		e.logger.Error(nil, "Too many inFlight nodes, skipping expansion to avoid too many nodes provisioned concurrently")
 		time.Sleep(WaitingInFlightNodesPeriod)
 		return nil

--- a/internal/utils/resource.go
+++ b/internal/utils/resource.go
@@ -18,6 +18,15 @@ import (
 
 const MaxGPUCounterPerAllocation = 128
 
+// IsGPUMissing returns true when the GPU device was marked missing by hypervisor
+// discovery (physical device not enumerated on the node while workloads still
+// reference it). Missing GPUs must be excluded from scheduling, phase sync and
+// capacity statistics until they either recover or are deleted by a later
+// discovery run once idle.
+func IsGPUMissing(gpu *tfv1.GPU) bool {
+	return gpu.Annotations[constants.GPUMissingSinceAnnotationKey] != ""
+}
+
 func GPUResourcesFromAnnotations(annotations map[string]string) (*tfv1.Resources, error) {
 	result := tfv1.Resources{}
 	resInfo := []struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -72,7 +72,11 @@ var (
 	InitialGPUNodeSelector      = "nvidia.com/gpu.present=true"
 
 	LastSyncTimeAnnotationKey = Domain + "/last-sync"
-	WorkloadKey               = Domain + "/workload"
+	// GPUMissingSinceAnnotationKey marks a GPU CR whose physical device was not
+	// enumerated by the latest hypervisor discovery run, value is the RFC3339 time
+	// it was first found missing. Cleared automatically when the device reappears.
+	GPUMissingSinceAnnotationKey = Domain + "/gpu-missing-since"
+	WorkloadKey                  = Domain + "/workload"
 	// JSON encoded virtualization capability payload from hypervisor discovery.
 	GPUVirtualizationCapabilitiesAnnotation = Domain + "/virtualization-capabilities"
 

--- a/pkg/hypervisor/backend/kubernetes/api_client.go
+++ b/pkg/hypervisor/backend/kubernetes/api_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	"github.com/NexusGPU/tensor-fusion/pkg/hypervisor/api"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -263,5 +265,91 @@ func (a *APIClient) DeleteGPU(uuid string) error {
 	if err := a.client.Delete(a.ctx, gpu); err != nil {
 		return fmt.Errorf("failed to delete GPU %s: %w", uuid, err)
 	}
+	return nil
+}
+
+// CleanupStaleGPUs cleans up GPU CRs owned by this node whose physical device
+// was not enumerated in the current discovery run (e.g. physically removed, or
+// removed while the hypervisor was down): idle GPUs are deleted directly, busy
+// GPUs are only marked missing so transient NVML/driver hiccups do not wipe
+// allocation state, and get deleted by a later run once idle.
+func (a *APIClient) CleanupStaleGPUs(gpuNodeName string, aliveDeviceIDs []string) error {
+	gpuList := &tfv1.GPUList{}
+	if err := a.client.List(a.ctx, gpuList,
+		client.MatchingLabels{constants.LabelKeyOwner: gpuNodeName}); err != nil {
+		return fmt.Errorf("list GPUs owned by node %s: %w", gpuNodeName, err)
+	}
+
+	alive := make(map[string]struct{}, len(aliveDeviceIDs))
+	for _, id := range aliveDeviceIDs {
+		alive[strings.ToLower(id)] = struct{}{}
+	}
+
+	for i := range gpuList.Items {
+		gpu := &gpuList.Items[i]
+		if _, ok := alive[strings.ToLower(gpu.Name)]; ok {
+			continue
+		}
+		if err := a.deleteOrMarkMissingGPU(gpu); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteOrMarkMissingGPU handles a device that is no longer enumerated: the GPU
+// CR is deleted when idle, or marked missing (phase Unknown plus missing-since
+// annotation) when workloads still reference it.
+func (a *APIClient) DeleteOrMarkMissingGPU(uuid string) error {
+	gpu := &tfv1.GPU{}
+	if err := a.client.Get(a.ctx, client.ObjectKey{Name: uuid}, gpu); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get GPU %s: %w", uuid, err)
+	}
+	return a.deleteOrMarkMissingGPU(gpu)
+}
+
+func (a *APIClient) deleteOrMarkMissingGPU(gpu *tfv1.GPU) error {
+	// Cards are always drained before being physically pulled, so an idle
+	// missing GPU has nothing to lose (Available == Capacity): delete it
+	// directly. Even a false positive is harmless, the next discovery run
+	// recreates it identically.
+	if len(gpu.Status.RunningApps) == 0 && len(gpu.Status.AllocatedPartitions) == 0 {
+		klog.Infof("GPU device not enumerated and has no running apps, deleting directly: %s", gpu.Name)
+		if err := a.client.Delete(a.ctx, gpu); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete missing idle GPU %s: %w", gpu.Name, err)
+		}
+		return nil
+	}
+
+	// A missing GPU still referenced by running apps: deleting now would reset
+	// allocation accounting on recreate (transient NVML/driver hiccups), so
+	// only mark it. Once its workloads are gone, the next discovery run
+	// deletes it via the idle path above.
+	// Keep the first missing-since timestamp for observability.
+	if _, marked := gpu.Annotations[constants.GPUMissingSinceAnnotationKey]; !marked {
+		patch := client.MergeFrom(gpu.DeepCopy())
+		if gpu.Annotations == nil {
+			gpu.Annotations = map[string]string{}
+		}
+		gpu.Annotations[constants.GPUMissingSinceAnnotationKey] = time.Now().Format(time.RFC3339)
+		if err := a.client.Patch(a.ctx, gpu, patch); err != nil {
+			return fmt.Errorf("mark GPU %s missing: %w", gpu.Name, err)
+		}
+	}
+
+	if gpu.Status.Phase != tfv1.TensorFusionGPUPhaseUnknown {
+		patch := client.MergeFrom(gpu.DeepCopy())
+		gpu.Status.Phase = tfv1.TensorFusionGPUPhaseUnknown
+		if err := a.client.Status().Patch(a.ctx, gpu, patch); err != nil {
+			return fmt.Errorf("update phase of missing GPU %s: %w", gpu.Name, err)
+		}
+	}
+
+	klog.Infof("GPU device not enumerated in this discovery run but still has running apps, "+
+		"marked as missing, it will be deleted once idle in a future discovery run unless it recovers: "+
+		"uuid=%s missingSince=%s", gpu.Name, gpu.Annotations[constants.GPUMissingSinceAnnotationKey])
 	return nil
 }

--- a/pkg/hypervisor/backend/kubernetes/api_client_missing_test.go
+++ b/pkg/hypervisor/backend/kubernetes/api_client_missing_test.go
@@ -1,0 +1,175 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	"github.com/NexusGPU/tensor-fusion/pkg/hypervisor/api"
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const missingTestGPUNodeName = "missing-test-gpu-node"
+
+func newMissingTestGPU(name, owner string, phase tfv1.TensorFusionGPUPhase) *tfv1.GPU {
+	return &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.LabelKeyOwner: owner,
+			},
+			Annotations: map[string]string{
+				constants.LastSyncTimeAnnotationKey: time.Now().Format(time.RFC3339),
+			},
+		},
+		Status: tfv1.GPUStatus{
+			Phase: phase,
+			Capacity: &tfv1.Resource{
+				Tflops: resource.MustParse("100"),
+				Vram:   resource.MustParse("16Gi"),
+			},
+			Available: &tfv1.Resource{
+				Tflops: resource.MustParse("100"),
+				Vram:   resource.MustParse("16Gi"),
+			},
+		},
+	}
+}
+
+func TestCleanupStaleGPUs(t *testing.T) {
+	ctx := context.Background()
+
+	present := newMissingTestGPU("gpu-present", missingTestGPUNodeName, tfv1.TensorFusionGPUPhaseRunning)
+	missing := newMissingTestGPU("gpu-missing", missingTestGPUNodeName, tfv1.TensorFusionGPUPhaseRunning)
+	otherNodeGPU := newMissingTestGPU("gpu-other-node", "other-gpu-node", tfv1.TensorFusionGPUPhaseRunning)
+	// a missing GPU still referenced by running apps: must be marked, not deleted
+	busyMissing := newMissingTestGPU("gpu-missing-busy", missingTestGPUNodeName, tfv1.TensorFusionGPUPhaseRunning)
+	busyMissing.Status.RunningApps = []*tfv1.RunningAppDetail{{Name: "app-1", Namespace: "default"}}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPU{}).
+		WithObjects(present, missing, otherNodeGPU, busyMissing).Build()
+	apiClient := NewAPIClient(ctx, k8sClient)
+
+	err := apiClient.CleanupStaleGPUs(missingTestGPUNodeName, []string{"gpu-present"})
+	assert.NoError(t, err)
+
+	// an idle missing GPU must be deleted immediately (ops always drain before pulling a card)
+	got := &tfv1.GPU{}
+	err = k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-missing"}, got)
+	assert.True(t, apierrors.IsNotFound(err), "idle missing GPU should be deleted directly, got err=%v", err)
+
+	// a missing GPU still referenced by running apps must be marked, not deleted,
+	// so a transient NVML hiccup cannot wipe allocation accounting
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-missing-busy"}, got))
+	assert.Equal(t, tfv1.TensorFusionGPUPhaseUnknown, got.Status.Phase,
+		"busy missing GPU should be marked Unknown")
+	missingSince := got.Annotations[constants.GPUMissingSinceAnnotationKey]
+	assert.NotEmpty(t, missingSince, "busy missing GPU should carry missing-since annotation")
+	_, err = time.Parse(time.RFC3339, missingSince)
+	assert.NoError(t, err, "missing-since should be a valid RFC3339 timestamp")
+
+	// the GPU still enumerated must be untouched
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-present"}, got))
+	assert.Equal(t, tfv1.TensorFusionGPUPhaseRunning, got.Status.Phase)
+	assert.NotContains(t, got.Annotations, constants.GPUMissingSinceAnnotationKey)
+
+	// GPUs owned by other nodes must not be touched
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-other-node"}, got))
+	assert.Equal(t, tfv1.TensorFusionGPUPhaseRunning, got.Status.Phase)
+	assert.NotContains(t, got.Annotations, constants.GPUMissingSinceAnnotationKey)
+
+	// idempotent: re-marking must keep the original missing-since timestamp
+	err = apiClient.CleanupStaleGPUs(missingTestGPUNodeName, []string{"gpu-present"})
+	assert.NoError(t, err)
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-missing-busy"}, got))
+	assert.Equal(t, missingSince, got.Annotations[constants.GPUMissingSinceAnnotationKey],
+		"missing-since must not be refreshed on subsequent runs")
+}
+
+func TestDeleteOrMarkMissingGPU(t *testing.T) {
+	ctx := context.Background()
+
+	idle := newMissingTestGPU("gpu-idle", missingTestGPUNodeName, tfv1.TensorFusionGPUPhaseRunning)
+	busy := newMissingTestGPU("gpu-busy", missingTestGPUNodeName, tfv1.TensorFusionGPUPhaseRunning)
+	busy.Status.RunningApps = []*tfv1.RunningAppDetail{{Name: "app-1", Namespace: "default"}}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPU{}).
+		WithObjects(idle, busy).Build()
+	apiClient := NewAPIClient(ctx, k8sClient)
+
+	// idle GPU: deleted directly
+	assert.NoError(t, apiClient.DeleteOrMarkMissingGPU("gpu-idle"))
+	got := &tfv1.GPU{}
+	err := k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-idle"}, got)
+	assert.True(t, apierrors.IsNotFound(err), "idle GPU should be deleted, got err=%v", err)
+
+	// busy GPU: marked missing instead of deleted
+	assert.NoError(t, apiClient.DeleteOrMarkMissingGPU("gpu-busy"))
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: "gpu-busy"}, got))
+	assert.Equal(t, tfv1.TensorFusionGPUPhaseUnknown, got.Status.Phase)
+	assert.NotEmpty(t, got.Annotations[constants.GPUMissingSinceAnnotationKey])
+
+	// already-deleted GPU: no error
+	assert.NoError(t, apiClient.DeleteOrMarkMissingGPU("gpu-gone"))
+}
+
+func TestCreateOrUpdateGPU_RecoversMissingGPU(t *testing.T) {
+	ctx := context.Background()
+
+	gpuNode := &tfv1.GPUNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: missingTestGPUNodeName,
+			OwnerReferences: []metav1.OwnerReference{
+				{Name: "test-gpu-pool"},
+			},
+		},
+	}
+	uuid := "gpu-recovered"
+	missingGPU := newMissingTestGPU(uuid, missingTestGPUNodeName, tfv1.TensorFusionGPUPhaseUnknown)
+	missingGPU.Annotations[constants.GPUMissingSinceAnnotationKey] =
+		time.Now().Add(-5 * time.Minute).Format(time.RFC3339)
+	// simulate in-use accounting that must survive recovery
+	missingGPU.Status.Available.Tflops = resource.MustParse("40")
+	missingGPU.Status.RunningApps = []*tfv1.RunningAppDetail{{Name: "app-1", Namespace: "default"}}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&tfv1.GPU{}).
+		WithObjects(gpuNode, missingGPU).Build()
+
+	backend := &KubeletBackend{
+		ctx:          ctx,
+		apiClient:    NewAPIClient(ctx, k8sClient),
+		nodeName:     missingTestGPUNodeName,
+		deviceTflops: map[string]resource.Quantity{},
+	}
+	device := &api.DeviceInfo{
+		UUID:             uuid,
+		Model:            "NVIDIA-Test-GPU",
+		TotalMemoryBytes: 16 * 1024 * 1024 * 1024,
+		MaxTflops:        100,
+	}
+
+	err := backend.apiClient.CreateOrUpdateGPU(missingTestGPUNodeName, uuid,
+		func(node *tfv1.GPUNode, gpu *tfv1.GPU) error {
+			return backend.mutateGPUResourceState(device, node, gpu)
+		})
+	assert.NoError(t, err)
+
+	gpu := &tfv1.GPU{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: uuid}, gpu))
+	assert.NotContains(t, gpu.Annotations, constants.GPUMissingSinceAnnotationKey,
+		"missing marker must be cleared when the device reappears")
+	assert.Equal(t, tfv1.TensorFusionGPUPhasePending, gpu.Status.Phase,
+		"recovered GPU should go back to Pending for the controller to promote")
+	assert.Equal(t, resource.MustParse("40"), gpu.Status.Available.Tflops,
+		"existing allocation accounting must be preserved on recovery")
+}

--- a/pkg/hypervisor/backend/kubernetes/kubernetes_backend.go
+++ b/pkg/hypervisor/backend/kubernetes/kubernetes_backend.go
@@ -262,8 +262,11 @@ func (b *KubeletBackend) GetDeviceChangeHandler() framework.DeviceChangeHandler 
 			if device != nil {
 				b.deleteDeviceTflops(device.UUID)
 			}
-			if err := b.apiClient.DeleteGPU(device.UUID); err != nil {
-				klog.Errorf("Failed to delete GPU when device removed: %v", err)
+			// Delete only when idle; a missing GPU still referenced by running
+			// apps is marked (Unknown phase + missing-since annotation) so a
+			// transient NVML/driver hiccup cannot wipe allocation accounting.
+			if err := b.apiClient.DeleteOrMarkMissingGPU(device.UUID); err != nil {
+				klog.Errorf("Failed to clean up GPU when device removed: %v", err)
 			} else {
 				klog.Infof("Device removed: %s", device.UUID)
 			}
@@ -282,6 +285,13 @@ func (b *KubeletBackend) GetDeviceChangeHandler() framework.DeviceChangeHandler 
 			if nodeInfo != nil {
 				if totalTflops, ok := b.getTotalDeviceTflops(); ok {
 					nodeInfo.TotalTFlops = totalTflops
+				}
+				// GPU CRs owned by this node but absent from the current
+				// enumeration (e.g. card removed while the hypervisor was down,
+				// so no OnRemove ever fired) must be cleaned up, otherwise stale
+				// GPU CRs keep polluting scheduling and capacity statistics forever.
+				if err := b.apiClient.CleanupStaleGPUs(b.nodeName, nodeInfo.DeviceIDs); err != nil {
+					klog.Errorf("Failed to clean up stale GPUs: %v", err)
 				}
 			}
 			if err := b.apiClient.UpdateGPUNodeStatus(b.nodeName, nodeInfo); err != nil {
@@ -358,7 +368,11 @@ func (b *KubeletBackend) mutateGPUResourceState(
 	if gpu.Status.UsedBy == "" {
 		gpu.Status.UsedBy = tfv1.UsedByTensorFusion
 	}
-	if gpu.Status.Phase == "" {
+	if gpu.Status.Phase == "" || gpu.Status.Phase == tfv1.TensorFusionGPUPhaseUnknown {
+		// Unknown means the device was previously marked missing by discovery,
+		// it has recovered now (the missing-since annotation is cleared by the
+		// full annotation rewrite above), reset to Pending for the controller
+		// to promote.
 		gpu.Status.Phase = tfv1.TensorFusionGPUPhasePending
 	}
 	gpu.Status.Message = "managed"


### PR DESCRIPTION
Port outstanding v1 fixes onto main and harden hypervisor pod creation:

- defrag (#734): add SelectFromStore so joint-placement dry-runs score against the same virtual budget they filter on; add placement diagnostics (per-target rejection trail, dirty/free GPU accounting, node exclusions) surfaced on the DefragSkipUnschedulable event and logs.
- gpunode (#713): make expander MaxInFlightNodes configurable via GlobalConfig (atomic pointer to fix the config-watch race), initialize new GPUNodes to Pending and add an empty-phase safety net so the inflight window is visible.
- nodediscovery (#736): reconcile owned GPU CRs against the current enumeration on discovery completion so cards removed while the hypervisor was down get cleaned up; idle missing GPUs are deleted, busy ones are marked Unknown + gpu-missing-since and excluded from phase sync and node capacity until they recover or go idle; hypervisor RBAC gains gpus delete.
- gpunode: skip hypervisor pod creation on a NotReady node and remove any non-running pod stuck on it; recovery re-triggers via the Node watch. Cordon (spec.Unschedulable) is intentionally not gated.

695/697/716/723/705 verified already present on main; no action needed.