### PR TITLE
fix(hypervisor): validate pod-resources proxy names

### DIFF
--- a/charts/tensor-fusion/Chart.yaml
+++ b/charts/tensor-fusion/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.5
+version: 1.8.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.17.0"
+appVersion: "2.16.3"

--- a/pkg/hypervisor/backend/kubernetes/pod_resources_proxy.go
+++ b/pkg/hypervisor/backend/kubernetes/pod_resources_proxy.go
@@ -240,7 +240,11 @@ func isTFDevicePluginResource(resourceName string) bool {
 		return true
 	}
 	prefix := constants.PodIndexAnnotation + constants.PodIndexDelimiter
-	return strings.HasPrefix(resourceName, prefix)
+	suffix := strings.TrimPrefix(resourceName, prefix)
+	if suffix == resourceName || len(suffix) != 1 {
+		return false
+	}
+	return (suffix[0] >= '0' && suffix[0] <= '9') || (suffix[0] >= 'a' && suffix[0] <= 'f')
 }
 
 // containerGPUIDs returns the real GPU UUIDs assigned to a container, in the

--- a/pkg/hypervisor/backend/kubernetes/pod_resources_proxy_test.go
+++ b/pkg/hypervisor/backend/kubernetes/pod_resources_proxy_test.go
@@ -82,6 +82,10 @@ func TestIsTFDevicePluginResource(t *testing.T) {
 		{"nvidia.com/gpu", false},
 		{"cpu", false},
 		{constants.PodIndexAnnotation + "x", false},
+		{prefix, false},
+		{prefix + "g", false},
+		{prefix + "10", false},
+		{prefix + "0_extra", false},
 		{"", false},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

  - Strictly validate TensorFusion device-plugin resource names.
  - Preserve compatibility with the v1 `tensor-fusion.ai/index` resource.
  - Accept only valid v2 resources from `tensor-fusion.ai/index_0` to `index_f`.
  - Bump the Helm chart to `1.8.6` with application version `2.16.3`.

  ## Root Cause

  The Pod Resources Proxy previously used prefix matching for v2 resource
  names. Invalid names such as `index_10` and `index_0_extra` could therefore
  be treated as TensorFusion device-plugin resources.

  The previous merged change also used a non-Conventional Commit title, so
  semantic-release did not publish a patch release.

  ## Verification

  - `make test`
  - `make lint`
  - `helm lint charts/tensor-fusion`
  - Helm template and package validation