### PR TITLE
fix: stop allocator store leaks and shrink oversized defrag diagnosti…

### DIFF
--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -1586,13 +1586,68 @@ func (d *defragPlacementDiagnostics) logFields() map[string]any {
 		return nil
 	}
 	return map[string]any{
-		"sourceNode":     d.SourceNode,
-		"profile":        d.Profile,
-		"budgetTargets":  d.BudgetTargets,
+		"sourceNode": d.SourceNode,
+		"profile":    d.Profile,
+		// budgetTargets is omitted: it's the same node names already
+		// present as the "Node" field of each budgetNodes entry.
 		"budgetNodes":    d.BudgetNodes,
-		"excludedNodes":  d.ExcludedNodes,
-		"podDiagnostics": d.PodDiagnostics,
+		"excludedNodes":  d.excludedNodesByReason(),
+		"podDiagnostics": d.logPodDiagnostics(),
 	}
+}
+
+// groupByReason collapses same-reason entries (e.g. dozens of nodes deleted
+// in one node-churn event, all "not in scheduler snapshot") into one entry
+// with a node-name list, instead of repeating the reason text per node.
+func groupByReason(node, reason string, into map[string][]string) {
+	into[reason] = append(into[reason], node)
+}
+
+func (d *defragPlacementDiagnostics) excludedNodesByReason() map[string][]string {
+	if d == nil || len(d.ExcludedNodes) == 0 {
+		return nil
+	}
+	grouped := make(map[string][]string)
+	for _, e := range d.ExcludedNodes {
+		groupByReason(e.Node, e.Reason, grouped)
+	}
+	for reason := range grouped {
+		sort.Strings(grouped[reason])
+	}
+	return grouped
+}
+
+// logPodDiagnostics renders PodDiagnostics for logging with Rejections
+// grouped by "stage: reason" the same way excludedNodesByReason groups
+// ExcludedNodes: most rejected targets for a given pod share the identical
+// stage/reason (e.g. "scheduler-infeasible: in budget but scheduler did not
+// return node as feasible") and only differ by which node they targeted.
+func (d *defragPlacementDiagnostics) logPodDiagnostics() []map[string]any {
+	if d == nil || len(d.PodDiagnostics) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(d.PodDiagnostics))
+	for _, pd := range d.PodDiagnostics {
+		if pd == nil {
+			continue
+		}
+		rejections := make(map[string][]string, len(pd.Rejections))
+		for _, r := range pd.Rejections {
+			groupByReason(r.Target, r.Stage+": "+r.Reason, rejections)
+		}
+		for reason := range rejections {
+			sort.Strings(rejections[reason])
+		}
+		out = append(out, map[string]any{
+			"pod":              pd.Pod,
+			"request":          pd.Request,
+			"feasibleNodes":    pd.FeasibleNodes,
+			"schedulerDetails": pd.SchedulerDetails,
+			"rejections":       rejections,
+			"selectedTarget":   pd.SelectedTarget,
+		})
+	}
+	return out
 }
 
 func defragPodRequestSummary(pod *corev1.Pod) string {
@@ -1777,7 +1832,11 @@ func buildDefragNodeBudgets(
 		if err != nil {
 			// Allocator state can briefly outlive scheduler cache for
 			// deleted nodes; drop only this target, not the candidate.
-			exclude(nodeName, "not in scheduler snapshot: "+err.Error())
+			// err.Error() just repeats nodeName ("nodeinfo not found for
+			// node name ..."), which is already in the Node field below,
+			// so it's dropped here to keep the (often long) exclusion
+			// list from duplicating it per entry.
+			exclude(nodeName, "not in scheduler snapshot")
 			continue
 		}
 		if node := nodeInfo.Node(); node == nil {

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -2820,6 +2821,61 @@ func TestBuildDefragNodeBudgets_ReportsDirtyFreeAndExclusions(t *testing.T) {
 	}
 	if !foundEmpty {
 		t.Fatalf("empty node exclusion missing, got %+v", exclusions)
+	}
+}
+
+func TestExcludedNodesByReason_GroupsSameReasonNodes(t *testing.T) {
+	// A node-churn burst can exclude dozens of nodes with the identical
+	// "not in scheduler snapshot" reason; grouping must collapse them to one
+	// key with all node names present, instead of repeating the reason text.
+	diag := &defragPlacementDiagnostics{
+		ExcludedNodes: []defragNodeExclusion{
+			{Node: "node-b", Reason: "not in scheduler snapshot"},
+			{Node: "node-a", Reason: "not in scheduler snapshot"},
+			{Node: "node-c", Reason: "deletion-marked"},
+		},
+	}
+
+	grouped := diag.excludedNodesByReason()
+
+	if got := grouped["not in scheduler snapshot"]; !reflect.DeepEqual(got, []string{"node-a", "node-b"}) {
+		t.Fatalf("grouped snapshot reason = %v, want sorted [node-a node-b]", got)
+	}
+	if got := grouped["deletion-marked"]; !reflect.DeepEqual(got, []string{"node-c"}) {
+		t.Fatalf("grouped deletion-marked = %v, want [node-c]", got)
+	}
+}
+
+func TestLogPodDiagnostics_GroupsRejectionsByStageAndReason(t *testing.T) {
+	// Mirrors the production case: dozens of budget targets rejected for the
+	// identical scheduler-infeasible reason, differing only by Target. The
+	// log rendering must collapse them instead of repeating the reason text.
+	diag := &defragPlacementDiagnostics{
+		PodDiagnostics: []*defragPodPlacementDiagnostic{
+			{
+				Pod: "ns/pod-a",
+				Rejections: []defragTargetRejection{
+					{Target: "node-2", Stage: "scheduler-infeasible", Reason: "in budget but scheduler did not return node as feasible"},
+					{Target: "node-1", Stage: "scheduler-infeasible", Reason: "in budget but scheduler did not return node as feasible"},
+					{Target: "node-3", Stage: "not-in-budget", Reason: "scheduler feasible node is not a defrag budget target"},
+				},
+			},
+		},
+	}
+
+	rendered := diag.logPodDiagnostics()
+	if len(rendered) != 1 {
+		t.Fatalf("logPodDiagnostics() len = %d, want 1", len(rendered))
+	}
+	rejections, ok := rendered[0]["rejections"].(map[string][]string)
+	if !ok {
+		t.Fatalf("rejections field has wrong type: %T", rendered[0]["rejections"])
+	}
+	if got := rejections["scheduler-infeasible: in budget but scheduler did not return node as feasible"]; !reflect.DeepEqual(got, []string{"node-1", "node-2"}) {
+		t.Fatalf("grouped scheduler-infeasible = %v, want sorted [node-1 node-2]", got)
+	}
+	if got := rejections["not-in-budget: scheduler feasible node is not a defrag budget target"]; !reflect.DeepEqual(got, []string{"node-3"}) {
+		t.Fatalf("grouped not-in-budget = %v, want [node-3]", got)
 	}
 }
 

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -763,8 +763,33 @@ func (s *GpuAllocator) Dealloc(
 		s.markGPUDirty(gpuNameNs)
 	}
 
+	podKey := types.NamespacedName{Name: podMeta.Name, Namespace: podMeta.Namespace}
+	if nodeName == "" {
+		// Every gpu in gpus was already gone from gpuStore (e.g. its node
+		// was torn down and handleGPUDelete ran before this Dealloc call),
+		// so NodeSelector couldn't be read off any of them. Fall back to
+		// scanning nodeWorkerStore for whichever node still lists this pod,
+		// otherwise the pod's entry - and possibly its node's now-empty
+		// entry - would never get reaped.
+		for candidateNode, workers := range s.nodeWorkerStore {
+			if _, ok := workers[podKey]; ok {
+				nodeName = candidateNode
+				break
+			}
+		}
+	}
+
 	// remove pod from nodeWorkerStore
-	delete(s.nodeWorkerStore[nodeName], types.NamespacedName{Name: podMeta.Name, Namespace: podMeta.Namespace})
+	delete(s.nodeWorkerStore[nodeName], podKey)
+	// handleGPUDelete leaves a node's nodeWorkerStore entry in place if it
+	// still had workers when the node's last GPU disappeared (to avoid
+	// discarding live bookkeeping); once the last worker also drains here,
+	// and the node has no GPUs left either, there's nothing left to trigger
+	// cleanup for this node again, so reap it now instead of leaving an
+	// empty map behind forever.
+	if nodeName != "" && len(s.nodeWorkerStore[nodeName]) == 0 && s.nodeGpuStore[nodeName] == nil {
+		delete(s.nodeWorkerStore, nodeName)
+	}
 	delete(s.uniqueAllocation, podUID)
 	delete(s.podNamespaceNsToPodUID, podMeta.Namespace+"/"+podMeta.Name)
 	s.uniqueDeallocation[podUID] = struct{}{}
@@ -1291,6 +1316,23 @@ func (s *GpuAllocator) handleGPUDelete(ctx context.Context, gpu *tfv1.GPU) {
 		gpuNodeName := gpu.Status.NodeSelector[constants.KubernetesHostNameLabel]
 		if s.nodeGpuStore[gpuNodeName] != nil {
 			delete(s.nodeGpuStore[gpuNodeName], gpu.Name)
+			// A node's last GPU being removed almost always means the node
+			// itself is gone (terminated/scaled down). Drop the now-empty
+			// entry too, otherwise it lingers in nodeGpuStore forever and
+			// keeps showing up as a defunct defrag budget target.
+			if len(s.nodeGpuStore[gpuNodeName]) == 0 {
+				delete(s.nodeGpuStore, gpuNodeName)
+				// GPU CR deletion doesn't guarantee the node's workers are
+				// gone too (e.g. cascade-delete on node termination races
+				// ahead of pod cleanup, or RunningApps hasn't synced to the
+				// GPU CR yet when node-discovery decides to delete it) so
+				// only reap nodeWorkerStore here if it's already empty;
+				// otherwise leave live worker bookkeeping for Dealloc /
+				// the cleanup checker to retire pod-by-pod.
+				if len(s.nodeWorkerStore[gpuNodeName]) == 0 {
+					delete(s.nodeWorkerStore, gpuNodeName)
+				}
+			}
 		}
 	}
 
@@ -1298,6 +1340,9 @@ func (s *GpuAllocator) handleGPUDelete(ctx context.Context, gpu *tfv1.GPU) {
 		pool := gpu.Labels[constants.GpuPoolKey]
 		if pool != "" {
 			delete(s.poolGpuStore[pool], gpu.Name)
+			if len(s.poolGpuStore[pool]) == 0 {
+				delete(s.poolGpuStore, pool)
+			}
 		}
 	}
 	log.Info("Removed GPU from store", "name", key.Name)

--- a/internal/gpuallocator/gpuallocator_test.go
+++ b/internal/gpuallocator/gpuallocator_test.go
@@ -455,6 +455,162 @@ var _ = Describe("GPU Allocator", func() {
 			_, exists = allocator.gpuStore[key]
 			Expect(exists).To(BeFalse())
 		})
+
+		It("should drop the node entry from nodeGpuStore once its last GPU is deleted", func() {
+			// Regression: a node's GPU CRs are all deleted when the node itself
+			// is terminated, but nodeGpuStore previously only removed the GPU
+			// key and left an empty map for the node behind forever, so defrag
+			// kept treating long-gone nodes as budget candidates.
+			nodeName := "solo-node"
+			soloGPU := &tfv1.GPU{
+				ObjectMeta: metav1.ObjectMeta{Name: "solo-gpu"},
+				Status: tfv1.GPUStatus{
+					NodeSelector: map[string]string{
+						constants.KubernetesHostNameLabel: nodeName,
+					},
+				},
+			}
+			allocator.storeMutex.Lock()
+			allocator.nodeGpuStore[nodeName] = map[string]*tfv1.GPU{soloGPU.Name: soloGPU}
+			allocator.storeMutex.Unlock()
+
+			allocator.handleGPUDelete(ctx, soloGPU)
+
+			allocator.storeMutex.RLock()
+			_, exists := allocator.nodeGpuStore[nodeName]
+			allocator.storeMutex.RUnlock()
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should drop nodeWorkerStore and poolGpuStore entries alongside nodeGpuStore", func() {
+			// Same leak class as nodeGpuStore: nodeWorkerStore and
+			// poolGpuStore must not keep an empty entry behind for a
+			// node/pool whose last GPU was just removed.
+			nodeName := "solo-node-2"
+			poolName := "solo-pool"
+			soloGPU := &tfv1.GPU{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "solo-gpu-2",
+					Labels: map[string]string{constants.GpuPoolKey: poolName},
+				},
+				Status: tfv1.GPUStatus{
+					NodeSelector: map[string]string{
+						constants.KubernetesHostNameLabel: nodeName,
+					},
+				},
+			}
+			allocator.storeMutex.Lock()
+			allocator.nodeGpuStore[nodeName] = map[string]*tfv1.GPU{soloGPU.Name: soloGPU}
+			allocator.poolGpuStore[poolName] = map[string]*tfv1.GPU{soloGPU.Name: soloGPU}
+			allocator.nodeWorkerStore[nodeName] = map[types.NamespacedName]struct{}{}
+			allocator.storeMutex.Unlock()
+
+			allocator.handleGPUDelete(ctx, soloGPU)
+
+			allocator.storeMutex.RLock()
+			_, nodeWorkerExists := allocator.nodeWorkerStore[nodeName]
+			_, poolExists := allocator.poolGpuStore[poolName]
+			allocator.storeMutex.RUnlock()
+			Expect(nodeWorkerExists).To(BeFalse())
+			Expect(poolExists).To(BeFalse())
+		})
+
+		It("should keep nodeWorkerStore when the node still has live worker entries", func() {
+			// GPU CR deletion doesn't guarantee the node's workers are gone
+			// (e.g. node-termination cascade racing ahead of pod cleanup, or
+			// RunningApps not yet synced when node-discovery deletes the
+			// CR) so a non-empty nodeWorkerStore entry must survive even
+			// though the node's last GPU just disappeared.
+			nodeName := "busy-node"
+			soloGPU := &tfv1.GPU{
+				ObjectMeta: metav1.ObjectMeta{Name: "busy-gpu"},
+				Status: tfv1.GPUStatus{
+					NodeSelector: map[string]string{
+						constants.KubernetesHostNameLabel: nodeName,
+					},
+				},
+			}
+			livePod := types.NamespacedName{Namespace: "default", Name: "still-running-worker"}
+			allocator.storeMutex.Lock()
+			allocator.nodeGpuStore[nodeName] = map[string]*tfv1.GPU{soloGPU.Name: soloGPU}
+			allocator.nodeWorkerStore[nodeName] = map[types.NamespacedName]struct{}{livePod: {}}
+			allocator.storeMutex.Unlock()
+
+			allocator.handleGPUDelete(ctx, soloGPU)
+
+			allocator.storeMutex.RLock()
+			workers, exists := allocator.nodeWorkerStore[nodeName]
+			allocator.storeMutex.RUnlock()
+			Expect(exists).To(BeTrue())
+			Expect(workers).To(HaveKey(livePod))
+		})
+
+		It("should reap nodeWorkerStore once the last worker drains from a node with no GPUs left", func() {
+			// Closes the other half of the leak: handleGPUDelete deliberately
+			// leaves a non-empty nodeWorkerStore entry behind for a node
+			// whose GPUs are already gone (see the previous spec). Once the
+			// last worker on that node is later dealloc'd, nothing else will
+			// ever revisit this node again, so Dealloc itself must reap the
+			// now-empty entry instead of leaving a ghost key forever.
+			nodeName := "draining-node"
+			gpuName := "draining-gpu"
+			podMeta := metav1.ObjectMeta{Namespace: "default", Name: "last-worker", UID: "last-worker-uid"}
+
+			allocator.storeMutex.Lock()
+			allocator.gpuStore[types.NamespacedName{Name: gpuName}] = &tfv1.GPU{
+				ObjectMeta: metav1.ObjectMeta{Name: gpuName},
+				Status: tfv1.GPUStatus{
+					NodeSelector: map[string]string{constants.KubernetesHostNameLabel: nodeName},
+					Available:    &tfv1.Resource{},
+					Capacity:     &tfv1.Resource{},
+				},
+			}
+			// nodeGpuStore has no entry for nodeName: its GPUs are already gone.
+			allocator.nodeWorkerStore[nodeName] = map[types.NamespacedName]struct{}{
+				{Namespace: podMeta.Namespace, Name: podMeta.Name}: {},
+			}
+			allocator.uniqueAllocation[string(podMeta.UID)] = &tfv1.AllocRequest{
+				WorkloadNameNamespace: workloadNameNs,
+				Request:               tfv1.Resource{},
+			}
+			allocator.storeMutex.Unlock()
+
+			allocator.Dealloc(workloadNameNs, []string{gpuName}, podMeta)
+
+			allocator.storeMutex.RLock()
+			_, exists := allocator.nodeWorkerStore[nodeName]
+			allocator.storeMutex.RUnlock()
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should still locate and clean up the pod's node when its GPU was already purged from gpuStore", func() {
+			// handleGPUDelete unconditionally deletes from gpuStore the moment
+			// a GPU CR is removed, which can race ahead of this worker's own
+			// Dealloc call (node-termination cascade vs. pod cleanup are
+			// independent async paths). When that happens Dealloc can't read
+			// NodeSelector off gpuStore anymore, so it must fall back to
+			// scanning nodeWorkerStore to find - and clean up - the right node.
+			nodeName := "already-gone-node"
+			gpuName := "already-gone-gpu"
+			podMeta := metav1.ObjectMeta{Namespace: "default", Name: "orphaned-worker", UID: "orphaned-worker-uid"}
+			podKey := types.NamespacedName{Namespace: podMeta.Namespace, Name: podMeta.Name}
+
+			allocator.storeMutex.Lock()
+			// gpuStore has NO entry for gpuName: it was already purged by handleGPUDelete.
+			allocator.nodeWorkerStore[nodeName] = map[types.NamespacedName]struct{}{podKey: {}}
+			allocator.uniqueAllocation[string(podMeta.UID)] = &tfv1.AllocRequest{
+				WorkloadNameNamespace: workloadNameNs,
+				Request:               tfv1.Resource{},
+			}
+			allocator.storeMutex.Unlock()
+
+			allocator.Dealloc(workloadNameNs, []string{gpuName}, podMeta)
+
+			allocator.storeMutex.RLock()
+			_, exists := allocator.nodeWorkerStore[nodeName]
+			allocator.storeMutex.RUnlock()
+			Expect(exists).To(BeFalse())
+		})
 	})
 
 	Context("FilterWithPreempt", func() {


### PR DESCRIPTION
…cs logs

handleGPUDelete only removed the inner GPU-keyed entry from nodeGpuStore/nodeWorkerStore/poolGpuStore, leaving an empty outer node/pool key behind forever once a node's or pool's last GPU was deleted. In a churny cluster this accumulated into hundreds of stale "ghost" nodes that kept showing up as invalid defrag budget targets ("not in scheduler snapshot").

nodeWorkerStore cleanup is conditioned on it already being empty, since a node's GPU CR can be deleted (node-termination cascade, or a discovery rescan racing ahead of RunningApps sync) before its worker pods have actually drained — deleting it unconditionally would discard live worker bookkeeping and let maxWorkerPerNode / ListNonUsingNodes misjudge the node. Dealloc gets a matching fallback: if a pod's GPU was already purged from gpuStore by the time it dealloc's, it now scans nodeWorkerStore to find and clean up the right node instead of silently operating on an empty node name.

Separately, a node-churn burst can exclude or reject dozens of nodes with identical reason text, differing only by node name — this blew one placement-diagnostics log line up to 65KB+ and got silently truncated by the log collector before it could be inspected. Group excludedNodes and each pod's Rejections by reason instead of repeating it per node, and drop the redundant budgetTargets field (same data as budgetNodes' Node field). No information is dropped — every node name is still present, just restructured.