### PR TITLE
fix(worker): merge and deduplicate template env

### DIFF
--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -308,6 +308,7 @@ func AddTFDefaultClientConfBeforePatch(
 
 			pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
 				Name: constants.TFContainerNameWorker,
+				Env:  workerTemplateEnv(pool.Spec.ComponentConfig.Worker),
 				VolumeMounts: []v1.VolumeMount{
 					{
 						Name:      constants.TransportShmVolumeName,
@@ -855,6 +856,9 @@ func SetWorkerContainerSpec(
 	disabledFeatures string,
 	sharedMemMode bool,
 ) {
+	templateEnv := container.Env
+	container.Env = nil
+
 	// NOTE: need to set environment variable to make all GPUs visible to the worker,
 	// vgpu.rs limiter will limit to specific devices after Pod started
 	container.Name = constants.TFContainerNameWorker
@@ -929,6 +933,8 @@ func SetWorkerContainerSpec(
 			Value: strconv.FormatInt(workloadProfile.Resources.Limits.Vram.Value()/(1024*1024), 10),
 		})
 	}
+	container.Env = appendMissingEnv(nil, container.Env)
+	container.Env = appendMissingEnv(container.Env, templateEnv)
 
 	// TODO support hostNetwork mode and InfiniBand for higher performance
 	container.Ports = append(container.Ports, v1.ContainerPort{
@@ -964,6 +970,39 @@ func SetWorkerContainerSpec(
 	if len(container.Resources.Requests) == 0 {
 		container.Resources.Requests = workerDefaultRequests
 	}
+}
+
+func workerTemplateEnv(workerConfig *tfv1.WorkerConfig) []v1.EnvVar {
+	if workerConfig == nil || workerConfig.PodTemplate == nil {
+		return nil
+	}
+
+	podTemplate := &v1.PodTemplate{}
+	if err := json.Unmarshal(workerConfig.PodTemplate.Raw, podTemplate); err != nil || len(podTemplate.Template.Spec.Containers) == 0 {
+		return nil
+	}
+
+	return podTemplate.Template.Spec.Containers[0].Env
+}
+
+func appendMissingEnv(existing, additions []v1.EnvVar) []v1.EnvVar {
+	seen := make(map[string]struct{}, len(existing)+len(additions))
+	result := make([]v1.EnvVar, 0, len(existing)+len(additions))
+	for _, env := range existing {
+		if _, ok := seen[env.Name]; ok {
+			continue
+		}
+		result = append(result, env)
+		seen[env.Name] = struct{}{}
+	}
+	for _, env := range additions {
+		if _, ok := seen[env.Name]; ok {
+			continue
+		}
+		result = append(result, env)
+		seen[env.Name] = struct{}{}
+	}
+	return result
 }
 
 // HypervisorTemplateHash computes hash of the full hypervisor pod template

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -2,10 +2,13 @@ package utils_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 
@@ -233,6 +236,112 @@ func TestSetWorkerContainerSpec(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetWorkerContainerSpecMergesAndDeduplicatesExistingEnv(t *testing.T) {
+	container := &corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: "CUSTOM_WORKER_ENV", Value: "custom-value"},
+			{Name: constants.EnableWorkerLogEnv, Value: "custom"},
+			{Name: "CUSTOM_WORKER_ENV", Value: "duplicate-value"},
+		},
+	}
+
+	utils.SetWorkerContainerSpec(
+		container,
+		&tfv1.WorkloadProfileSpec{},
+		&tfv1.WorkerConfig{},
+		&tfv1.HypervisorConfig{},
+		"",
+		false,
+	)
+
+	require.Contains(t, container.Env, corev1.EnvVar{Name: "CUSTOM_WORKER_ENV", Value: "custom-value"})
+	require.Contains(t, container.Env, corev1.EnvVar{
+		Name:  constants.EnableWorkerLogEnv,
+		Value: constants.EnableWorkerLogValue,
+	})
+	require.Equal(t, 1, lo.CountBy(container.Env, func(env corev1.EnvVar) bool {
+		return env.Name == "CUSTOM_WORKER_ENV"
+	}))
+	require.Equal(t, 1, lo.CountBy(container.Env, func(env corev1.EnvVar) bool {
+		return env.Name == constants.EnableWorkerLogEnv
+	}))
+}
+
+func TestAddTFDefaultClientConfBeforePatchMergesWorkerTemplateEnvIntoSidecar(t *testing.T) {
+	workerTemplate, err := json.Marshal(corev1.PodTemplate{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: constants.TFContainerNameWorker,
+						Env: []corev1.EnvVar{
+							{Name: "CUSTOM_WORKER_ENV", Value: "custom-value"},
+							{
+								Name: "CUSTOM_WORKER_SECRET",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{Name: "worker-secret"},
+										Key:                  "token",
+									},
+								},
+							},
+							{Name: constants.EnableWorkerLogEnv, Value: "custom"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	pool := &tfv1.GPUPool{
+		Spec: tfv1.GPUPoolSpec{
+			ComponentConfig: &tfv1.ComponentConfig{
+				Client: &tfv1.ClientConfig{},
+				Worker: &tfv1.WorkerConfig{
+					PodTemplate: &runtime.RawExtension{Raw: workerTemplate},
+				},
+				Hypervisor: &tfv1.HypervisorConfig{},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "application"}},
+		},
+	}
+	tfInfo := utils.TensorFusionInfo{
+		Profile: &tfv1.WorkloadProfileSpec{
+			IsLocalGPU:    true,
+			SidecarWorker: true,
+		},
+	}
+
+	utils.AddTFDefaultClientConfBeforePatch(context.Background(), pod, pool, tfInfo, []int{0})
+
+	require.Len(t, pod.Spec.Containers, 2)
+	worker := pod.Spec.Containers[1]
+	require.Equal(t, constants.TFContainerNameWorker, worker.Name)
+	require.Contains(t, worker.Env, corev1.EnvVar{Name: "CUSTOM_WORKER_ENV", Value: "custom-value"})
+	require.Contains(t, worker.Env, corev1.EnvVar{
+		Name: "CUSTOM_WORKER_SECRET",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "worker-secret"},
+				Key:                  "token",
+			},
+		},
+	})
+	require.Contains(t, worker.Env, corev1.EnvVar{
+		Name:  constants.EnableWorkerLogEnv,
+		Value: constants.EnableWorkerLogValue,
+	})
+	require.Equal(t, 1, lo.CountBy(worker.Env, func(env corev1.EnvVar) bool {
+		return env.Name == constants.EnableWorkerLogEnv
+	}))
 }
 
 func TestNodeDiscoveryInitContainerImageFallback(t *testing.T) {


### PR DESCRIPTION
  ## Summary

  Fix worker environment variable handling in the v1 local sidecar and remote worker paths.

  ## Problem

  Local GPU sidecar workers were constructed without merging environment variables from:

  `GPUPool.spec.componentConfig.worker.podTemplate`

  As a result, required variables such as license and library path configuration were missing from local hard-isolation workers.

  Remote workers preserved template env variables, but appending Operator-generated variables could produce duplicate env names.

  ## Changes

  - Merge all worker PodTemplate env variables into local sidecar workers.
  - Apply the same deduplication behavior to local sidecar and remote workers.
  - Deduplicate environment variables by name.
  - Preserve Operator-generated worker variables as the authoritative values.
  - Preserve custom `value` and `valueFrom` environment variables from the worker template.
  - Add unit tests covering local sidecar merging, remote worker merging, and duplicate handling.

  ## Validation

  - `make test` passed: 25 Ginkgo suites.
  - `make lint` passed.
  - Verified local hard sidecar worker reaches `2/2 Running`.
  - Verified local and remote workers contain all TFC worker template env variables.
  - Verified generated worker Pods contain no duplicate env names.
  - Verified remote client runs on `rhzs` and its worker runs on the GPU node.
  - Verified remote NVML calls successfully return GPU name, UUID, and memory information.