### PR TITLE
fix(scheduler): preserve placement priority with GPU topology

### DIFF
--- a/charts/tensor-fusion/Chart.yaml
+++ b/charts/tensor-fusion/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.4
+version: 1.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.16.0"
+appVersion: "2.17.0"

--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -902,8 +902,6 @@ schedulerConfig:
         enabled:
         - name: GPUResourcesFit
           weight: 5
-        - name: GPUNetworkTopologyAware
-          weight: 3
       postFilter:
         # Only GPUResourcesFit is listed here. DefaultPreemption stays enabled
         # through the scheduler's default MultiPoint plugin set.

--- a/config/manager/configs/scheduler-config.yaml
+++ b/config/manager/configs/scheduler-config.yaml
@@ -23,8 +23,6 @@ profiles:
       enabled:
       - name: GPUResourcesFit
         weight: 5
-      - name: GPUNetworkTopologyAware
-        weight: 3
     postFilter:
       # Only GPUResourcesFit is listed here. DefaultPreemption stays enabled
       # through the scheduler's default MultiPoint plugin set.

--- a/config/samples/scheduler-config.yaml
+++ b/config/samples/scheduler-config.yaml
@@ -23,8 +23,6 @@ profiles:
       enabled:
       - name: GPUResourcesFit
         weight: 5
-      - name: GPUNetworkTopologyAware
-        weight: 3
     postFilter:
       # Only GPUResourcesFit is listed here. DefaultPreemption stays enabled
       # through the scheduler's default MultiPoint plugin set.

--- a/internal/scheduler/gputopo/evaluator.go
+++ b/internal/scheduler/gputopo/evaluator.go
@@ -1,8 +1,14 @@
 package scheduler
 
 import (
+	"sort"
+
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 )
+
+// GPUScorer returns a placement score for one GPU. Higher scores are preferred.
+// Topology evaluators use it only after topology quality is equal.
+type GPUScorer func(*tfv1.GPU) int
 
 // Evaluator evaluates GPU topology for a set of candidate GPUs and returns
 // the best combination for the requested GPU count.
@@ -15,6 +21,42 @@ type Evaluator interface {
 	// preferLeastDamage: if true, single-GPU requests prefer GPUs that
 	//   cause the least damage to high-quality topology clusters.
 	Evaluate(gpus []*tfv1.GPU, count uint, preferLeastDamage bool) (*NodeTopologyPlan, error)
+
+	// EvaluateWithScorer keeps topology as the primary ordering and uses the
+	// placement score only to break ties between equivalent GPU combinations.
+	EvaluateWithScorer(gpus []*tfv1.GPU, count uint, preferLeastDamage bool, scorer GPUScorer) (*NodeTopologyPlan, error)
+}
+
+func sortGPUsByPlacement(gpus []*tfv1.GPU, scorer GPUScorer) {
+	sort.SliceStable(gpus, func(i, j int) bool {
+		if scorer != nil {
+			si, sj := scorer(gpus[i]), scorer(gpus[j])
+			if si != sj {
+				return si > sj
+			}
+		}
+		return gpus[i].Name < gpus[j].Name
+	})
+}
+
+func placementScore(gpus []*tfv1.GPU, scorer GPUScorer) int {
+	if scorer == nil {
+		return 0
+	}
+	total := 0
+	for _, gpu := range gpus {
+		total += scorer(gpu)
+	}
+	return total
+}
+
+func bestPlacementScore(gpus []*tfv1.GPU, count int, scorer GPUScorer) int {
+	ordered := append([]*tfv1.GPU(nil), gpus...)
+	sortGPUsByPlacement(ordered, scorer)
+	if count < len(ordered) {
+		ordered = ordered[:count]
+	}
+	return placementScore(ordered, scorer)
 }
 
 // AutoEvaluator selects the appropriate evaluator based on available topology data.
@@ -41,6 +83,10 @@ func (e *AutoEvaluator) Name() string {
 // 2. If any GPU has NUMANode set → NUMAEvaluator
 // 3. Otherwise → returns TierUnknown result
 func (e *AutoEvaluator) Evaluate(gpus []*tfv1.GPU, count uint, preferLeastDamage bool) (*NodeTopologyPlan, error) {
+	return e.EvaluateWithScorer(gpus, count, preferLeastDamage, nil)
+}
+
+func (e *AutoEvaluator) EvaluateWithScorer(gpus []*tfv1.GPU, count uint, preferLeastDamage bool, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	if len(gpus) == 0 {
 		return &NodeTopologyPlan{
 			CandidateGPUIds: []string{},
@@ -54,14 +100,14 @@ func (e *AutoEvaluator) Evaluate(gpus []*tfv1.GPU, count uint, preferLeastDamage
 	// Check if vendor topology (peer link) data is available
 	for _, gpu := range gpus {
 		if gpu.Status.Topology != nil && len(gpu.Status.Topology.Peers) > 0 {
-			return e.peerEvaluator.Evaluate(gpus, count, preferLeastDamage)
+			return e.peerEvaluator.EvaluateWithScorer(gpus, count, preferLeastDamage, scorer)
 		}
 	}
 
 	// Check if NUMA data is available
 	for _, gpu := range gpus {
 		if gpu.Status.NUMANode != nil && *gpu.Status.NUMANode >= 0 {
-			return e.numaEvaluator.Evaluate(gpus, count, preferLeastDamage)
+			return e.numaEvaluator.EvaluateWithScorer(gpus, count, preferLeastDamage, scorer)
 		}
 	}
 
@@ -70,9 +116,14 @@ func (e *AutoEvaluator) Evaluate(gpus []*tfv1.GPU, count uint, preferLeastDamage
 	for i, gpu := range gpus {
 		gpuNames[i] = gpu.Name
 	}
-	bestGPUs := gpuNames
+	ordered := append([]*tfv1.GPU(nil), gpus...)
+	sortGPUsByPlacement(ordered, scorer)
+	bestGPUs := make([]string, len(ordered))
+	for i, gpu := range ordered {
+		bestGPUs[i] = gpu.Name
+	}
 	if count > 0 && int(count) < len(gpuNames) {
-		bestGPUs = gpuNames[:count]
+		bestGPUs = bestGPUs[:count]
 	}
 
 	return &NodeTopologyPlan{

--- a/internal/scheduler/gputopo/gpu_network_topo.go
+++ b/internal/scheduler/gputopo/gpu_network_topo.go
@@ -143,7 +143,13 @@ func (s *GPUNetworkTopologyAware) PreFilter(ctx context.Context, state fwk.Cycle
 			continue
 		}
 
-		plan, evalErr := eval.Evaluate(gpus, gpuCount, preferLeastDamage)
+		var placementScorer GPUScorer
+		if schedulingResult.ScoringStrategy != nil {
+			placementScorer = func(gpu *tfv1.GPU) int {
+				return schedulingResult.ScoringStrategy.Score(gpu, false)
+			}
+		}
+		plan, evalErr := eval.EvaluateWithScorer(gpus, gpuCount, preferLeastDamage, placementScorer)
 		if evalErr != nil {
 			s.logger.Error(evalErr, "topology evaluation failed", "pod", pod.Name, "node", nodeName)
 			continue
@@ -260,28 +266,16 @@ func (s *GPUNetworkTopologyAware) Filter(ctx context.Context, state fwk.CycleSta
 	return fwk.NewStatus(fwk.Success, "")
 }
 
-// Score returns a topology-based score for the node.
-func (s *GPUNetworkTopologyAware) Score(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
-	nodeName := nodeInfo.Node().Name
+// Score is retained for compatibility with existing scheduler configs that
+// list this plugin at the Score extension point. Node ordering is owned by
+// GPUResourcesFit's placement mode, so topology contributes no node score.
+func (s *GPUNetworkTopologyAware) Score(_ context.Context, _ fwk.CycleState, pod *v1.Pod, _ fwk.NodeInfo) (int64, *fwk.Status) {
 	if !utils.IsTensorFusionWorker(pod) {
 		return 0, fwk.NewStatus(fwk.Success, "")
 	}
-
-	topoStateRaw, err := state.Read(CycleStateGPUTopologyResult)
-	if err != nil {
-		return 0, fwk.NewStatus(fwk.Success, "")
-	}
-
-	topoState := topoStateRaw.(*GPUTopologyStateData)
-	plan, exists := topoState.Plans[nodeName]
-	if !exists {
-		return 0, fwk.NewStatus(fwk.Success, "")
-	}
-
-	return plan.Score, fwk.NewStatus(fwk.Success, "")
+	return 0, fwk.NewStatus(fwk.Success, "node ordering is controlled by placement mode")
 }
 
-// ScoreExtensions returns nil since no normalization extension is needed.
 func (s *GPUNetworkTopologyAware) ScoreExtensions() fwk.ScoreExtensions {
 	return nil
 }

--- a/internal/scheduler/gputopo/numa_evaluator.go
+++ b/internal/scheduler/gputopo/numa_evaluator.go
@@ -24,6 +24,10 @@ func (e *NUMAEvaluator) Name() string {
 }
 
 func (e *NUMAEvaluator) Evaluate(gpus []*tfv1.GPU, count uint, preferLeastDamage bool) (*NodeTopologyPlan, error) {
+	return e.EvaluateWithScorer(gpus, count, preferLeastDamage, nil)
+}
+
+func (e *NUMAEvaluator) EvaluateWithScorer(gpus []*tfv1.GPU, count uint, preferLeastDamage bool, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	if count == 0 {
 		return &NodeTopologyPlan{
 			CandidateGPUIds: []string{},
@@ -40,9 +44,9 @@ func (e *NUMAEvaluator) Evaluate(gpus []*tfv1.GPU, count uint, preferLeastDamage
 	}
 
 	if count == 1 {
-		return e.evaluateSingleGPU(gpus, candidateNames, preferLeastDamage)
+		return e.evaluateSingleGPU(gpus, candidateNames, preferLeastDamage, scorer)
 	}
-	return e.evaluateMultiGPU(gpus, candidateNames, count)
+	return e.evaluateMultiGPU(gpus, candidateNames, count, scorer)
 }
 
 // numaGroup groups GPUs by their NUMA node ID.
@@ -69,16 +73,18 @@ func groupByNUMA(gpus []*tfv1.GPU) map[int32][]*tfv1.GPU {
 // 1. GPU in a NUMA domain with only 1 remaining GPU ("orphan")
 // 2. GPU in a smaller NUMA domain
 // 3. GPU in a larger NUMA domain (avoid breaking large clusters)
-func (e *NUMAEvaluator) evaluateSingleGPU(gpus []*tfv1.GPU, candidateNames []string, preferLeastDamage bool) (*NodeTopologyPlan, error) {
+func (e *NUMAEvaluator) evaluateSingleGPU(gpus []*tfv1.GPU, candidateNames []string, preferLeastDamage bool, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	if !preferLeastDamage || len(gpus) <= 1 {
+		ordered := append([]*tfv1.GPU(nil), gpus...)
+		sortGPUsByPlacement(ordered, scorer)
 		// No least-damage optimization needed; determine tier from the GPU's actual NUMA status
 		tier := TierSameNUMA
-		if gpus[0].Status.NUMANode == nil || *gpus[0].Status.NUMANode < 0 {
+		if ordered[0].Status.NUMANode == nil || *ordered[0].Status.NUMANode < 0 {
 			tier = TierUnknown
 		}
 		return &NodeTopologyPlan{
 			CandidateGPUIds: candidateNames,
-			BestGPUIds:      []string{gpus[0].Name},
+			BestGPUIds:      []string{ordered[0].Name},
 			Tier:            tier,
 			Score:           TierBandedScore(tier, 100),
 			ModeSatisfied:   int(tier) <= e.maxAllowedTier,
@@ -123,6 +129,12 @@ func (e *NUMAEvaluator) evaluateSingleGPU(gpus []*tfv1.GPU, candidateNames []str
 		if si.domainSize != sj.domainSize {
 			return si.domainSize < sj.domainSize
 		}
+		if scorer != nil {
+			siScore, sjScore := scorer(si.gpu), scorer(sj.gpu)
+			if siScore != sjScore {
+				return siScore > sjScore
+			}
+		}
 		// Stable tie-breaking by name
 		return si.gpu.Name < sj.gpu.Name
 	})
@@ -145,7 +157,7 @@ func (e *NUMAEvaluator) evaluateSingleGPU(gpus []*tfv1.GPU, candidateNames []str
 
 // evaluateMultiGPU selects the best multi-GPU combination based on NUMA affinity.
 // Uses a three-phase approach: prune → enumerate → sort.
-func (e *NUMAEvaluator) evaluateMultiGPU(gpus []*tfv1.GPU, candidateNames []string, count uint) (*NodeTopologyPlan, error) {
+func (e *NUMAEvaluator) evaluateMultiGPU(gpus []*tfv1.GPU, candidateNames []string, count uint, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	n := int(count)
 	if len(gpus) < n {
 		return &NodeTopologyPlan{
@@ -160,17 +172,17 @@ func (e *NUMAEvaluator) evaluateMultiGPU(gpus []*tfv1.GPU, candidateNames []stri
 	numaGroups := groupByNUMA(gpus)
 
 	// Phase 1: Try same-NUMA combinations first (best tier)
-	bestPlan := e.findBestSameNUMACombination(numaGroups, candidateNames, n)
+	bestPlan := e.findBestSameNUMACombination(numaGroups, candidateNames, n, scorer)
 	if bestPlan != nil {
 		return bestPlan, nil
 	}
 
 	// Phase 2: Cross-NUMA enumeration with complexity control
-	return e.findBestCrossNUMACombination(gpus, candidateNames, n, numaGroups)
+	return e.findBestCrossNUMACombination(gpus, candidateNames, n, numaGroups, scorer)
 }
 
 // findBestSameNUMACombination searches for the best all-same-NUMA combination.
-func (e *NUMAEvaluator) findBestSameNUMACombination(numaGroups map[int32][]*tfv1.GPU, candidateNames []string, count int) *NodeTopologyPlan {
+func (e *NUMAEvaluator) findBestSameNUMACombination(numaGroups map[int32][]*tfv1.GPU, candidateNames []string, count int, scorer GPUScorer) *NodeTopologyPlan {
 	// Collect NUMA domains that have enough GPUs
 	var viableGroups []numaGroup
 	for numaID, gpus := range numaGroups {
@@ -188,16 +200,17 @@ func (e *NUMAEvaluator) findBestSameNUMACombination(numaGroups map[int32][]*tfv1
 
 	// Sort groups: prefer NUMA domains with fewer excess GPUs (compact allocation)
 	sort.SliceStable(viableGroups, func(i, j int) bool {
-		return len(viableGroups[i].gpus) < len(viableGroups[j].gpus)
+		if len(viableGroups[i].gpus) != len(viableGroups[j].gpus) {
+			return len(viableGroups[i].gpus) < len(viableGroups[j].gpus)
+		}
+		return bestPlacementScore(viableGroups[i].gpus, count, scorer) > bestPlacementScore(viableGroups[j].gpus, count, scorer)
 	})
 
 	// From the best group, pick the first `count` GPUs (sorted by name for stability)
 	bestGroup := viableGroups[0]
 	selected := make([]*tfv1.GPU, len(bestGroup.gpus))
 	copy(selected, bestGroup.gpus)
-	sort.SliceStable(selected, func(i, j int) bool {
-		return selected[i].Name < selected[j].Name
-	})
+	sortGPUsByPlacement(selected, scorer)
 
 	bestGPUIds := make([]string, count)
 	for i := 0; i < count; i++ {
@@ -226,10 +239,10 @@ func (e *NUMAEvaluator) findBestSameNUMACombination(numaGroups map[int32][]*tfv1
 
 // findBestCrossNUMACombination finds the best cross-NUMA combination using
 // a three-level strategy: full enumeration → domain-based pruning → heuristic.
-func (e *NUMAEvaluator) findBestCrossNUMACombination(gpus []*tfv1.GPU, candidateNames []string, count int, numaGroups map[int32][]*tfv1.GPU) (*NodeTopologyPlan, error) {
+func (e *NUMAEvaluator) findBestCrossNUMACombination(gpus []*tfv1.GPU, candidateNames []string, count int, numaGroups map[int32][]*tfv1.GPU, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	// Level 1: if full enumeration is feasible, use it directly
 	if combinationCount(len(gpus), count) <= MaxCombinationSearch {
-		return e.enumerateAndSelectBest(gpus, candidateNames, count, numaGroups)
+		return e.enumerateAndSelectBest(gpus, candidateNames, count, numaGroups, scorer)
 	}
 
 	// Level 2: domain-based pruning — keep only the top NUMA domains (largest
@@ -238,11 +251,11 @@ func (e *NUMAEvaluator) findBestCrossNUMACombination(gpus []*tfv1.GPU, candidate
 	pruned := e.pruneByDomain(gpus, count, numaGroups)
 	if pruned != nil && combinationCount(len(pruned), count) <= MaxCombinationSearch {
 		prunedNUMAGroups := groupByNUMA(pruned)
-		return e.enumerateAndSelectBest(pruned, candidateNames, count, prunedNUMAGroups)
+		return e.enumerateAndSelectBest(pruned, candidateNames, count, prunedNUMAGroups, scorer)
 	}
 
 	// Level 3: heuristic greedy selection
-	return e.heuristicCrossNUMASelection(gpus, candidateNames, count, numaGroups)
+	return e.heuristicCrossNUMASelection(gpus, candidateNames, count, numaGroups, scorer)
 }
 
 // pruneByDomain reduces the candidate GPU set by keeping only GPUs from the
@@ -298,10 +311,11 @@ type combinationScore struct {
 	affinityScore  int64 // normalized pairwise affinity (0-100)
 	fragmentationP int   // total leftover GPUs in used NUMA domains / clusters
 	totalBandwidth int64 // sum of pairwise bandwidth (bytes/sec), for tie-breaking
+	placementScore int   // placement score; used only after topology quality ties
 }
 
 // enumerateAndSelectBest enumerates all C(M, N) combinations and returns the best one.
-func (e *NUMAEvaluator) enumerateAndSelectBest(gpus []*tfv1.GPU, candidateNames []string, count int, numaGroups map[int32][]*tfv1.GPU) (*NodeTopologyPlan, error) {
+func (e *NUMAEvaluator) enumerateAndSelectBest(gpus []*tfv1.GPU, candidateNames []string, count int, numaGroups map[int32][]*tfv1.GPU, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	var bestCombo *combinationScore
 
 	// Generate all combinations
@@ -312,7 +326,7 @@ func (e *NUMAEvaluator) enumerateAndSelectBest(gpus []*tfv1.GPU, candidateNames 
 
 	for {
 		// Score current combination
-		combo := e.scoreCombination(gpus, indices, numaGroups)
+		combo := e.scoreCombination(gpus, indices, numaGroups, scorer)
 		if bestCombo == nil || compareCombinations(combo, bestCombo) < 0 {
 			bestCombo = combo
 		}
@@ -346,12 +360,14 @@ func (e *NUMAEvaluator) enumerateAndSelectBest(gpus []*tfv1.GPU, candidateNames 
 }
 
 // scoreCombination computes the topology score for a specific GPU combination.
-func (e *NUMAEvaluator) scoreCombination(gpus []*tfv1.GPU, indices []int, numaGroups map[int32][]*tfv1.GPU) *combinationScore {
+func (e *NUMAEvaluator) scoreCombination(gpus []*tfv1.GPU, indices []int, numaGroups map[int32][]*tfv1.GPU, scorer GPUScorer) *combinationScore {
 	names := make([]string, len(indices))
+	selectedGPUs := make([]*tfv1.GPU, len(indices))
 	numaSet := make(map[int32]int) // numaID → count of GPUs selected from this domain
 
 	for i, idx := range indices {
 		gpu := gpus[idx]
+		selectedGPUs[i] = gpu
 		names[i] = gpu.Name
 		numaID := int32(-1)
 		if gpu.Status.NUMANode != nil && *gpu.Status.NUMANode >= 0 {
@@ -416,11 +432,13 @@ func (e *NUMAEvaluator) scoreCombination(gpus []*tfv1.GPU, indices []int, numaGr
 		numaCount:      len(numaSet),
 		affinityScore:  normalizedScore,
 		fragmentationP: fragmentationP,
+		placementScore: placementScore(selectedGPUs, scorer),
 	}
 }
 
 // compareCombinations returns negative if a is better than b.
-// Priority: smaller tier → higher score → lower fragmentation → higher bandwidth → lexicographic.
+// Priority: smaller tier → higher topology score → lower topology fragmentation →
+// higher bandwidth → higher placement score → lexicographic.
 func compareCombinations(a, b *combinationScore) int {
 	if a.tier != b.tier {
 		return int(a.tier) - int(b.tier)
@@ -437,6 +455,9 @@ func compareCombinations(a, b *combinationScore) int {
 		}
 		return -1
 	}
+	if a.placementScore != b.placementScore {
+		return b.placementScore - a.placementScore
+	}
 	// Lexicographic tie-break
 	for i := 0; i < len(a.gpuNames) && i < len(b.gpuNames); i++ {
 		if a.gpuNames[i] < b.gpuNames[i] {
@@ -451,7 +472,7 @@ func compareCombinations(a, b *combinationScore) int {
 
 // heuristicCrossNUMASelection uses a greedy heuristic when full enumeration is too expensive.
 // Strategy: fill from the largest NUMA domain first to minimize cross-NUMA traffic.
-func (e *NUMAEvaluator) heuristicCrossNUMASelection(_ []*tfv1.GPU, candidateNames []string, count int, numaGroups map[int32][]*tfv1.GPU) (*NodeTopologyPlan, error) {
+func (e *NUMAEvaluator) heuristicCrossNUMASelection(_ []*tfv1.GPU, candidateNames []string, count int, numaGroups map[int32][]*tfv1.GPU, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	// Sort NUMA groups by size descending (fill from largest first)
 	type groupEntry struct {
 		numaID int32
@@ -464,6 +485,9 @@ func (e *NUMAEvaluator) heuristicCrossNUMASelection(_ []*tfv1.GPU, candidateName
 	sort.SliceStable(groups, func(i, j int) bool {
 		if len(groups[i].gpus) != len(groups[j].gpus) {
 			return len(groups[i].gpus) > len(groups[j].gpus)
+		}
+		if scoreI, scoreJ := placementScore(groups[i].gpus, scorer), placementScore(groups[j].gpus, scorer); scoreI != scoreJ {
+			return scoreI > scoreJ
 		}
 		return groups[i].numaID < groups[j].numaID
 	})
@@ -478,9 +502,7 @@ func (e *NUMAEvaluator) heuristicCrossNUMASelection(_ []*tfv1.GPU, candidateName
 		// Sort GPUs within group for stability
 		sorted := make([]*tfv1.GPU, len(g.gpus))
 		copy(sorted, g.gpus)
-		sort.SliceStable(sorted, func(i, j int) bool {
-			return sorted[i].Name < sorted[j].Name
-		})
+		sortGPUsByPlacement(sorted, scorer)
 
 		for _, gpu := range sorted {
 			if len(selected) >= count {

--- a/internal/scheduler/gputopo/peer_evaluator.go
+++ b/internal/scheduler/gputopo/peer_evaluator.go
@@ -33,6 +33,10 @@ func (e *PeerTopologyEvaluator) Name() string {
 }
 
 func (e *PeerTopologyEvaluator) Evaluate(gpus []*tfv1.GPU, count uint, preferLeastDamage bool) (*NodeTopologyPlan, error) {
+	return e.EvaluateWithScorer(gpus, count, preferLeastDamage, nil)
+}
+
+func (e *PeerTopologyEvaluator) EvaluateWithScorer(gpus []*tfv1.GPU, count uint, preferLeastDamage bool, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	if count == 0 {
 		return &NodeTopologyPlan{
 			CandidateGPUIds: []string{},
@@ -49,9 +53,9 @@ func (e *PeerTopologyEvaluator) Evaluate(gpus []*tfv1.GPU, count uint, preferLea
 	}
 
 	if count == 1 {
-		return e.evaluateSingleGPU(gpus, candidateNames, preferLeastDamage)
+		return e.evaluateSingleGPU(gpus, candidateNames, preferLeastDamage, scorer)
 	}
-	return e.evaluateMultiGPU(gpus, candidateNames, count)
+	return e.evaluateMultiGPU(gpus, candidateNames, count, scorer)
 }
 
 // peerTierMatrix holds pairwise tier and bandwidth values between GPUs.
@@ -209,9 +213,11 @@ func buildTier0Clusters(matrix *peerTierMatrix) [][]int {
 }
 
 // evaluateSingleGPU selects the least-damage single GPU using peer topology clusters.
-func (e *PeerTopologyEvaluator) evaluateSingleGPU(gpus []*tfv1.GPU, candidateNames []string, preferLeastDamage bool) (*NodeTopologyPlan, error) {
+func (e *PeerTopologyEvaluator) evaluateSingleGPU(gpus []*tfv1.GPU, candidateNames []string, preferLeastDamage bool, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	if !preferLeastDamage || len(gpus) <= 1 {
-		gpu := gpus[0]
+		ordered := append([]*tfv1.GPU(nil), gpus...)
+		sortGPUsByPlacement(ordered, scorer)
+		gpu := ordered[0]
 		tier := singleGPUTier(gpu)
 		return &NodeTopologyPlan{
 			CandidateGPUIds: candidateNames,
@@ -256,6 +262,12 @@ func (e *PeerTopologyEvaluator) evaluateSingleGPU(gpus []*tfv1.GPU, candidateNam
 		if si.cSize != sj.cSize {
 			return si.cSize < sj.cSize
 		}
+		if scorer != nil {
+			siScore, sjScore := scorer(si.gpu), scorer(sj.gpu)
+			if siScore != sjScore {
+				return siScore > sjScore
+			}
+		}
 		return si.gpu.Name < sj.gpu.Name
 	})
 
@@ -284,7 +296,7 @@ func singleGPUTier(gpu *tfv1.GPU) GPUAffinityTier {
 }
 
 // evaluateMultiGPU selects the best multi-GPU combination using peer topology data.
-func (e *PeerTopologyEvaluator) evaluateMultiGPU(gpus []*tfv1.GPU, candidateNames []string, count uint) (*NodeTopologyPlan, error) {
+func (e *PeerTopologyEvaluator) evaluateMultiGPU(gpus []*tfv1.GPU, candidateNames []string, count uint, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	n := int(count)
 	if len(gpus) < n {
 		return &NodeTopologyPlan{
@@ -300,18 +312,18 @@ func (e *PeerTopologyEvaluator) evaluateMultiGPU(gpus []*tfv1.GPU, candidateName
 	clusters := buildTier0Clusters(matrix)
 
 	// Phase 1: try same-interconnect cluster (all pairs tier 0)
-	bestPlan := e.findBestSameClusterCombination(gpus, candidateNames, n, matrix, clusters)
+	bestPlan := e.findBestSameClusterCombination(gpus, candidateNames, n, matrix, clusters, scorer)
 	if bestPlan != nil {
 		return bestPlan, nil
 	}
 
 	// Phase 2: cross-cluster with complexity control
-	return e.findBestCrossClusterCombination(gpus, candidateNames, n, matrix, clusters)
+	return e.findBestCrossClusterCombination(gpus, candidateNames, n, matrix, clusters, scorer)
 }
 
 // findBestSameClusterCombination searches for a viable tier-0 cluster.
 // A valid cluster must have all internal pairs at tier 0 and enough GPUs.
-func (e *PeerTopologyEvaluator) findBestSameClusterCombination(gpus []*tfv1.GPU, candidateNames []string, count int, matrix *peerTierMatrix, clusters [][]int) *NodeTopologyPlan {
+func (e *PeerTopologyEvaluator) findBestSameClusterCombination(gpus []*tfv1.GPU, candidateNames []string, count int, matrix *peerTierMatrix, clusters [][]int, scorer GPUScorer) *NodeTopologyPlan {
 	var viableClusters [][]int
 	for _, cluster := range clusters {
 		if len(cluster) < count {
@@ -339,7 +351,17 @@ func (e *PeerTopologyEvaluator) findBestSameClusterCombination(gpus []*tfv1.GPU,
 
 	// Prefer cluster with fewer excess GPUs (compact fit)
 	sort.SliceStable(viableClusters, func(i, j int) bool {
-		return len(viableClusters[i]) < len(viableClusters[j])
+		if len(viableClusters[i]) != len(viableClusters[j]) {
+			return len(viableClusters[i]) < len(viableClusters[j])
+		}
+		scoreCluster := func(cluster []int) int {
+			clusterGPUs := make([]*tfv1.GPU, len(cluster))
+			for n, idx := range cluster {
+				clusterGPUs[n] = gpus[idx]
+			}
+			return bestPlacementScore(clusterGPUs, count, scorer)
+		}
+		return scoreCluster(viableClusters[i]) > scoreCluster(viableClusters[j])
 	})
 
 	bestCluster := viableClusters[0]
@@ -349,9 +371,7 @@ func (e *PeerTopologyEvaluator) findBestSameClusterCombination(gpus []*tfv1.GPU,
 	for i, idx := range bestCluster {
 		selected[i] = gpus[idx]
 	}
-	sort.SliceStable(selected, func(i, j int) bool {
-		return selected[i].Name < selected[j].Name
-	})
+	sortGPUsByPlacement(selected, scorer)
 	bestGPUIds := make([]string, count)
 	for i := 0; i < count; i++ {
 		bestGPUIds[i] = selected[i].Name
@@ -378,21 +398,21 @@ func (e *PeerTopologyEvaluator) findBestSameClusterCombination(gpus []*tfv1.GPU,
 
 // findBestCrossClusterCombination uses enumeration, pruning, or heuristic
 // for combinations that span multiple interconnect clusters.
-func (e *PeerTopologyEvaluator) findBestCrossClusterCombination(gpus []*tfv1.GPU, candidateNames []string, count int, matrix *peerTierMatrix, clusters [][]int) (*NodeTopologyPlan, error) {
+func (e *PeerTopologyEvaluator) findBestCrossClusterCombination(gpus []*tfv1.GPU, candidateNames []string, count int, matrix *peerTierMatrix, clusters [][]int, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	// Level 1: full enumeration
 	if combinationCount(len(gpus), count) <= MaxCombinationSearch {
-		return e.enumerateAndSelectBest(gpus, candidateNames, count, matrix)
+		return e.enumerateAndSelectBest(gpus, candidateNames, count, matrix, scorer)
 	}
 
 	// Level 2: cluster-based pruning
 	pruned := pruneByClusters(gpus, count, clusters)
 	if pruned != nil && combinationCount(len(pruned), count) <= MaxCombinationSearch {
 		prunedMatrix := buildPeerTierMatrix(pruned)
-		return e.enumerateAndSelectBest(pruned, candidateNames, count, prunedMatrix)
+		return e.enumerateAndSelectBest(pruned, candidateNames, count, prunedMatrix, scorer)
 	}
 
 	// Level 3: heuristic
-	return e.heuristicSelection(gpus, candidateNames, count, matrix, clusters)
+	return e.heuristicSelection(gpus, candidateNames, count, matrix, clusters, scorer)
 }
 
 // pruneByClusters reduces the candidate set by keeping GPUs from the largest
@@ -415,7 +435,7 @@ func pruneByClusters(gpus []*tfv1.GPU, count int, clusters [][]int) []*tfv1.GPU 
 }
 
 // enumerateAndSelectBest scores all C(M,N) combinations using the peer tier matrix.
-func (e *PeerTopologyEvaluator) enumerateAndSelectBest(gpus []*tfv1.GPU, candidateNames []string, count int, matrix *peerTierMatrix) (*NodeTopologyPlan, error) {
+func (e *PeerTopologyEvaluator) enumerateAndSelectBest(gpus []*tfv1.GPU, candidateNames []string, count int, matrix *peerTierMatrix, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	var bestCombo *combinationScore
 
 	indices := make([]int, count)
@@ -435,7 +455,7 @@ func (e *PeerTopologyEvaluator) enumerateAndSelectBest(gpus []*tfv1.GPU, candida
 	}
 
 	for {
-		combo := scoreCombinationFromMatrix(gpus, indices, matrix, gpuClusterID, clusterSizes)
+		combo := scoreCombinationFromMatrix(gpus, indices, matrix, gpuClusterID, clusterSizes, scorer)
 		if bestCombo == nil || compareCombinations(combo, bestCombo) < 0 {
 			bestCombo = combo
 		}
@@ -469,10 +489,12 @@ func (e *PeerTopologyEvaluator) enumerateAndSelectBest(gpus []*tfv1.GPU, candida
 // gpuClusterID maps each GPU index to its tier-0 cluster ID.
 // clusterSizes maps each cluster ID to the total number of GPUs in that cluster
 // within the current candidate set.
-func scoreCombinationFromMatrix(gpus []*tfv1.GPU, indices []int, matrix *peerTierMatrix, gpuClusterID []int, clusterSizes map[int]int) *combinationScore {
+func scoreCombinationFromMatrix(gpus []*tfv1.GPU, indices []int, matrix *peerTierMatrix, gpuClusterID []int, clusterSizes map[int]int, scorer GPUScorer) *combinationScore {
 	names := make([]string, len(indices))
+	selectedGPUs := make([]*tfv1.GPU, len(indices))
 	for i, idx := range indices {
 		names[i] = gpus[idx].Name
+		selectedGPUs[i] = gpus[idx]
 	}
 
 	// Determine worst-case tier, pairwise affinity, and total bandwidth
@@ -526,6 +548,7 @@ func scoreCombinationFromMatrix(gpus []*tfv1.GPU, indices []int, matrix *peerTie
 		affinityScore:  normalizedScore,
 		fragmentationP: fragmentationP,
 		totalBandwidth: totalBandwidth,
+		placementScore: placementScore(selectedGPUs, scorer),
 	}
 }
 
@@ -544,7 +567,7 @@ func peerAffinityForTier(tier int32) int64 {
 }
 
 // heuristicSelection fills from the largest tier-0 cluster first.
-func (e *PeerTopologyEvaluator) heuristicSelection(gpus []*tfv1.GPU, candidateNames []string, count int, matrix *peerTierMatrix, clusters [][]int) (*NodeTopologyPlan, error) {
+func (e *PeerTopologyEvaluator) heuristicSelection(gpus []*tfv1.GPU, candidateNames []string, count int, matrix *peerTierMatrix, clusters [][]int, scorer GPUScorer) (*NodeTopologyPlan, error) {
 	// clusters already sorted by size descending
 	var selected []string
 	clustersUsed := 0
@@ -558,6 +581,12 @@ func (e *PeerTopologyEvaluator) heuristicSelection(gpus []*tfv1.GPU, candidateNa
 		sorted := make([]int, len(cluster))
 		copy(sorted, cluster)
 		sort.SliceStable(sorted, func(i, j int) bool {
+			if scorer != nil {
+				si, sj := scorer(gpus[sorted[i]]), scorer(gpus[sorted[j]])
+				if si != sj {
+					return si > sj
+				}
+			}
 			return gpus[sorted[i]].Name < gpus[sorted[j]].Name
 		})
 		for _, idx := range sorted {

--- a/internal/scheduler/gputopo/placement_order_test.go
+++ b/internal/scheduler/gputopo/placement_order_test.go
@@ -1,0 +1,140 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/config"
+	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func placementTestGPU(name, available string, numa int32) *tfv1.GPU {
+	gpu := makeGPU(name, int32Ptr(numa))
+	gpu.Status.Capacity = &tfv1.Resource{
+		Tflops: resource.MustParse("100"),
+		Vram:   resource.MustParse("100Mi"),
+	}
+	gpu.Status.Available = &tfv1.Resource{
+		Tflops: resource.MustParse(available),
+		Vram:   resource.MustParse(available + "Mi"),
+	}
+	return gpu
+}
+
+func scorerForMode(mode tfv1.PlacementMode) GPUScorer {
+	strategy := gpuallocator.NewStrategy(mode, &config.GPUFitConfig{
+		TflopsWeight: 0.5,
+		VramWeight:   0.5,
+	}, nil)
+	return func(gpu *tfv1.GPU) int { return strategy.Score(gpu, false) }
+}
+
+func TestNUMATopologyUsesPlacementToBreakEquivalentCombinationTies(t *testing.T) {
+	gpus := []*tfv1.GPU{
+		placementTestGPU("gpu-most-used", "10", 0),
+		placementTestGPU("gpu-used", "30", 0),
+		placementTestGPU("gpu-idle", "100", 0),
+		placementTestGPU("gpu-less-used", "80", 0),
+	}
+
+	tests := []struct {
+		name string
+		mode tfv1.PlacementMode
+		want []string
+	}{
+		{name: "compact first chooses the most used GPUs", mode: tfv1.PlacementModeCompactFirst, want: []string{"gpu-most-used", "gpu-used"}},
+		{name: "node compact GPU low load chooses the least used GPUs", mode: tfv1.PlacementModeNodeCompactGPULowLoad, want: []string{"gpu-idle", "gpu-less-used"}},
+		{name: "low load first chooses the least used GPUs", mode: tfv1.PlacementModeLowLoadFirst, want: []string{"gpu-idle", "gpu-less-used"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := NewNUMAEvaluator(1).EvaluateWithScorer(gpus, 2, true, scorerForMode(tt.mode))
+			if err != nil {
+				t.Fatalf("EvaluateWithScorer() error = %v", err)
+			}
+			if len(plan.BestGPUIds) != len(tt.want) {
+				t.Fatalf("BestGPUIds = %v, want %v", plan.BestGPUIds, tt.want)
+			}
+			for i := range tt.want {
+				if plan.BestGPUIds[i] != tt.want[i] {
+					t.Fatalf("BestGPUIds = %v, want %v", plan.BestGPUIds, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestPeerTopologyUsesPlacementInsideEquivalentNVLinkGroup(t *testing.T) {
+	gpus := []*tfv1.GPU{
+		placementTestGPU("gpu-most-used", "10", 0),
+		placementTestGPU("gpu-used", "30", 0),
+		placementTestGPU("gpu-idle", "100", 0),
+		placementTestGPU("gpu-less-used", "80", 0),
+	}
+	for _, gpu := range gpus {
+		peers := make([]tfv1.GPUPeerLinkStatus, 0, len(gpus)-1)
+		for _, peer := range gpus {
+			if peer.Name != gpu.Name {
+				peers = append(peers, tfv1.GPUPeerLinkStatus{PeerGPUUUID: peer.Status.UUID, Tier: int32(TierSameInterconnect)})
+			}
+		}
+		gpu.Status.Topology = &tfv1.GPUTopologyStatus{Peers: peers}
+	}
+
+	compact, err := NewPeerTopologyEvaluator(1).EvaluateWithScorer(gpus, 2, true, scorerForMode(tfv1.PlacementModeCompactFirst))
+	if err != nil {
+		t.Fatalf("compact EvaluateWithScorer() error = %v", err)
+	}
+	if compact.BestGPUIds[0] != "gpu-most-used" || compact.BestGPUIds[1] != "gpu-used" {
+		t.Fatalf("compact BestGPUIds = %v, want most-used pair", compact.BestGPUIds)
+	}
+
+	lowLoad, err := NewPeerTopologyEvaluator(1).EvaluateWithScorer(gpus, 2, true, scorerForMode(tfv1.PlacementModeNodeCompactGPULowLoad))
+	if err != nil {
+		t.Fatalf("low-load EvaluateWithScorer() error = %v", err)
+	}
+	if lowLoad.BestGPUIds[0] != "gpu-idle" || lowLoad.BestGPUIds[1] != "gpu-less-used" {
+		t.Fatalf("low-load BestGPUIds = %v, want least-used pair", lowLoad.BestGPUIds)
+	}
+}
+
+func TestBetterTopologyWinsBeforePlacementScore(t *testing.T) {
+	// CompactFirst strongly prefers the used GPUs, but they span NUMA domains.
+	// The idle pair is same-NUMA, so topology must win first.
+	gpus := []*tfv1.GPU{
+		placementTestGPU("used-numa-0", "10", 0),
+		placementTestGPU("used-numa-1", "10", 1),
+		placementTestGPU("idle-numa-2-a", "100", 2),
+		placementTestGPU("idle-numa-2-b", "100", 2),
+	}
+
+	plan, err := NewNUMAEvaluator(2).EvaluateWithScorer(gpus, 2, true, scorerForMode(tfv1.PlacementModeCompactFirst))
+	if err != nil {
+		t.Fatalf("EvaluateWithScorer() error = %v", err)
+	}
+	if plan.Tier != TierSameNUMA || plan.BestGPUIds[0] != "idle-numa-2-a" || plan.BestGPUIds[1] != "idle-numa-2-b" {
+		t.Fatalf("plan = tier %d GPUs %v, want same-NUMA idle pair", plan.Tier, plan.BestGPUIds)
+	}
+}
+
+func TestTopologyScoreDoesNotChangeNodePlacement(t *testing.T) {
+	plugin := &GPUNetworkTopologyAware{}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{constants.LabelComponent: constants.ComponentWorker},
+	}}
+
+	score, status := plugin.Score(context.Background(), framework.NewCycleState(), pod, nil)
+	if !status.IsSuccess() {
+		t.Fatalf("Score() status = %v", status)
+	}
+	if score != 0 {
+		t.Fatalf("Score() = %d, want 0 so placement owns node ordering", score)
+	}
+}


### PR DESCRIPTION
 ## Summary

   调整 GPU placement 与 NVLink/NUMA topology 的调度优先级，避免 topology soft 评分覆盖既有 placement 策
  略。

  ## Changes

  - 保留三种 placement 模式的节点级优先级：
    - `NodeCompactGPULowLoad`：优先紧凑节点。
    - `CompactFirst`：优先紧凑节点。
    - `LowLoadFirst`：优先低负载节点。
  - 调整节点内 GPU 选择逻辑：
    - 优先选择更好的 NVLink/NUMA 拓扑组合。
    - 同等拓扑条件下，按照 placement 策略的 GPU 分数排序。
  - `GPUNetworkTopologyAware` 不再通过 Score 改变节点排序。
  - topology hard 模式仍通过 Filter 淘汰不满足拓扑要求的节点。
  - 无拓扑数据时回退到 placement GPU 评分。
  - 增加 NUMA、NVLink 等价拓扑组合与三种 placement 的回归测试。
  - Helm chart 版本升级：
    - Chart: `1.8.5`
    - App: `2.17.0`

  ## Validation

  - `make test`
  - `helm lint charts/tensor-fusion`
  - `helm template`
  - 集群 `rhzs` / `ubuntu` 节点验证：
    - 两张 RTX 3090 shared GPU 调度成功。
    - 两个 Pod 分别获得不同 GPU。
    - `nvidia-smi` 调用成功。
    - `cuInit=0`、`cuDeviceGetCount=0`。
    - 删除业务 Pod 后 GPU 资源恢复。