### PR TITLE
 feat: support dynamic GPU isolation with rollback-safe configuration

### DIFF
--- a/api/v1/gpu_types.go
+++ b/api/v1/gpu_types.go
@@ -41,6 +41,24 @@ type GPUStatus struct {
 	// +kubebuilder:default=soft
 	IsolationMode IsolationModeType `json:"isolationMode,omitempty"`
 
+	// IsolationPolicy is the policy actually advertised by the node hypervisor.
+	// Static is the backward-compatible zero-value interpretation.
+	// +optional
+	// +kubebuilder:validation:Enum=Static;Dynamic
+	IsolationPolicy IsolationModePolicyType `json:"isolationPolicy,omitempty"`
+
+	// ActiveIsolationMode is the mode lock for a Dynamic GPU. It is empty when
+	// the GPU has no TensorFusion allocation; Static GPUs leave it empty.
+	// +optional
+	// +kubebuilder:validation:Enum=shared;soft;hard
+	ActiveIsolationMode IsolationModeType `json:"activeIsolationMode,omitempty"`
+
+	// DynamicIsolationConflict is true when recovery found multiple workload
+	// isolation modes on one Dynamic GPU. Such a GPU is fail-closed until the
+	// conflicting allocations are gone and recovery converges.
+	// +optional
+	DynamicIsolationConflict bool `json:"dynamicIsolationConflict,omitempty"`
+
 	// +optional
 	Index *int32 `json:"index,omitempty"`
 
@@ -79,6 +97,15 @@ type GPUStatus struct {
 	// used by the GPUNetworkTopologyAware scheduler plugin.
 	Topology *GPUTopologyStatus `json:"topology,omitempty"`
 }
+
+// IsolationModePolicyType controls whether isolation is selected per node or
+// per GPU allocation. It is deliberately separate from IsolationModeType.
+type IsolationModePolicyType string
+
+const (
+	IsolationModePolicyStatic  IsolationModePolicyType = "Static"
+	IsolationModePolicyDynamic IsolationModePolicyType = "Dynamic"
+)
 
 // GPUNvLinkStatus records point-to-point NVLink topology and bandwidth hints for scheduler decisions.
 type GPUNvLinkStatus struct {

--- a/charts/tensor-fusion/Chart.yaml
+++ b/charts/tensor-fusion/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.6
+version: 1.8.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.16.3"
+appVersion: "2.17.0"

--- a/charts/tensor-fusion/crds/tensor-fusion.ai_gpus.yaml
+++ b/charts/tensor-fusion/crds/tensor-fusion.ai_gpus.yaml
@@ -69,6 +69,21 @@ spec:
               GPUStatus defines the observed state of GPU.
               NOTE: When new fields added, remember to update syncGPUMetadataAndStatusFromCluster
             properties:
+              activeIsolationMode:
+                allOf:
+                - enum:
+                  - shared
+                  - soft
+                  - hard
+                  - partitioned
+                - enum:
+                  - shared
+                  - soft
+                  - hard
+                description: |-
+                  ActiveIsolationMode is the mode lock for a Dynamic GPU. It is empty when
+                  the GPU has no TensorFusion allocation; Static GPUs leave it empty.
+                type: string
               allocatedPartitions:
                 additionalProperties:
                   description: |-
@@ -175,6 +190,12 @@ spec:
                 - tflops
                 - vram
                 type: object
+              dynamicIsolationConflict:
+                description: |-
+                  DynamicIsolationConflict is true when recovery found multiple workload
+                  isolation modes on one Dynamic GPU. Such a GPU is fail-closed until the
+                  conflicting allocations are gone and recovery converges.
+                type: boolean
               gpuModel:
                 type: string
               index:
@@ -187,6 +208,14 @@ spec:
                 - soft
                 - hard
                 - partitioned
+                type: string
+              isolationPolicy:
+                description: |-
+                  IsolationPolicy is the policy actually advertised by the node hypervisor.
+                  Static is the backward-compatible zero-value interpretation.
+                enum:
+                - Static
+                - Dynamic
                 type: string
               message:
                 type: string

--- a/charts/tensor-fusion/templates/controller-deployment.yaml
+++ b/charts/tensor-fusion/templates/controller-deployment.yaml
@@ -38,6 +38,7 @@ spec:
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           command: 
             {{- toYaml .Values.controller.command | nindent 12 }}
+            - -isolation-mode-policy={{ .Values.controller.isolationModePolicy | default "static" }}
           livenessProbe:
             {{- toYaml .Values.controller.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/tensor-fusion/templates/controller-deployment.yaml
+++ b/charts/tensor-fusion/templates/controller-deployment.yaml
@@ -38,7 +38,6 @@ spec:
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           command: 
             {{- toYaml .Values.controller.command | nindent 12 }}
-            - -isolation-mode-policy={{ .Values.controller.isolationModePolicy | default "static" }}
           livenessProbe:
             {{- toYaml .Values.controller.livenessProbe | nindent 12 }}
           readinessProbe:
@@ -51,6 +50,8 @@ spec:
             - name: metrics
               containerPort: 8081
           env:
+            - name: TF_ISOLATION_MODE_POLICY
+              value: {{ .Values.controller.isolationModePolicy | default "dynamic" | quote }}
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -27,9 +27,10 @@ controller:
 
   nvidiaOperatorProgressiveMigration: false
 
-  # Scheduling-domain GPU isolation policy. Static preserves v1/v2 behavior;
-  # Dynamic recovers per-GPU mode from existing worker Pod annotations.
-  isolationModePolicy: static
+  # Scheduling-domain GPU isolation policy, injected as TF_ISOLATION_MODE_POLICY.
+  # Static preserves v1/v2 behavior; Dynamic recovers per-GPU mode from
+  # existing worker Pod annotations. Older images safely ignore this env var.
+  isolationModePolicy: dynamic
 
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:

--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -27,6 +27,10 @@ controller:
 
   nvidiaOperatorProgressiveMigration: false
 
+  # Scheduling-domain GPU isolation policy. Static preserves v1/v2 behavior;
+  # Dynamic recovers per-GPU mode from existing worker Pod annotations.
+  isolationModePolicy: static
+
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:
     repository: tensorfusion/tensor-fusion-operator

--- a/cmd/hypervisor/main.go
+++ b/cmd/hypervisor/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -34,6 +35,8 @@ var (
 		"./provider/build/libaccelerator_example.so", "Path to accelerator library")
 	isolationMode = flag.String("isolation-mode", "soft",
 		"Isolation mode: shared, soft, hard, partitioned")
+	isolationPolicy = flag.String("isolation-policy", "static",
+		"Isolation policy: static or dynamic")
 	backendType       = flag.String("backend-type", "kubernetes", "Backend type: kubernetes, simple")
 	discoveryInterval = flag.Duration("discovery-interval",
 		12*time.Hour, "Device discovery interval")
@@ -51,6 +54,16 @@ func main() {
 	}
 
 	flag.Parse()
+	policy := tfv1.IsolationModePolicyStatic
+	switch strings.ToLower(strings.TrimSpace(*isolationPolicy)) {
+	case "static":
+		*isolationPolicy = "static"
+	case "dynamic":
+		*isolationPolicy = "dynamic"
+		policy = tfv1.IsolationModePolicyDynamic
+	default:
+		klog.Fatalf("invalid isolation policy: %s", *isolationPolicy)
+	}
 	klog.InitFlags(nil)
 	defer klog.Flush()
 
@@ -75,6 +88,7 @@ func main() {
 	if err != nil {
 		klog.Fatalf("Failed to create device controller: %v", err)
 	}
+	deviceController.SetIsolationPolicy(policy)
 	if err := deviceController.Start(); err != nil {
 		klog.Fatalf("Failed to start device manager: %v", err)
 	}
@@ -84,6 +98,7 @@ func main() {
 
 	// Create allocation controller first - it's a shared dependency
 	allocationController := worker.NewAllocationController(deviceController)
+	allocationController.SetIsolationPolicy(policy)
 	deviceController.SetAllocationController(allocationController)
 	klog.Info("Allocation controller created")
 
@@ -109,10 +124,10 @@ func main() {
 		if err != nil {
 			klog.Fatalf("Failed to create Kubernetes backend: %v", err)
 		}
-		workerController = worker.NewWorkerController(deviceController, allocationController, mode, backend)
+		workerController = worker.NewWorkerControllerWithPolicy(deviceController, allocationController, mode, policy, backend)
 	case "simple":
 		backend = single_node.NewSingleNodeBackend(ctx, deviceController, allocationController)
-		workerController = worker.NewWorkerController(deviceController, allocationController, mode, backend)
+		workerController = worker.NewWorkerControllerWithPolicy(deviceController, allocationController, mode, policy, backend)
 	default:
 		klog.Fatalf("Invalid backend type: %s", *backendType)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -144,8 +145,6 @@ func main() {
 		"/etc/tensor-fusion/config.yaml", "specify the path to dynamic config file")
 	flag.StringVar(&schedulerConfigPath, "scheduler-config", "/etc/tensor-fusion/scheduler-config.yaml",
 		"specify the path to TensorFusion scheduler config file")
-	flag.StringVar(&isolationModePolicy, "isolation-mode-policy", "static",
-		"GPU isolation policy for the TensorFusion scheduling domain: static or dynamic")
 	flag.StringVar(&metricsPath, "metrics-path", "/logs/metrics.log", "specify the path to metrics file")
 	flag.StringVar(&nodeLevelPortRange, "host-port-range", "40000-42000",
 		"specify the port range for assigning ports to pre-scheduled Pods such as vGPU workers")
@@ -170,15 +169,12 @@ func main() {
 
 	klog.InitFlags(nil)
 	flag.Parse()
-	switch strings.ToLower(strings.TrimSpace(isolationModePolicy)) {
-	case "static":
-		isolationModePolicy = string(tfv1.IsolationModePolicyStatic)
-	case "dynamic":
-		isolationModePolicy = string(tfv1.IsolationModePolicyDynamic)
-	default:
-		setupLog.Error(nil, "invalid isolation-mode-policy", "value", isolationModePolicy)
+	resolvedIsolationModePolicy, err := resolveIsolationModePolicy(os.Getenv(constants.IsolationModePolicyEnv))
+	if err != nil {
+		setupLog.Error(err, "invalid isolation mode policy", "env", constants.IsolationModePolicyEnv)
 		os.Exit(1)
 	}
+	isolationModePolicy = string(resolvedIsolationModePolicy)
 	ctrl.SetLogger(klog.NewKlogr())
 	ctx := context.Background()
 
@@ -297,6 +293,17 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
+	}
+}
+
+func resolveIsolationModePolicy(raw string) (tfv1.IsolationModePolicyType, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "static":
+		return tfv1.IsolationModePolicyStatic, nil
+	case "dynamic":
+		return tfv1.IsolationModePolicyDynamic, nil
+	default:
+		return "", fmt.Errorf("%s must be static or dynamic, got %q", constants.IsolationModePolicyEnv, raw)
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	// Embed tzdata so named timezones (e.g. "Asia/Shanghai") resolve
@@ -107,6 +108,7 @@ var timeSeriesDB *metrics.TimeSeriesDB
 var dynamicConfigPath string
 var alertEvaluator *alert.AlertEvaluator
 var schedulerConfigPath string
+var isolationModePolicy string
 var alertEvaluatorReady chan struct{}
 var enableAutoExpander bool
 var compatibleWithNvidiaContainerToolkit bool
@@ -142,6 +144,8 @@ func main() {
 		"/etc/tensor-fusion/config.yaml", "specify the path to dynamic config file")
 	flag.StringVar(&schedulerConfigPath, "scheduler-config", "/etc/tensor-fusion/scheduler-config.yaml",
 		"specify the path to TensorFusion scheduler config file")
+	flag.StringVar(&isolationModePolicy, "isolation-mode-policy", "static",
+		"GPU isolation policy for the TensorFusion scheduling domain: static or dynamic")
 	flag.StringVar(&metricsPath, "metrics-path", "/logs/metrics.log", "specify the path to metrics file")
 	flag.StringVar(&nodeLevelPortRange, "host-port-range", "40000-42000",
 		"specify the port range for assigning ports to pre-scheduled Pods such as vGPU workers")
@@ -166,6 +170,15 @@ func main() {
 
 	klog.InitFlags(nil)
 	flag.Parse()
+	switch strings.ToLower(strings.TrimSpace(isolationModePolicy)) {
+	case "static":
+		isolationModePolicy = string(tfv1.IsolationModePolicyStatic)
+	case "dynamic":
+		isolationModePolicy = string(tfv1.IsolationModePolicyDynamic)
+	default:
+		setupLog.Error(nil, "invalid isolation-mode-policy", "value", isolationModePolicy)
+		os.Exit(1)
+	}
 	ctrl.SetLogger(klog.NewKlogr())
 	ctx := context.Background()
 
@@ -304,6 +317,7 @@ func startTensorFusionAllocators(
 	indexAllocator *indexallocator.IndexAllocator,
 ) (*gpuallocator.GpuAllocator, *portallocator.PortAllocator) {
 	allocator := gpuallocator.NewGpuAllocator(ctx, indexAllocator, mgr.GetClient(), 10*time.Second)
+	allocator.SetIsolationPolicy(tfv1.IsolationModePolicyType(isolationModePolicy))
 	if err := allocator.SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to set up GPU allocator watches")
 		os.Exit(1)
@@ -445,9 +459,10 @@ func startCustomResourceController(
 	}
 
 	GPUPoolReconciler := &controller.GPUPoolReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("GPUPool"),
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		Recorder:            mgr.GetEventRecorder("GPUPool"),
+		IsolationModePolicy: tfv1.IsolationModePolicyType(isolationModePolicy),
 	}
 	if err = GPUPoolReconciler.SetupWithManager(mgr, true); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GPUPool")
@@ -461,6 +476,7 @@ func startCustomResourceController(
 		Allocator:                            allocator,
 		Expander:                             nodeExpander,
 		CompatibleWithNvidiaContainerToolkit: compatibleWithNvidiaContainerToolkit,
+		IsolationModePolicy:                  tfv1.IsolationModePolicyType(isolationModePolicy),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GPUNode")
 		os.Exit(1)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveIsolationModePolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    tfv1.IsolationModePolicyType
+		wantErr bool
+	}{
+		{name: "unset defaults to static", want: tfv1.IsolationModePolicyStatic},
+		{name: "static", raw: " static ", want: tfv1.IsolationModePolicyStatic},
+		{name: "dynamic", raw: "DYNAMIC", want: tfv1.IsolationModePolicyDynamic},
+		{name: "invalid", raw: "mixed", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveIsolationModePolicy(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/config/crd/bases/tensor-fusion.ai_gpus.yaml
+++ b/config/crd/bases/tensor-fusion.ai_gpus.yaml
@@ -69,6 +69,21 @@ spec:
               GPUStatus defines the observed state of GPU.
               NOTE: When new fields added, remember to update syncGPUMetadataAndStatusFromCluster
             properties:
+              activeIsolationMode:
+                allOf:
+                - enum:
+                  - shared
+                  - soft
+                  - hard
+                  - partitioned
+                - enum:
+                  - shared
+                  - soft
+                  - hard
+                description: |-
+                  ActiveIsolationMode is the mode lock for a Dynamic GPU. It is empty when
+                  the GPU has no TensorFusion allocation; Static GPUs leave it empty.
+                type: string
               allocatedPartitions:
                 additionalProperties:
                   description: |-
@@ -175,6 +190,12 @@ spec:
                 - tflops
                 - vram
                 type: object
+              dynamicIsolationConflict:
+                description: |-
+                  DynamicIsolationConflict is true when recovery found multiple workload
+                  isolation modes on one Dynamic GPU. Such a GPU is fail-closed until the
+                  conflicting allocations are gone and recovery converges.
+                type: boolean
               gpuModel:
                 type: string
               index:
@@ -187,6 +208,14 @@ spec:
                 - soft
                 - hard
                 - partitioned
+                type: string
+              isolationPolicy:
+                description: |-
+                  IsolationPolicy is the policy actually advertised by the node hypervisor.
+                  Static is the backward-compatible zero-value interpretation.
+                enum:
+                - Static
+                - Dynamic
                 type: string
               message:
                 type: string

--- a/docs/dynamic-gpu-isolation-design.md
+++ b/docs/dynamic-gpu-isolation-design.md
@@ -156,7 +156,7 @@ flowchart TB
 
 | 对象 | 字段 | 含义 | 主要写入方 |
 |---|---|---|---|
-| Operator | `--isolation-mode-policy` | 调度域期望策略 | 用户/Helm |
+| Operator | `TF_ISOLATION_MODE_POLICY` | 调度域期望策略 | 用户/Helm |
 | GPUPool | `defaultIsolationMode/isolationModeRules` | 静态节点模式规则 | 用户/TFC |
 | GPU | `status.isolationPolicy` | 当前节点 Hypervisor 实际生效策略 | Hypervisor |
 | GPU | `status.isolationMode` | 静态策略下的节点模式；动态策略下忽略 | Hypervisor |
@@ -175,14 +175,15 @@ Operator 参数是调度域期望状态，GPU status 是实际数据面状态。
 
 ### 6.1 Operator 调度域开关
 
-在 Operator 中增加启动参数：
+Operator 从环境变量读取调度域策略：
 
 ```text
---isolation-mode-policy=static|dynamic
+TF_ISOLATION_MODE_POLICY=static|dynamic
 ```
 
-默认值必须是 `static`，以保证现有 Helm values、自定义 Operator command、TFC、GPUPool 和升级场景
-行为不变。Helm values 应提供对应字段并生成该参数；没有显式配置时不得启用 Dynamic。
+新 Helm Chart 默认注入 `dynamic`。Operator 二进制在环境变量不存在时仍回退为 `static`，保证旧部署
+清单和非 Helm 启动方式兼容；v1 镜像会安全忽略这个未知环境变量，因此可以只回退镜像而不必先修改
+容器命令。
 
 配置示例：
 
@@ -302,7 +303,7 @@ Hypervisor rollout hash 必须包含当前调度域的有效 isolation policy：
 1. 用户停止或迁出该调度域的全部 TensorFusion workload。
 2. 确认调度域内不存在有效 Worker Pod、assumed allocation 或硬件分区；GPU RunningApps 只作为
    辅助检查，不能作为唯一真相来源。
-3. 修改 Operator 的 `--isolation-mode-policy` 并重启 Operator。
+3. 修改 Operator 的 `TF_ISOLATION_MODE_POLICY` 并重启 Operator。
 4. Operator 按现有批次策略重建调度域内的 Hypervisor。
 5. 所有 GPU 发布新的实际策略后，调度域恢复调度。
 
@@ -750,12 +751,12 @@ Dynamic 调度域第一阶段必须拒绝 partitioned 请求，原因包括：
 
 ```text
 TensorFusion deployment A
-  --isolation-mode-policy=static
+  TF_ISOLATION_MODE_POLICY=static
   GPUPool: nvidia-mig
     defaultIsolationMode: partitioned
 
 TensorFusion deployment B
-  --isolation-mode-policy=dynamic
+  TF_ISOLATION_MODE_POLICY=dynamic
   GPUPool: nvidia-flexible
     supports: soft, hard, shared
 ```
@@ -803,7 +804,7 @@ Hypervisor和 Scheduler 对同一 status subresource 的更新必须使用冲突
 
 建议分层校验：
 
-- Operator 参数：`--isolation-mode-policy` 只允许 `static`、`dynamic`，非法值启动失败。
+- Operator 环境变量：`TF_ISOLATION_MODE_POLICY` 只允许 `static`、`dynamic`，非法值启动失败。
 - Operator：Dynamic 调度域中的静态规则被忽略并提示。
 - Scheduler：明确拒绝 Dynamic 调度域的 partitioned 请求。
 - Scheduler/PodResources：识别非 TensorFusion GPU 使用者并建立 external allocation；信息不可确认时
@@ -840,8 +841,8 @@ Webhook 可以提前给用户更友好的错误，但正确性不能依赖 webho
 
 ### 16.1 旧对象
 
-未设置 Operator `--isolation-mode-policy` 参数时默认为 Static。现有 TFC/GPUPool 无需增加或迁移
-字段，行为不变。
+未设置 Operator `TF_ISOLATION_MODE_POLICY` 时二进制默认为 Static。现有 TFC/GPUPool 无需增加或迁移
+字段；新 Helm Chart 默认显式注入 Dynamic，旧清单仍保持 Static。
 
 ### 16.2 Operator 与 Hypervisor 版本
 

--- a/docs/dynamic-gpu-isolation-design.md
+++ b/docs/dynamic-gpu-isolation-design.md
@@ -1,0 +1,998 @@
+# 动态 GPU 隔离设计
+
+## 1. 文档状态
+
+- 状态：设计评审稿
+- 目标版本：待定
+- 适用范围：TensorFusion v2
+- 本文只描述设计，不代表当前代码已经实现。
+
+## 2. 背景
+
+TensorFusion 当前使用 GPUPool 中的节点隔离配置预先确定节点运行模式：
+
+```yaml
+spec:
+  nodeManagerConfig:
+    defaultIsolationMode: soft
+    isolationModeRules:
+      - mode: hard
+        selector:
+          matchLabels:
+            gpu-workload-class: hard
+```
+
+Operator 根据 Kubernetes Node labels 解析出节点的 `soft`、`hard` 或
+`partitioned` 模式，并将结果作为 `--isolation-mode` 参数传给该节点的
+Hypervisor。Hypervisor 再把同一个模式发布给节点上的所有 GPU。因此，虽然当前
+`GPU.status.isolationMode` 位于 GPU CR 上，其实际来源仍是节点级静态配置。
+
+这种方式适合提前规划资源池，但存在以下限制：
+
+- soft 与 hard 必须在节点投入使用前划分好。
+- 一个多卡节点无法同时让不同物理 GPU 分别承载 soft 和 hard workload。
+- 节点的业务结构变化后，静态规划可能形成资源碎片。
+
+本设计增加调度域级隔离策略。一套 TensorFusion Operator/Scheduler 管理的所有 GPUPool 统一
+选择静态或动态模式：
+
+- 静态模式维持现有行为。
+- 动态模式不预先指定节点属于 soft 或 hard。
+- 动态模式下，一张空闲 GPU 第一次被分配时，由该 Pod 的隔离类型锁定当前模式。
+- 一张 GPU 在同一时刻只能服务一种隔离类型。
+- 最后一个占用该 GPU 的 Pod 释放后，GPU 回到未锁定状态，可被另一种模式重新占用。
+
+## 3. 目标与非目标
+
+### 3.1 第一阶段目标
+
+1. TensorFusion 集群在一个调度域内选择并启用一种隔离策略：`Static` 或 `Dynamic`。
+2. 动态调度域支持 `soft`、`hard` 和 `shared` workload。
+3. 同一动态节点上的不同 GPU 可以同时处于 soft、hard 或 shared 状态。
+4. 同一 GPU 上只允许相同隔离类型的 Pod 共存；shared 始终独占整张空闲 GPU。
+5. 模式选择、并发预占和释放必须在调度器中保持原子性。
+6. Hypervisor 必须对设备插件分配进行二次校验，防止控制面状态异常导致跨模式混用。
+7. Hypervisor 或 Operator 正常重启后，能够根据存量 Pod 恢复动态 GPU 状态。
+8. Dynamic defrag 能在同一 isolation 类型内安全重排资源，并在失败时原子回滚。
+9. 原生 device-plugin Pod 能与 TensorFusion Pod 在同一节点的不同 GPU 上安全共存；原生占用卡
+   不会被动态调度。
+10. 现有静态配置与旧对象升级后保持原行为。
+
+v1→Dynamic 接管的前置条件：每个存量 Worker Pod 有有效的
+`tensor-fusion.ai/gpu-ids` 和 `tensor-fusion.ai/isolation`；同一 GPU 恢复出的模式不能冲突；
+不存在 partitioned/MIG 或无法确认的外部 GPU 占用。接管期间暂停新 allocation，Hypervisor 和
+Scheduler 恢复完成后才开放调度。
+
+当前版本不支持 Static 与 Dynamic GPUPool 在同一 TensorFusion 调度域内共存。首版使用 Operator
+启动参数作为调度域级策略开关，降低 Operator、Scheduler 和 Hypervisor 同时维护两套状态语义的
+复杂度。
+
+### 3.2 第一阶段明确不支持
+
+1. 动态调度域不支持 `partitioned`，包括 NVIDIA MIG 和其他厂商硬件切分。
+2. 不支持带有无法恢复存量 allocation 的静态与动态策略无损在线切换；普通切换前必须清空整个
+   调度域的 workload。满足上述条件的 v1 soft/hard 存量 Pod 走单独的 v1→Dynamic 接管流程，
+   不要求删除业务 Pod。
+3. 不支持跨隔离类型抢占，例如 hard Pod 通过抢占 soft Pod 将 GPU 从 soft 改成 hard。
+4. 不改变现有 workload 运行限制，例如 hard local 模式仍需要当前支持的 sidecar 或 remote 路径。
+
+动态调度域首版必须支持以下两项能力：
+
+- Dynamic node compaction/defrag：只允许在不改变 workload isolation 的前提下迁移或重排 allocation；
+  planner 必须维护每张 GPU 的 active mode、committed/assumed allocation 和外部设备占用，禁止把
+  soft、hard、shared allocation 通过 defrag 合并到同一张卡。
+- 原生 device-plugin Pod 共存：原生 Pod 可以和 TensorFusion Pod 位于同一动态节点的不同 GPU 上。
+  被原生 Pod 占用的 GPU 必须作为外部独占 allocation 纳入状态，并从 TensorFusion 动态候选中排除；
+  不能仅因为节点仍有其他空闲 GPU 就把该卡视为空闲动态 GPU。
+
+### 3.3 后续可扩展项
+
+- 跨模式抢占。
+- 将隔离策略下沉到 GPUPool，支持同一调度域内 Static/Dynamic GPUPool 共存。
+- 原生 device-plugin 与 TensorFusion allocation 的更细粒度共享（当前首版按整卡 external 保护）。
+- 在硬件切分关闭、设备完全空闲时进行动态 MIG 模式转换。
+- 有状态的静态/动态在线迁移。
+
+## 4. 核心概念
+
+本设计明确区分以下两个维度。
+
+### 4.1 调度域隔离策略
+
+隔离策略回答“GPU 模式由谁决定”：
+
+- `Static`：由节点 labels、`isolationModeRules` 和 `defaultIsolationMode` 预先确定。
+- `Dynamic`：由第一个使 GPU 从空闲变为已分配的 Pod 决定。
+
+### 4.2 Workload 隔离类型
+
+workload 隔离类型回答“Pod 如何使用 GPU”：
+
+- `soft`
+- `hard`
+- `shared`
+- `partitioned`
+
+`Dynamic` 不是一种 workload 隔离类型，因此不能加入 `IsolationModeType`，也不能作为
+`tensor-fusion.ai/isolation` 的值。
+
+### 4.3 外部 GPU 占用
+
+原生 device-plugin/DRA Pod 不属于 TensorFusion workload，不设置 `activeIsolationMode`，也不能
+参与 TensorFusion 的 mode lock。PodResources proxy 和 Hypervisor 将其表示为独立的 `external`
+整卡占用：该 GPU 在外部进程释放前不可被 Dynamic TensorFusion allocation 使用。外部占用信息
+无法确认时按占用处理（fail-closed），避免设备发现延迟造成同卡争用。
+
+## 5. 总体架构
+
+```mermaid
+flowchart TB
+    User[用户 / Helm / GitOps] -->|Operator 启动参数 Static / Dynamic| Operator[Operator]
+    Operator --> Pool[所有 GPUPool]
+
+    Operator -->|Static: --isolation-mode=soft/hard/partitioned| StaticHV[静态 Hypervisor]
+    Operator -->|Dynamic: --isolation-policy=dynamic| DynamicHV[动态 Hypervisor]
+
+    StaticHV -->|发布实际策略与静态模式| GPUCR[GPU CR]
+    DynamicHV -->|发布实际策略与设备能力| GPUCR
+
+    Pod[Worker Pod isolation annotation] --> Scheduler[TensorFusion Scheduler]
+    Operator -->|调度域期望策略| Scheduler
+    Pool -->|Pool 资源范围| Scheduler
+    GPUCR -->|实际策略 / active mode / capacity| Scheduler
+
+    Scheduler --> Filter[Filter / Score]
+    Filter --> Assume[原子 Assume]
+    Assume --> Commit[Commit]
+    Commit -->|更新 available / runningApps / active mode| GPUCR
+    Commit -->|gpu-ids annotation| Pod
+
+    Pod --> Kubelet[Kubelet Device Plugin Allocate]
+    Kubelet --> DynamicHV
+    DynamicHV -->|二次校验同卡隔离模式| Runtime[设备、环境变量和 limiter 配置]
+```
+
+设计中的配置源与运行状态分工如下：
+
+| 对象 | 字段 | 含义 | 主要写入方 |
+|---|---|---|---|
+| Operator | `--isolation-mode-policy` | 调度域期望策略 | 用户/Helm |
+| GPUPool | `defaultIsolationMode/isolationModeRules` | 静态节点模式规则 | 用户/TFC |
+| GPU | `status.isolationPolicy` | 当前节点 Hypervisor 实际生效策略 | Hypervisor |
+| GPU | `status.isolationMode` | 静态策略下的节点模式；动态策略下忽略 | Hypervisor |
+| GPU | `status.activeIsolationMode` | 动态策略下当前卡级锁；空字符串表示未锁定 | Scheduler |
+| GPU | `status.available/runningApps` | 已分配资源和 Pod 明细 | Scheduler |
+
+Operator 参数是调度域期望状态，GPU status 是实际数据面状态。调度器不能仅根据 Operator 的期望
+策略判断节点是否已经完成滚动更新，否则可能在新参数生效、旧 Hypervisor 尚未替换期间提前使用
+动态规则。
+
+兼容约定：旧 GPU CR 没有 `status.isolationPolicy` 时一律按 `Static` 解释，继续使用现有
+`status.isolationMode`。只有新 Hypervisor 明确发布 `Dynamic` 后，调度器才允许对该 GPU 使用
+动态规则。
+
+## 6. API 设计
+
+### 6.1 Operator 调度域开关
+
+在 Operator 中增加启动参数：
+
+```text
+--isolation-mode-policy=static|dynamic
+```
+
+默认值必须是 `static`，以保证现有 Helm values、自定义 Operator command、TFC、GPUPool 和升级场景
+行为不变。Helm values 应提供对应字段并生成该参数；没有显式配置时不得启用 Dynamic。
+
+配置示例：
+
+```yaml
+controller:
+  isolationModePolicy: dynamic
+```
+
+动态策略下，所有 GPUPool 的 `defaultIsolationMode` 和 `isolationModeRules` 都不参与运行时决策。
+Operator 应忽略这些字段并记录一次明确日志，避免用户误以为静态规则仍对部分 Pool 生效。
+
+首版不在 TensorFusionCluster 或 GPUPool CRD 增加 `isolationModePolicy`，从 API 层面避免用户配置出
+Static/Dynamic 混合调度域。
+
+TODO：后续支持共存时，将该字段正式下沉到 `GPUPool.spec.nodeManagerConfig`；Operator 参数可保留为
+默认策略，但 GPUPool 显式值覆盖默认值。届时需要补充 CRD default、TFC 派生字段和冲突校验。
+
+### 6.2 GPU status
+
+建议增加两个字段：
+
+```go
+// +kubebuilder:validation:Enum=Static;Dynamic
+type IsolationModePolicyType string
+
+const (
+    IsolationModePolicyStatic  IsolationModePolicyType = "Static"
+    IsolationModePolicyDynamic IsolationModePolicyType = "Dynamic"
+)
+
+type GPUStatus struct {
+    // Hypervisor 当前实际执行的策略。
+    IsolationPolicy IsolationModePolicyType `json:"isolationPolicy,omitempty"`
+
+    // Dynamic 策略下当前 GPU 的分配锁；空字符串表示未锁定。
+    // 该字段不能配置 CRD default。
+    ActiveIsolationMode IsolationModeType `json:"activeIsolationMode,omitempty"`
+
+    // Existing field. Static 策略下继续表示有效静态模式。
+    IsolationMode IsolationModeType `json:"isolationMode,omitempty"`
+}
+```
+
+不能使用现有 `status.isolationMode` 的空值表示动态 GPU 空闲，因为该字段当前 CRD default 为
+`soft`，并且旧客户端把它作为节点运行模式使用。新增无默认值的
+`activeIsolationMode` 能避免破坏兼容语义。
+
+状态约定：
+
+| 实际策略 | `isolationMode` | `activeIsolationMode` |
+|---|---|---|
+| Static soft | `soft` | 空 |
+| Static hard | `hard` | 空 |
+| Static partitioned | `partitioned` | 空 |
+| Dynamic 空闲 | 忽略 | 空 |
+| Dynamic soft 占用 | 忽略 | `soft` |
+| Dynamic hard 占用 | 忽略 | `hard` |
+| Dynamic shared 独占 | 忽略 | `shared` |
+
+### 6.3 状态字段所有权
+
+GPU status 当前由 Hypervisor 与 Scheduler 共同更新。动态模式必须保持字段所有权清晰：
+
+- Hypervisor 更新物理设备信息、Capacity、实际 `isolationPolicy`、静态 `isolationMode` 和能力注解。
+- Scheduler 更新 Available、RunningApps、AllocatedPartitions 和 `activeIsolationMode`。
+- Hypervisor 周期性设备发现不得清空或覆盖 `activeIsolationMode`。
+- Scheduler 不得把调度域的期望策略直接写入 GPU 的实际 `isolationPolicy`。
+
+现有 Hypervisor 的整段 status patch 需要调整为保留 Scheduler 拥有的字段，并在冲突重试时基于
+最新 GPU 对象重新生成 patch。
+
+## 7. Operator 与 Hypervisor 生命周期
+
+### 7.1 静态调度域
+
+静态路径保持现有参数，避免要求旧 Hypervisor 镜像识别新参数：
+
+```text
+hypervisor --isolation-mode=soft
+hypervisor --isolation-mode=hard
+hypervisor --isolation-mode=partitioned
+```
+
+Operator 继续调用 `ResolveNodeIsolationMode`，按照第一条匹配规则、Pool 默认值、soft fallback
+确定节点模式。
+
+### 7.2 动态调度域
+
+动态路径使用独立策略参数：
+
+```text
+hypervisor --isolation-policy=dynamic
+```
+
+新 Hypervisor 中 `--isolation-policy` 缺省为 `static`，确保旧命令和静态升级路径兼容。
+动态模式下：
+
+- Operator 不再调用节点规则为 Hypervisor 选择 soft/hard。
+- Hypervisor 不得把启动时默认的 `soft` 写成每张卡的有效模式。
+- Hypervisor 对 GPU CR 发布 `status.isolationPolicy=Dynamic`。
+- `--isolation-mode` 即使因旧模板残留而出现，也必须在 Dynamic 策略下被忽略。
+
+### 7.3 Hash 与滚动更新
+
+Hypervisor rollout hash 必须包含当前调度域的有效 isolation policy：
+
+- Static：hash 包含策略以及该节点最终解析出的 isolation mode。
+- Dynamic：hash 包含策略，但不包含 `defaultIsolationMode` 和 `isolationModeRules`。
+- Dynamic 调度域修改任意 GPUPool 的静态规则不应重启 Hypervisor。
+- Static 调度域修改规则时，保持当前“只重启最终有效模式变化节点”的行为。
+- Static 与 Dynamic 变化时，触发调度域内所有 Hypervisor 的滚动更新。
+
+### 7.4 策略切换
+
+第一阶段不支持无损策略切换。安全契约为：
+
+1. 用户停止或迁出该调度域的全部 TensorFusion workload。
+2. 确认调度域内不存在有效 Worker Pod、assumed allocation 或硬件分区；GPU RunningApps 只作为
+   辅助检查，不能作为唯一真相来源。
+3. 修改 Operator 的 `--isolation-mode-policy` 并重启 Operator。
+4. Operator 按现有批次策略重建调度域内的 Hypervisor。
+5. 所有 GPU 发布新的实际策略后，调度域恢复调度。
+
+Operator 应增加防误操作保护：策略发生变化且调度域仍有 allocation 时，不开始 Hypervisor
+滚动，设置类似以下 Condition：
+
+```text
+IsolationPolicyTransitionBlocked=True
+Reason=ActiveAllocationsExist
+```
+
+清空 workload 后自动继续。策略切换期间应阻止新的 TensorFusion GPU Pod 进入整个调度域，避免
+永远无法排空。
+
+调度门禁以“期望策略是否等于实际策略”为准：
+
+- 调度域处于策略切换阻塞或滚动更新状态时，拒绝所有新 allocation。
+- 正常的 Hypervisor 镜像滚动不改变策略时，不需要因此关闭整个调度域，沿用现有批次行为。
+- Dynamic 调度域中，GPU 尚未发布 `isolationPolicy=Dynamic` 前不可调度。
+- 任一 GPU 的实际策略与调度域期望策略不一致时，该 GPU 不进入候选集合。
+- 全部节点收敛后设置 `IsolationPolicyReady=True` 并重新开放调度。
+
+排空检查应同时使用 Worker Pod cache、allocator committed/assumed state 和 GPU status。仅检查
+RunningApps 会受到异步 status 同步延迟影响；仅检查 Pod 列表又可能漏掉尚未绑定的 Assume。
+
+### 7.5 调度域策略约束
+
+当前实现将隔离策略视为 TensorFusion 调度域的统一配置，而不是每个 GPUPool 独立配置：
+
+- 调度域启用 `Static` 时，所有 GPUPool 按现有节点静态模式运行；
+- 调度域启用 `Dynamic` 时，所有普通 GPU GPUPool 使用卡级 active mode；
+- Dynamic 调度域不支持 `partitioned/MIG`，MIG 仍使用独立的 Static 集群或专用部署；
+- 在已有 workload、assumed allocation 或 Hypervisor 未收敛时，不允许切换策略；切换仍要求先排空。
+
+配置字段首版放在 Operator 启动参数和对应 Helm values 中，不在 TensorFusionCluster/GPUPool CRD
+增加字段，也不实现按 Pool 混合策略。
+
+TODO：后续支持 Static/Dynamic 共存时，再将策略正式下沉到 GPUPool，并增加节点 selector 重叠
+校验、按 Pool 的 Hypervisor 参数、Scheduler 的跨 Pool 策略门禁和独立状态恢复。
+
+### 7.6 节点归属约束
+
+一个 Kubernetes Node 在任一时刻只能由一个 GPUPool 管理。即使当前不支持 Static/Dynamic 共存，
+该资源边界仍然必须保留；未来按 Pool 混合策略时，如果同一节点同时命中两个 Pool，Operator
+无法为它选择唯一 Hypervisor 策略。
+
+- Pool selector reconcile 应检测重叠节点并阻止第二个 Pool 接管。
+- 冲突节点不得创建或替换 Hypervisor。
+- 两个 Pool 均应产生可定位 selector 重叠的 Condition/Event。
+- 该约束不仅适用于 Dynamic，也应作为所有 GPUPool 的通用不变量。
+
+## 8. 动态 GPU 状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Soft: 第一个 soft Assume
+    Idle --> Hard: 第一个 hard Assume
+    Idle --> Shared: shared Assume 且 GPU 完全空闲
+
+    Soft --> Soft: 后续 soft Assume
+    Hard --> Hard: 后续 hard Assume
+
+    Soft --> Idle: 最后一个 soft allocation 释放
+    Hard --> Idle: 最后一个 hard allocation 释放
+    Shared --> Idle: shared allocation 释放
+
+    Soft --> Soft: hard/shared 请求被拒绝
+    Hard --> Hard: soft/shared 请求被拒绝
+    Shared --> Shared: 任意新增请求被拒绝
+```
+
+### 8.1 空闲定义
+
+动态 GPU 只有同时满足以下条件才能视为未锁定：
+
+- 没有 committed allocation。
+- 没有 assumed allocation。
+- 没有 RunningApps。
+- 没有 AllocatedPartitions。
+- 对 shared 请求，还要求 Available 等于 Capacity。
+
+不能只通过 `Available == Capacity` 判断空闲，因为零资源请求、状态恢复误差和异步同步都可能
+导致该判断与真实 allocation 不一致。
+
+### 8.2 100% 请求
+
+- soft 100% 仍然锁定为 `soft`。
+- hard 100% 仍然锁定为 `hard`。
+- 只有显式 `isolation=shared` 的整卡请求锁定为 `shared`。
+
+使用量大小不能隐式改变隔离类型，否则存量 Pod 的注入方式与 GPU 状态会不一致。
+
+## 9. 调度设计
+
+### 9.1 调度域范围
+
+当前调度域只启用一种 isolation policy，因此一次调度周期不会混合 Static 和 Dynamic
+策略。`AllocRequest.PoolName` 继续限定候选 GPU 来自同一个 GPUPool；调度器先读取调度域的策略
+门禁，再根据 Static 或 Dynamic 路径执行过滤。
+
+调度器读取调度域的期望策略用于门禁，读取 GPU 的实际策略用于选择过滤语义。旧 GPU 的实际
+`GPU.status.isolationPolicy` 为空时按 Static 处理；不得把空值当成 Dynamic 或“任意模式”。未来按
+Pool 支持混合策略时，再增加 GPUPool 级期望策略校验。
+
+### 9.2 Filter
+
+静态 GPU 保持当前规则：
+
+```text
+shared 请求：允许任意静态模式上的完整空闲卡
+soft/hard/partitioned 请求：GPU isolationMode 必须匹配请求
+```
+
+动态 GPU 使用以下规则：
+
+```text
+partitioned 请求                  -> 拒绝
+Provider 不支持请求的隔离能力      -> 拒绝
+activeIsolationMode 为空           -> soft/hard/shared 可进入后续过滤
+activeIsolationMode == 请求模式    -> 允许进入后续过滤
+activeIsolationMode != 请求模式    -> 拒绝
+shared 请求                        -> 额外要求完整空闲、未分区
+```
+
+Filter 是候选计算，不承担最终锁定。它可能读取到随后失效的快照。
+
+### 9.3 Score 与 binpack
+
+第一阶段不引入新的放置算法，继续使用现有 GPUPool placement 配置。
+
+项目中的三种 placement 策略语义不同：
+
+| 策略 | 节点选择 | 节点内 GPU 选择 | 常用术语 |
+|---|---|---|---|
+| `CompactFirst` | 优先已使用比例高的节点 | 优先已使用比例高的 GPU | 两级 bin packing |
+| `NodeCompactGPULowLoad` | 优先已使用比例高的节点 | 优先剩余资源多的 GPU | node binpack + GPU spread |
+| `LowLoadFirst` | 优先低负载节点 | 优先低负载 GPU | spread |
+
+因此，“优先继续使用已有 GPU，再优先已有节点，保留更多完整空闲卡和节点”的准确策略名是
+`CompactFirst`，通用术语是 **bin packing**，更准确地说是 node-level 与 GPU-level 两级
+bin packing。当前 CRD 默认值和 Helm 模板使用的是 `NodeCompactGPULowLoad`，不能把它描述成
+GPU 与节点都压紧的默认策略。如果动态调度域需要完整的减少碎片语义，必须显式配置
+`CompactFirst`，或者另行评审是否修改产品默认值；本设计不隐式改变所有存量 Pool 的 placement。
+
+动态模式下，GPU 级评分可继续复用现有策略，但节点级评分需要使用“对当前请求兼容的节点视图”。
+当前 Scheduler 在 PreFilter 中把不匹配的 GPU 单独保存，并在最终 Node Score 时把它们重新加回。
+静态节点中这样做可以表达整个节点的使用率；动态节点中却可能让另一隔离类型的负载错误抬高节点
+分数。例如调度 soft Pod 时，节点上一张 90% 使用的 hard GPU 不应成为该节点的 soft binpack
+优势。
+
+动态调度域的 Node Score 只应统计：
+
+- `activeIsolationMode` 与当前请求一致的 GPU；
+- 尚未锁定且通过能力、模型、vendor 等基础约束的空闲 GPU，其已用分通常为 0；
+- 不应统计因 active mode 不匹配而被过滤的 GPU。
+
+实现上需要保留过滤原因，不能简单把所有 non-matching GPU 都加回或全部丢弃。GPU 级 Score、
+topology plan 和 Node Score 都只是偏好；Reserve/Assume 仍必须原子复检卡级模式。
+
+节点级 topology plugin 不再通过 Score 改变 placement 的节点顺序。placement 是节点排序的
+唯一偏好来源；topology hard 只在 Filter 阶段淘汰不满足拓扑约束的节点，topology soft 不淘汰节点。
+节点确定后，topology evaluator 在该节点的候选 GPU 中优先选择更好的 NVLink/NUMA 组合，再以
+placement 的 GPU 分数作为同拓扑等级组合的排序依据。没有拓扑数据时回退到 placement GPU 评分。
+
+如果用户选择 spread 类型 placement，系统遵循用户配置，不额外强制“相同模式优先”。模式
+一致性属于正确性约束，模式集中度属于调度策略，两者不应混在 Filter 中。
+
+### 9.4 Assume：正确性边界
+
+GPU 模式的最终决定必须发生在 allocator `Assume` 的同一临界区内：
+
+```text
+1. 获取 allocator store 写锁
+2. 读取 committed + 所有 assumed allocation
+3. 对全部目标 GPU 重新检查 active mode
+4. 空闲 GPU 建立本次 assumed mode lock
+5. 扣减 assumed 资源与 quota
+6. 任意 GPU 失败时，整体回滚
+7. 释放锁
+```
+
+典型竞争：
+
+```text
+Pod A Filter: GPU-0 空闲，可运行 soft
+Pod B Filter: GPU-0 空闲，可运行 hard
+Pod A Assume: 原子锁定 GPU-0=soft
+Pod B Assume: 发现 GPU-0 已锁定为 soft，失败并重新调度
+```
+
+模式锁必须包含 assumed allocation；不能等到 Commit 后才可见，否则两个并行调度周期可能同时
+预占不同模式。
+
+### 9.5 Commit、Forget、Rollback、Dealloc
+
+- `Commit`：把 assumed mode lock 转成 committed lock，并同步 GPU status。
+- `Forget`：删除本次 assumed allocation；如果该 GPU 不再有其他 assumed/committed allocation，
+  清除内存中的模式锁。
+- `Rollback`：释放已 Commit 但尚未完成绑定的 allocation，并重新计算 GPU 模式。
+- `Dealloc`：删除目标 Pod 后，基于剩余 committed 和 assumed allocation 重新计算模式；只有全部
+  为空时才清除 `activeIsolationMode`。
+- stale assumed allocation 清理也必须释放其模式锁。
+
+多卡 Pod 的模式建立和回滚必须是全有或全无，不能出现部分 GPU 锁定成功、部分失败。
+
+### 9.6 状态持久化与真相来源
+
+正确性的首要来源是 allocator 内的 committed/assumed allocation，而不是异步写入的 GPU CR。
+
+- `activeIsolationMode` 用于可观测性、重启恢复和其他组件读取。
+- Assume 临界区必须结合内存中的 assumed allocation 重新验证。
+- GPU CR status 更新可以异步批量执行，但不能早于内存状态建立。
+- Scheduler重启时根据存量 Worker Pod 的 `gpu-ids` 和 `isolation` 重建 committed 模式。
+
+## 10. Hypervisor 设计
+
+### 10.1 Device Controller
+
+当前 Device Controller 在每次设备发现时把 Hypervisor 的节点启动模式写到全部设备。动态策略
+下需要调整为：
+
+- 设备发现只发布 `isolationPolicy=Dynamic` 和设备能力。
+- 不为物理 GPU 设置卡级 active mode。
+- 不覆盖 Scheduler 管理的 `activeIsolationMode`。
+- Static 路径完全保持现有行为。
+
+### 10.2 Worker Allocation Controller 二次校验
+
+Hypervisor 的 device-plugin Allocate 已能获取 WorkerInfo，其中包含 Pod isolation 和目标 GPU。
+动态模式应在 `AllocateWorkerDevices` 的同一把锁内增加设备级校验：
+
+- 设备无现存 allocation：接受请求并建立本地模式。
+- 设备已有 allocation 且模式相同：接受请求。
+- 设备已有 allocation 且模式不同：拒绝 Allocate。
+- shared：只有设备没有任何 allocation 时接受。
+- partitioned：Dynamic 策略下拒绝。
+
+该检查是 Scheduler 之后的数据面保险，不能替代 Scheduler Assume。若 Hypervisor 拒绝分配，Pod
+应保持失败可见，并由控制面清理已提交 allocation，避免永久占用。
+
+### 10.3 soft quota controller
+
+当前 soft ERL 的启动条件依赖 Hypervisor 的节点模式等于 soft。动态 Hypervisor 可能同时管理
+soft 卡和 hard 卡，因此需改为：
+
+- Dynamic 且 Provider 支持 soft 时启动 soft quota controller。
+- quota controller 只构造和更新 `worker.IsolationMode == soft` 的状态。
+- hard/shared worker 不创建 soft ERL 状态，也不进入 soft PID/token 计算。
+- Provider 不支持 soft 时不启动该 controller，soft 请求由能力过滤拒绝。
+
+### 10.4 Pod 注入
+
+现有 Pod 注入已主要按照 workload isolation 处理，原则上无需改成节点模式判断：
+
+- soft：注入 soft limiter、共享内存和所需环境变量。
+- hard：使用 hard preload/worker 路径和 SM/VRAM limit 环境变量。
+- shared：完整 GPU，不注入 soft limiter 或 hard preload。
+
+动态实现必须检查所有注入分支，确保没有残留代码使用 GPUNode/Hypervisor 启动模式推断 Pod 的
+运行方式。
+
+## 11. 重启与恢复
+
+### 11.1 Scheduler 重启
+
+Scheduler初始化时遍历已调度且仍有效的 Worker Pod：
+
+1. 从 `tensor-fusion.ai/gpu-ids` 获取 GPU。
+2. 从 `tensor-fusion.ai/isolation` 获取 Pod 模式；缺省按现有兼容规则视为 soft。
+3. 恢复 resource allocation、RunningApps 和卡级 active mode。
+4. 如果同一 GPU 恢复出多种模式，将 GPU 标记为冲突并停止新分配。
+5. 重建完成后再开放 Scheduler ready。
+
+恢复结果应覆盖可能过期的 GPU `activeIsolationMode`，因为 Pod annotations 是存量分配事实。
+
+### 11.2 Hypervisor 重启
+
+Hypervisor启动后通过 Pod cache 恢复本节点 WorkerInfo：
+
+- 按每个 Worker 的 `gpu-ids` 和 `isolation` 重建本地 device allocation mode。
+- soft worker 重新打开 limiter shared memory。
+- hard/shared worker 恢复设备占用关系，但不进入 soft ERL。
+- 发现同卡多模式时将设备标记冲突，拒绝后续 Allocate，并上报 Event/metric。
+
+### 11.3 Operator 重启
+
+Operator 重启后从启动参数重新得到调度域期望策略，从现有 Hypervisor Pod args/hash 和 GPU 实际
+状态判断是否需要滚动。不能因为 Operator 内存丢失就把 Dynamic 调度域当成默认 Static。
+
+## 12. 抢占、模拟调度与其他功能
+
+### 12.1 抢占
+
+第一阶段只支持同模式抢占：
+
+- soft 请求只使用空闲卡或 active=soft 的卡，并只抢占 soft victims。
+- hard 请求只使用空闲卡或 active=hard 的卡，并只抢占 hard victims。
+- shared 请求可以使用原本已经空闲的卡；暂不通过跨模式抢占清空一张卡。
+
+抢占模拟副本必须携带 active mode。模拟释放 victim 后，只有该 GPU 的全部模拟 allocation 都为空
+才能把副本模式清空。
+
+当前抢占模拟主要恢复 Available 资源，并未按剩余 allocation 重算 active mode。Dynamic 实现还需
+保证 victim 与请求模式兼容；仅仅“释放后资源足够”不能作为成功条件。第一阶段即使某次跨模式
+抢占能够清空整卡，也应明确拒绝，避免不同 scheduler cycle 对解锁时点产生不同判断。
+
+### 12.2 模拟调度
+
+模拟调度复用动态 Filter，但只产生过滤详情，不建立真实模式锁。结果中应展示类似：
+
+```text
+GPUIsolationModeFilter:
+  rejected: active isolation mode hard does not match requested soft
+```
+
+模拟对象必须包含 committed 与 assumed allocation 推导出的 active mode；不能只复制
+Available/Capacity，否则模拟结果会把资源足够但模式不兼容的 GPU 误报为可用。
+
+### 12.3 Defrag / node compaction
+
+Dynamic 调度域首版支持 defrag，但 defrag 只能在 isolation-compatible 的 allocation 之间执行：
+
+- planner 必须同时维护每张 GPU 的 `activeIsolationMode`、committed/assumed allocation、
+  RunningApps 和外部设备占用；不能只按 Available/Capacity 做预算。
+- soft、hard、shared 不能通过一次 defrag 合并到同一张 GPU；shared 仍保持整卡独占。
+- 迁移必须经过新的 GPU mode lock、原子 Reserve/Commit 和失败回滚，原 GPU 只有在所有 allocation
+  成功迁出后才能解锁。
+- topology、SameNode、quota 和 placement 偏好仍作为约束/排序条件，defrag 不得绕过动态 Filter。
+
+defrag 运行期间应设置 `DynamicIsolationDefragInProgress` 状态，并在 mode lock 或外部占用发生变化
+时重新计算计划；无法保持模式一致时放弃本轮计划而不是强制跨模式迁移。
+
+### 12.4 Auto-expander
+
+Auto-expander 创建的虚拟 GPU 必须携带：
+
+```text
+isolationPolicy=Dynamic
+activeIsolationMode=""
+```
+
+否则 CRD/测试对象的 soft 默认值会让 hard 请求被错误判断为无法通过新增节点承载。虚拟 GPU
+仍需带 Provider 能力，避免为不支持 hard/soft 的硬件错误扩容。
+
+expander 当前对 in-flight 节点上的 `preSchedulePods` 只按 TFLOPS/VRAM 顺序预扣资源。动态调度域
+中还必须在虚拟 GPU 上建立临时 active mode：同模式预调度 Pod 可以继续压到该卡，异模式 Pod
+只能选择另一张空闲虚拟 GPU。否则扩容模拟可能认为一张未来 GPU 同时容纳 soft 和 hard，造成
+节点创建完成后其中一个 Pod 仍然不可调度。
+
+### 12.5 Autoscaling 与 auto-freeze
+
+已分配 Pod 的资源伸缩不改变 isolation，因此可继续支持。调整 Available 或限额时必须保持
+`activeIsolationMode` 不变。auto-freeze 继续只按现有支持的 workload 类型执行。
+
+### 12.6 多卡与拓扑
+
+- SameNode、多卡 binpack 和 NVLink/NUMA topology 在动态过滤后的候选 GPU 上继续执行。
+- 一个 Pod 的所有 GPU 使用同一个 workload isolation。
+- 多卡 Reserve/Assume 必须原子锁定全部 GPU。
+- topology plan 只是候选选择，不能绕过 Assume 的模式复检。
+
+### 12.7 Gang、nominated reservation 与队列唤醒
+
+- Gang 的 Permit wait 已持有 allocator Assume，因此 mode lock 必须和 assumed resource 一起保留；
+  Permit reject、Unreserve、严格 gang 失败和 stale-assume 清理必须同时释放它。
+- 不同 isolation 的 gang member 可以落在同一动态节点的不同 GPU，但不能落在同一 GPU。多成员
+  并发 Assume 的任意失败仍按现有 gang 失败语义处理。
+- 高优先级 nominated Pod 的 GPU 预留当前按节点资源总量扣减。动态模式下必须按 isolation-compatible
+  GPU 计算；hard nominated Pod 不应预留 soft-locked GPU 的可用量，也不应阻塞只能使用 soft GPU
+  的当前 Pod。
+- QueueingHint 当前主要观察 Available 增量。动态模式还要把 active mode 从不匹配变为空闲或当前
+  请求模式视为唤醒信号；否则零资源请求、状态修复或仅 mode lock 变化时，Pending Pod 可能要等
+  unschedulable queue 的周期性刷新。
+
+### 12.8 AutoMigration、progressive migration 与原生 device plugin
+
+由 webhook 完整转换为 TensorFusion `shared` 请求的 autoMigration Pod 会经过正常
+Filter/Assume/Commit，可以按 shared 规则支持。
+
+仍直接使用 `nvidia.com/gpu` 等原生资源、没有经过 TensorFusion allocation 的 Pod 不会进入模式
+锁状态机，但首版必须保证安全共存：
+
+- PodResources proxy/Hypervisor 必须识别 GPU 上的非 TensorFusion 使用者，并将该 GPU 记录为
+  `external` 独占 allocation；该卡从 TensorFusion 动态候选集中排除，直到外部使用完全释放。
+- 原生 Pod 可以与 TensorFusion Pod 位于同一节点的不同 GPU；节点级 Score 不能把外部占用卡的
+  负载作为当前 isolation-compatible GPU 的 binpack 优势。
+- 外部占用状态丢失或无法确认时，按占用处理并拒绝该卡的新动态 allocation（fail-closed）。
+
+当前 progressive migration 对原生 GPU Pod 走独立 PreFilter 分支，只按节点是否被 TensorFusion
+使用来选择 native 节点，不进入 GPU Filter/Assume；该分支必须补充外部 GPU 占用同步，不能仅凭
+节点级使用判断。原生请求仍可保留旁路语义，但其设备必须先登记为 external allocation，并对
+`UsedBy` 非 TensorFusion 的 GPU 整卡排除。
+
+### 12.9 其他现有能力
+
+以下能力不以节点静态 isolation 为决策依据，在增加 Dynamic Filter/Assume 状态机后可以保留：
+
+- GPU model/vendor/index/node affinity、SameNode 和 `maxWorkerPerNode`；
+- namespace quota，以及 soft/hard 的百分比或绝对 TFLOPS、VRAM request/limit；
+- local/remote Pod 注入、shared 整卡、per-container GPU 映射；
+- DCGM/PodResources endpoint；它根据 Pod GPU annotations 重写设备信息；
+- vertical autoscaling/`AdjustAllocation`；它只调整原 allocation 的资源，不改变 isolation；
+- auto-freeze 配置；继续遵守其现有 remote worker/QoS 适用范围；
+- 基础 GPU/Worker metrics，但需要新增 active mode、冲突与 mode rejection 指标。
+
+`ReBalancer` 在 API 中仍标注为 Future，当前没有完整的 workload rebalancer 实现，因此不属于本次
+动态模式造成的回归能力。
+
+### 12.10 首阶段兼容矩阵
+
+| 功能 | Dynamic 第一阶段结论 | 主要原因或改造点 |
+|---|---|---|
+| soft/hard/shared 普通调度 | 改造后可用 | Dynamic Filter + 原子 Assume mode lock |
+| `CompactFirst` 两级 binpack | 改造后可用 | 节点由 placement 排序；节点内拓扑优先、同拓扑按高负载 GPU 排序 |
+| `NodeCompactGPULowLoad` / `LowLoadFirst` | 改造后可用 | 节点分别按紧凑/低负载排序；节点内拓扑优先、同拓扑按低负载 GPU 排序 |
+| local/remote、TFLOPS/VRAM、quota | 基本保留 | allocation isolation 不变 |
+| shared 整卡 | 改造后可用 | 空闲检查和 shared 独占 mode lock |
+| 多卡、SameNode、NVLink/NUMA topology | 改造后可用 | 候选先过滤，全部 GPU 原子锁定与回滚 |
+| Gang | 改造后可用 | Permit/Unreserve/stale Assume 同步 mode lock |
+| 同模式抢占 | 改造后可用 | victim 模拟需维护剩余 allocation 和 active mode |
+| 跨模式抢占 | 第一阶段禁用 | 清空、解锁与重新锁定存在跨 cycle 竞争 |
+| 模拟调度 | 改造后可用 | 模拟 active mode，不建立真实锁 |
+| nominated Pod reservation/queue hints | 改造后可用 | 按兼容卡预留，并监听 mode 解锁 |
+| auto-expander | 改造后可用 | in-flight 虚拟 GPU 维护 active mode |
+| vertical autoscaling/auto-freeze | 基本保留 | 不改变原 Pod isolation |
+| Scheduler/Hypervisor 重启恢复 | 必须改造 | 从存量 Pod annotations 重建卡级模式 |
+| defrag/node compaction | 改造后可用 | planner 维护 active mode、剩余 allocation 和外部占用，按 mode 原子迁移 |
+| progressive/native GPU/DRA 旁路 | 改造后可用 | 外部 GPU 登记为 external allocation，整卡排除并 fail-closed |
+| Static/Dynamic 在线切换 | 第一阶段不支持无损 | 切换前清空整个调度域 |
+
+“改造后可用”表示该能力没有架构性冲突，但不能用当前静态实现原样宣称兼容；需要对应单元、race、
+模拟调度和集群回归测试通过后再开放。
+
+## 13. MIG 与硬件切分边界
+
+Dynamic 调度域第一阶段必须拒绝 partitioned 请求，原因包括：
+
+- MIG 开关通常是节点或整卡硬件状态，切换需要 GPU 无进程、无实例。
+- MIG instance 创建/删除存在设备发现和 kubelet device-plugin 重注册窗口。
+- 当前设计的模式锁只管理逻辑 soft/hard/shared，不负责硬件模式生命周期。
+- 已启用 MIG 的卡不能按普通完整 GPU 直接加入 Dynamic 调度域。
+
+当前版本需要拆分为两个独立 TensorFusion 调度域，例如：
+
+```text
+TensorFusion deployment A
+  --isolation-mode-policy=static
+  GPUPool: nvidia-mig
+    defaultIsolationMode: partitioned
+
+TensorFusion deployment B
+  --isolation-mode-policy=dynamic
+  GPUPool: nvidia-flexible
+    supports: soft, hard, shared
+```
+
+两个部署必须使用互不重叠的 Node selectors 和资源对象范围。Operator/Hypervisor 应在 Dynamic
+调度域中检测现有 partition/MIG device。发现硬件已经被切分时，不发布为可调度动态 GPU，并设置
+明确的 NotReady 原因。
+
+## 14. 失败处理与一致性
+
+### 14.1 不变量
+
+实现必须始终保持：
+
+1. Dynamic GPU 的所有 committed 和 assumed allocation 隔离类型相同。
+2. `activeIsolationMode` 非空时，必须至少存在一个对应的 committed 或 assumed allocation。
+3. GPU 无 allocation 时，`activeIsolationMode` 最终收敛为空。
+4. shared GPU 只能存在一个 allocation，且分配前完整空闲、未切分。
+5. Dynamic GPU 不存在 partitioned allocation。
+6. Static GPU 的调度行为与当前版本一致。
+
+### 14.2 冲突状态
+
+如果恢复或异常写入发现同一 GPU 存在多种模式：
+
+- 不自动删除任何 Pod。
+- 将 GPU Phase/Condition 标记为冲突或不可调度。
+- 从所有新调度候选中排除。
+- 发出 Kubernetes Event 和 metric，列出 GPU、Pod UID 和模式。
+- 待管理员清理冲突 Pod 后由 reconcile 自动恢复。
+
+### 14.3 GPU status 写冲突
+
+Hypervisor和 Scheduler 对同一 status subresource 的更新必须使用冲突重试和字段保留。禁止通过
+旧缓存对象执行整段 status 覆盖。需要增加并发测试，验证设备发现与 Commit/Dealloc 同时发生时：
+
+- active mode 不丢失。
+- Available 不回满。
+- RunningApps 不丢失。
+- Capacity 更新仍能生效。
+
+## 15. Admission 与可观测性
+
+### 15.1 校验
+
+建议分层校验：
+
+- Operator 参数：`--isolation-mode-policy` 只允许 `static`、`dynamic`，非法值启动失败。
+- Operator：Dynamic 调度域中的静态规则被忽略并提示。
+- Scheduler：明确拒绝 Dynamic 调度域的 partitioned 请求。
+- Scheduler/PodResources：识别非 TensorFusion GPU 使用者并建立 external allocation；信息不可确认时
+  按占用处理。
+- Defrag planner：只允许 isolation-compatible 的原子迁移，不得跨 active mode 合并 GPU。
+- Hypervisor：再次拒绝 Dynamic + partitioned 或跨模式 Allocate。
+- 策略切换：有 active allocation 时阻止 rollout。
+
+Webhook 可以提前给用户更友好的错误，但正确性不能依赖 webhook，因为存量 Pod、关闭 webhook 或
+直接创建 Worker CR 的路径仍可能绕过 admission。
+
+### 15.2 状态与指标
+
+建议至少暴露：
+
+- `tensor_fusion_gpu_isolation_policy{pool,node,gpu,policy}`
+- `tensor_fusion_gpu_active_isolation_mode{pool,node,gpu,mode}`
+- `tensor_fusion_dynamic_isolation_conflicts_total{pool,node,gpu}`
+- `tensor_fusion_dynamic_isolation_assume_rejections_total{pool,requested,current}`
+- `tensor_fusion_isolation_policy_transition_blocked{pool}`
+- `tensor_fusion_dynamic_external_gpu_allocations{pool,node,gpu}`
+- `tensor_fusion_dynamic_defrag_rejections_total{pool,reason}`
+
+首版仍可在每个受管 GPUPool 上重复呈现调度域状态，Conditions 建议包括：
+
+- `IsolationPolicyReady`
+- `IsolationPolicyTransitionBlocked`
+- `UnsupportedDynamicPartitioning`
+- `DynamicIsolationConflict`
+
+日志和 Event 应包含 pool、node、GPU UUID、requested mode、active mode 和 Pod UID。
+
+## 16. 兼容性与升级
+
+### 16.1 旧对象
+
+未设置 Operator `--isolation-mode-policy` 参数时默认为 Static。现有 TFC/GPUPool 无需增加或迁移
+字段，行为不变。
+
+### 16.2 Operator 与 Hypervisor 版本
+
+- 新 Hypervisor不传 `--isolation-policy` 时默认 Static，可由旧 Operator 启动。
+- 新 Operator 在 Static 调度域继续只传旧的 `--isolation-mode`，兼容旧 Hypervisor。
+- Dynamic 调度域需要支持 `--isolation-policy=dynamic` 的新 Hypervisor 镜像。
+- 若配置 Dynamic 但镜像不支持新参数，Hypervisor会启动失败；Operator应在文档和状态中明确最低
+  版本要求。
+
+### 16.3 回退
+
+v1 和未实现本设计的旧 v2 版本不认识 Dynamic 策略。回退流程必须：
+
+1. 普通 Dynamic→Static 回退清空调度域内的全部 workload；如果是 v1→Dynamic 接管后回退，也
+   必须先清理已恢复的 Dynamic active mode 和全部 Dynamic workload。
+2. 将 Operator 参数改回 Static 并完成全部 Hypervisor 滚动。
+3. 确认 GPU 实际策略均为 Static。
+4. 再回退 Operator/CRD。
+
+不能带着动态分配的存量 Pod 直接回退。
+
+## 17. 安全实施阶段
+
+### Phase 1：调度域开关与静态兼容
+
+- 增加 Operator/Helm 调度域级 policy 开关和 GPU 实际/active 状态字段。
+- 默认 Static。
+- Static 路径测试结果与改动前一致。
+- Helm values、Operator 参数、GPU CRD 与文档同步；TFC/GPUPool 不增加 policy 字段。
+
+### Phase 2：Hypervisor dynamic 基础
+
+- 增加 `--isolation-policy=dynamic`。
+- 设备发现发布实际策略并保留 Scheduler-owned status。
+- AllocationController 增加同卡模式校验。
+- soft ERL 支持 Dynamic。
+- 完成 Hypervisor 重启恢复和冲突检测。
+
+### Phase 3：Scheduler 卡级状态机
+
+- Dynamic Filter。
+- Assume/Commit/Forget/Rollback/Dealloc 模式锁。
+- 启动恢复与 stale assumption 清理。
+- shared 整卡动态状态。
+- race 和多卡原子性测试。
+
+### Phase 4：外围能力
+
+- 模拟调度。
+- 同模式抢占。
+- auto-expander 虚拟 GPU。
+- autoscaling、topology、gang 和 binpack 回归。
+- Dynamic 调度域显式拒绝 partitioned，并启用具备 mode lock/external allocation 保护的 defrag。
+
+### Phase 5：集群验证
+
+- 单节点多卡 soft/hard/shared 共存。
+- local/remote CUDA 与 NVML 实际调用。
+- 算力和显存限制。
+- Hypervisor/Operator/Scheduler 重启恢复。
+- 并发竞争和失败注入。
+
+## 18. 测试与验收矩阵
+
+### 18.1 API/Operator
+
+- Operator 不传 policy 参数时，Hypervisor 仍按 Static soft/hard/partitioned 启动。
+- Static rules 第一条匹配和 default 行为不变。
+- Dynamic 调度域的所有 Hypervisor 使用 dynamic args。
+- Dynamic 调度域修改任意 GPUPool 的静态 rules 不触发重启。
+- Static/Dynamic 切换在任一 GPUPool 有 workload 时被阻止，清空整个调度域后继续。
+- 同一调度域不能配置部分 Static、部分 Dynamic；GPUPool API 不暴露该策略字段。
+
+### 18.2 调度正确性
+
+- 空闲动态 GPU 可被第一个 soft Pod 锁定。
+- soft GPU 接受更多 soft Pod，拒绝 hard/shared。
+- hard GPU 接受更多 hard Pod，拒绝 soft/shared。
+- shared 只分配完整空闲 GPU，且独占。
+- 最后一个 Pod 删除后 GPU 解锁。
+- soft/hard 100% 不被误判为 shared。
+- 两个并发 soft/hard Pod 竞争同卡时只能一个 Assume 成功。
+- 多卡 Pod 锁定全部成功或全部回滚。
+- stale Assume 清理后 GPU 可被另一模式使用。
+- defrag 在同一 active mode 内迁移成功，失败时原子回滚且不留下 mode lock。
+- defrag 遇到 external allocation 时保留该卡整卡保护，不迁移或覆盖原生设备占用。
+- 原生 device-plugin Pod 与 TensorFusion Pod 使用同一节点的不同 GPU 时均能正常运行。
+- PodResources/外部占用信息不可用时，相关 GPU 被排除并在恢复后重新进入候选。
+
+### 18.3 调度外围
+
+- compact/binpack 在同模式 GPU 内保持原行为。
+- 两组 `20% + 1Gi` 的同模式 Pod 在显式 `CompactFirst` 策略下进入同卡。
+- soft 调度的节点分数不受同节点 hard/shared 锁定 GPU 的使用率抬高，hard 调度反之亦然。
+- topology 硬/软策略不绕过模式过滤。
+- gang Reserve 失败时全部解锁。
+- 模拟调度报告正确的模式过滤原因。
+- 同模式抢占成功，跨模式抢占被拒绝。
+- Dynamic 调度域 defrag 能保持 active mode；跨模式迁移被拒绝，external allocation 卡保留整卡保护
+  且不作为迁移目标，并产生明确状态。
+- 原生 device-plugin Pod 与 TensorFusion Pod 位于同一节点的不同 GPU 时均可运行；原生占用卡不会
+  被动态调度，PodResources 信息丢失时动态调度 fail-closed。
+- hard/soft Pending Pod 可触发正确的动态节点扩容判断。
+- in-flight 扩容模拟不会把不同模式的 preSchedule Pod 放到同一张虚拟 GPU。
+- active mode 解锁能够唤醒资源数值没有增加的 Pending Pod。
+
+### 18.4 Hypervisor 与数据面
+
+- 动态节点不同卡分别运行 soft 和 hard CUDA workload。
+- soft 实际调用 CUDA/NVML，算力和显存限制生效。
+- hard 实际调用 CUDA/NVML，SM 百分比/绝对 TFLOPS 映射和显存限制生效。
+- shared 不注入 limiter/preload，按 gpu-count 调用完整 GPU。
+- local 与 remote 分别验证，不能只以 Pod Running 作为成功标准。
+- Hypervisor二次校验拒绝人工构造的同卡跨模式 Allocate。
+- Hypervisor 重启后存量 Pod 新建 CUDA/NVML 进程仍正常。
+- Scheduler 重启后模式、Available 和 RunningApps 恢复正确。
+
+### 18.5 故障与 race
+
+- Filter 后、Assume 前 GPU 被其他模式占用。
+- Assume 后、Commit 前取消调度。
+- Commit 后、Pod annotation patch 失败。
+- Pod 删除与 Hypervisor device discovery 并发。
+- Scheduler status sync 与 Hypervisor capacity update 冲突。
+- Hypervisor 重启时 Pod 同时创建/删除。
+- `go test -race` 覆盖 allocator mode lock 和 Hypervisor allocation map。
+
+## 19. 设计决策摘要
+
+1. 当前调度域统一选择 Static 或 Dynamic，暂不支持两种策略共存；GPUPool 级策略作为后续扩展口子。
+2. `Static/Dynamic` 与 `soft/hard/shared/partitioned` 分为两个类型体系。
+3. 现有静态路径和启动参数保持兼容。
+4. GPU CR 同时表达期望之外的“实际生效策略”和动态“当前卡级锁”。
+5. Filter 只计算候选，Assume 是模式一致性的控制面原子边界。
+6. Hypervisor Allocate 是数据面的第二道一致性保护。
+7. Dynamic MVP 支持 soft、hard、shared，不支持 partitioned/MIG。
+8. 策略切换要求先清空整个调度域，不承诺无损在线转换。
+9. 第一阶段只支持同模式抢占；Dynamic defrag 通过 active mode 和 external allocation 保护后可用。
+10. 重启恢复以存量 Pod annotations 为分配事实，而不是盲目信任可能过期的 GPU status。
+
+## 20. 待评审问题
+
+以下问题需要在进入编码前确认：
+
+1. 后续按 GPUPool 支持 Static/Dynamic 共存时，策略字段是否正式下沉到
+   `GPUPool.spec.nodeManagerConfig`，以及 Operator 参数是否保留为默认值。
+2. 第一阶段是否限定 NVIDIA，还是要求所有声明 soft/hard 能力的 Provider 同步支持。
+3. Dynamic 调度域是否允许 progressive migration；若允许，是否强制所有原生请求先转换为
+   TensorFusion shared。
+4. 策略切换保护是“阻止 rollout 直到排空”，还是允许显式 force 执行破坏性切换。
+5. `activeIsolationMode` 是否需要加入 `kubectl get gpu` print column，还是只通过 describe/metric
+   展示。
+6. Dynamic 调度域 defrag 的触发方式、迁移限额和失败后的 Condition 语义。
+7. 后续跨模式抢占是否要求“目标 GPU 上所有 allocation 都是 victims”作为必要条件。

--- a/internal/component/hypervisor.go
+++ b/internal/component/hypervisor.go
@@ -20,7 +20,8 @@ var (
 )
 
 type Hypervisor struct {
-	nodesToUpdate []*tfv1.GPUNode
+	nodesToUpdate       []*tfv1.GPUNode
+	IsolationModePolicy tfv1.IsolationModePolicyType
 }
 
 func (h *Hypervisor) GetName() string {
@@ -29,8 +30,19 @@ func (h *Hypervisor) GetName() string {
 
 func (h *Hypervisor) DetectConfigChange(pool *tfv1.GPUPool, status *tfv1.PoolComponentStatus) (bool, string, string) {
 	oldHash := status.HypervisorVersion
-	newHash := utils.HypervisorTemplateHash(pool)
+	newHash := h.templateHash(pool)
 	return oldHash != newHash, newHash, oldHash
+}
+
+func (h *Hypervisor) templateHash(pool *tfv1.GPUPool) string {
+	policy := h.IsolationModePolicy
+	if policy == "" {
+		policy = tfv1.IsolationModePolicyStatic
+	}
+	if policy == tfv1.IsolationModePolicyStatic {
+		return utils.HypervisorTemplateHash(pool)
+	}
+	return utils.HypervisorTemplateHashWithPolicy(pool, policy)
 }
 
 func (h *Hypervisor) SetConfigHash(status *tfv1.PoolComponentStatus, hash string) {
@@ -112,7 +124,11 @@ func (h *Hypervisor) GetResourcesInfo(r client.Client, ctx context.Context, pool
 			// cannot match a selector, so the pool default is used.
 			k8sNode = &corev1.Node{}
 		}
-		isolationMode, resolveErr := utils.ResolveNodeIsolationMode(k8sNode, pool.Spec.NodeManagerConfig)
+		isolationMode := tfv1.IsolationModeType("soft")
+		var resolveErr error
+		if h.IsolationModePolicy != tfv1.IsolationModePolicyDynamic {
+			isolationMode, resolveErr = utils.ResolveNodeIsolationMode(k8sNode, pool.Spec.NodeManagerConfig)
+		}
 		if resolveErr != nil {
 			return 0, 0, false, fmt.Errorf("resolve isolation mode for node %s: %w", node.Name, resolveErr)
 		}

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -62,6 +62,7 @@ type GPUNodeReconciler struct {
 	Allocator                            *gpuallocator.GpuAllocator
 	Expander                             *expander.NodeExpander
 	CompatibleWithNvidiaContainerToolkit bool
+	IsolationModePolicy                  tfv1.IsolationModePolicyType
 }
 
 // For test or troubleshooting purpose, using env var to force GPUNode state
@@ -387,6 +388,44 @@ func (r *GPUNodeReconciler) removeStuckHypervisorPodOnNotReadyNode(
 	return nil
 }
 
+func (r *GPUNodeReconciler) ensureHypervisorPrerequisites(
+	ctx context.Context,
+	nodeName string,
+	vendor string,
+	currentPod *corev1.Pod,
+	podExists bool,
+) error {
+	log := log.FromContext(ctx)
+	handler := r.getVendorHandler(vendor)
+	if handler == nil {
+		return nil
+	}
+
+	log.V(1).Info("checking hypervisor prerequisites", "node", nodeName, "vendor", vendor)
+	prereqs, err := handler.CheckHypervisorPrerequisites(ctx, r, nodeName)
+	if err != nil {
+		return fmt.Errorf("failed to check hypervisor prerequisites: %w", err)
+	}
+	if prereqs.Ready {
+		log.V(1).Info("hypervisor prerequisites are ready", "node", nodeName)
+		return nil
+	}
+
+	if podExists {
+		log.Info("hypervisor prerequisites not ready, deleting existing hypervisor pod",
+			"node", nodeName,
+			"pod", currentPod.Name,
+			"podPhase", currentPod.Status.Phase)
+		if err := r.Delete(ctx, currentPod); err != nil {
+			return fmt.Errorf("failed to delete existing hypervisor pod: %w", err)
+		}
+		log.Info("deleted hypervisor pod due to prerequisites not ready", "node", nodeName, "pod", currentPod.Name)
+	} else {
+		log.V(1).Info("hypervisor prerequisites not ready, no existing pod to delete", "node", nodeName)
+	}
+	return fmt.Errorf("waiting for hypervisor prerequisites (device plugin)")
+}
+
 func (r *GPUNodeReconciler) reconcileHypervisorPod(
 	ctx context.Context,
 	node *tfv1.GPUNode,
@@ -434,34 +473,11 @@ func (r *GPUNodeReconciler) reconcileHypervisorPod(
 		return "", fmt.Errorf("failed to resolve node vendor: %w", err)
 	}
 
-	handler := r.getVendorHandler(vendor)
-	if handler != nil {
-		log.V(1).Info("checking hypervisor prerequisites", "node", node.Name, "vendor", vendor)
-		prereqs, err := handler.CheckHypervisorPrerequisites(ctx, r, node.Name)
-		if err != nil {
-			return "", fmt.Errorf("failed to check hypervisor prerequisites: %w", err)
-		}
-
-		if !prereqs.Ready {
-			if podExists {
-				log.Info("hypervisor prerequisites not ready, deleting existing hypervisor pod",
-					"node", node.Name,
-					"pod", currentPod.Name,
-					"podPhase", currentPod.Status.Phase)
-				if err := r.Delete(ctx, currentPod); err != nil {
-					return "", fmt.Errorf("failed to delete existing hypervisor pod: %w", err)
-				}
-				log.Info("deleted hypervisor pod due to prerequisites not ready", "node", node.Name, "pod", key.Name)
-			} else {
-				log.V(1).Info("hypervisor prerequisites not ready, no existing pod to delete", "node", node.Name)
-			}
-			// Return error to trigger requeue, ensuring eventual creation when prerequisites are met
-			return "", fmt.Errorf("waiting for hypervisor prerequisites (device plugin)")
-		}
-		log.V(1).Info("hypervisor prerequisites are ready", "node", node.Name)
+	if err := r.ensureHypervisorPrerequisites(ctx, node.Name, vendor, currentPod, podExists); err != nil {
+		return "", err
 	}
 
-	desiredIsolationMode, err := utils.ResolveNodeIsolationMode(k8sNode, pool.Spec.NodeManagerConfig)
+	desiredIsolationMode, err := r.effectiveHypervisorIsolationMode(k8sNode, pool)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve isolation mode for node %s: %w", node.Name, err)
 	}
@@ -484,7 +500,12 @@ func (r *GPUNodeReconciler) reconcileHypervisorPod(
 			return "", nil
 		}
 
-		if !isHypervisorIsolationModeConfigured(currentPod, string(desiredIsolationMode)) {
+		policy := r.IsolationModePolicy
+		if policy == "" {
+			policy = tfv1.IsolationModePolicyStatic
+		}
+		if !isHypervisorIsolationModeConfigured(currentPod, string(desiredIsolationMode)) ||
+			!isHypervisorIsolationPolicyConfigured(currentPod, string(policy)) {
 			// Pool policy changes use the existing batched Hypervisor rollout.
 			// Running nodes wait until the pool controller selects them by
 			// moving the GPUNode to Pending.
@@ -576,11 +597,16 @@ func (r *GPUNodeReconciler) createHypervisorPod(
 	}
 	log.Info("adding hypervisor manifest for GPU node", "node", node.Name, "vendor", vendor)
 	utils.AddTFHypervisorConfAfterTemplate(ctx, &spec, pool, vendor, r.CompatibleWithNvidiaContainerToolkit)
-	isolationMode, err := utils.ResolveNodeIsolationMode(k8sNode, pool.Spec.NodeManagerConfig)
+	isolationMode, err := r.effectiveHypervisorIsolationMode(k8sNode, pool)
 	if err != nil {
 		return fmt.Errorf("failed to resolve isolation mode for node %s: %w", node.Name, err)
 	}
 	applyHypervisorIsolationModeArg(&spec, string(isolationMode))
+	policy := r.IsolationModePolicy
+	if policy == "" {
+		policy = tfv1.IsolationModePolicyStatic
+	}
+	applyHypervisorIsolationPolicyArg(&spec, string(policy))
 
 	// add vendor-specific env vars for multi-vendor support
 	if node.Labels != nil && node.Labels[constants.AcceleratorLabelVendor] != "" {
@@ -712,6 +738,23 @@ func (r *GPUNodeReconciler) createHypervisorPod(
 	}
 	log.Info("hypervisor pod created", "name", key.Name, "hash", newHash)
 	return nil
+}
+
+// effectiveHypervisorIsolationMode is the process-wide compatibility mode
+// passed to the Hypervisor. Dynamic scheduling owns the actual isolation mode
+// per GPU, so node labels/rules must not select or roll the Hypervisor between
+// soft and hard. Soft is the common base because it initializes the shared
+// quota controller used by dynamic soft workers; hard workers still bypass
+// soft limiter hooks based on their WorkerInfo isolation annotation.
+func (r *GPUNodeReconciler) effectiveHypervisorIsolationMode(node *corev1.Node, pool *tfv1.GPUPool) (tfv1.IsolationModeType, error) {
+	policy := r.IsolationModePolicy
+	if policy == "" {
+		policy = tfv1.IsolationModePolicyStatic
+	}
+	if policy == tfv1.IsolationModePolicyDynamic {
+		return tfv1.IsolationModeSoft, nil
+	}
+	return utils.ResolveNodeIsolationMode(node, pool.Spec.NodeManagerConfig)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -1116,6 +1159,32 @@ func applyHypervisorIsolationModeArg(spec *corev1.PodSpec, isolationMode string)
 	spec.Containers[0].Args = upsertHypervisorIsolationModeArg(spec.Containers[0].Args, isolationMode)
 }
 
+func applyHypervisorIsolationPolicyArg(spec *corev1.PodSpec, policy string) {
+	if spec == nil || len(spec.Containers) == 0 || policy == "" {
+		return
+	}
+	policy = strings.ToLower(strings.TrimSpace(policy))
+	const policyFlag = "--isolation-policy"
+	args := spec.Containers[0].Args
+	for i := 0; i < len(args); i++ {
+		if strings.HasPrefix(args[i], policyFlag+"=") {
+			args[i] = policyFlag + "=" + policy
+			spec.Containers[0].Args = args
+			return
+		}
+		if args[i] == policyFlag {
+			if i+1 < len(args) {
+				args[i+1] = policy
+			} else {
+				args = append(args, policy)
+			}
+			spec.Containers[0].Args = args
+			return
+		}
+	}
+	spec.Containers[0].Args = append(args, policyFlag+"="+policy)
+}
+
 func upsertHypervisorIsolationModeArg(args []string, isolationMode string) []string {
 	const isolationModeFlag = "--isolation-mode"
 	if isolationMode == "" {
@@ -1150,6 +1219,30 @@ func isHypervisorIsolationModeConfigured(pod *corev1.Pod, desiredIsolationMode s
 		return !found
 	}
 	return found && valid && actualIsolationMode == desiredIsolationMode
+}
+
+func isHypervisorIsolationPolicyConfigured(pod *corev1.Pod, desiredPolicy string) bool {
+	if pod == nil || len(pod.Spec.Containers) == 0 {
+		return false
+	}
+	actual, found := extractHypervisorIsolationPolicyArg(pod.Spec.Containers[0].Args)
+	if desiredPolicy == "" {
+		return !found
+	}
+	return found && strings.EqualFold(actual, desiredPolicy)
+}
+
+func extractHypervisorIsolationPolicyArg(args []string) (string, bool) {
+	const flagName = "--isolation-policy"
+	for i, arg := range args {
+		if strings.HasPrefix(arg, flagName+"=") {
+			return strings.TrimPrefix(arg, flagName+"="), true
+		}
+		if arg == flagName && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
 }
 
 func extractHypervisorIsolationModeArg(args []string) (string, bool, bool) {

--- a/internal/controller/gpunode_controller_test.go
+++ b/internal/controller/gpunode_controller_test.go
@@ -173,6 +173,15 @@ var _ = Describe("GPUNode Controller", func() {
 			Expect(spec.Containers[0].Args).To(ContainElement("--isolation-mode=partitioned"))
 		})
 
+		It("should append and detect the Dynamic isolation policy arg", func() {
+			spec := &corev1.PodSpec{Containers: []corev1.Container{{Name: constants.TFContainerNameHypervisor}}}
+			applyHypervisorIsolationPolicyArg(spec, string(tfv1.IsolationModePolicyDynamic))
+			Expect(spec.Containers[0].Args).To(ContainElement("--isolation-policy=dynamic"))
+			pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: spec.Containers}}
+			Expect(isHypervisorIsolationPolicyConfigured(pod, string(tfv1.IsolationModePolicyDynamic))).To(BeTrue())
+			Expect(isHypervisorIsolationPolicyConfigured(pod, string(tfv1.IsolationModePolicyStatic))).To(BeFalse())
+		})
+
 		It("should replace an existing isolation mode arg with the configured mode", func() {
 			spec := &corev1.PodSpec{
 				Containers: []corev1.Container{

--- a/internal/controller/gpupool_controller.go
+++ b/internal/controller/gpupool_controller.go
@@ -77,8 +77,9 @@ type GPUPoolReconciler struct {
 
 	LastProcessedItems sync.Map
 
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
+	Scheme              *runtime.Scheme
+	Recorder            events.EventRecorder
+	IsolationModePolicy tfv1.IsolationModePolicyType
 }
 
 // First round reconcile should build correct capacity, and then check provisioning
@@ -400,7 +401,7 @@ func (r *GPUPoolReconciler) reconcilePoolComponents(ctx context.Context, pool *t
 	}()
 
 	components := []component.Interface{
-		&component.Hypervisor{},
+		&component.Hypervisor{IsolationModePolicy: r.IsolationModePolicy},
 		&component.Worker{},
 		&component.Client{},
 	}

--- a/internal/controller/gpupool_defrag.go
+++ b/internal/controller/gpupool_defrag.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -1691,6 +1692,9 @@ func applyGPUPlacementToBudget(nb *nodeBudget, selected []*tfv1.GPU, req *tfv1.A
 		}
 		wasFree := isGPUFullyAvailable(live)
 		subtractGPURequest(live, req)
+		if live.Status.IsolationPolicy == tfv1.IsolationModePolicyDynamic && live.Status.ActiveIsolationMode == "" {
+			live.Status.ActiveIsolationMode = req.Isolation
+		}
 		if wasFree && !isGPUFullyAvailable(live) {
 			nb.usedGPUs++
 		}
@@ -1897,6 +1901,11 @@ func findFreshDefragWorker(
 // matches what those would do at real bind time.
 func subtractGPURequest(gpu *tfv1.GPU, req *tfv1.AllocRequest) {
 	if gpu == nil || gpu.Status.Available == nil || gpu.Status.Capacity == nil {
+		return
+	}
+	if req.Isolation == tfv1.IsolationModeShared {
+		gpu.Status.Available.Tflops = resource.Quantity{}
+		gpu.Status.Available.Vram = resource.Quantity{}
 		return
 	}
 	if !req.Request.ComputePercent.IsZero() {

--- a/internal/controller/gpupool_defrag_test.go
+++ b/internal/controller/gpupool_defrag_test.go
@@ -235,6 +235,41 @@ func TestSubtractGPURequest_SafelyIgnoresBadInput(t *testing.T) {
 	subtractGPURequest(g, &tfv1.AllocRequest{})
 }
 
+func TestApplyGPUPlacementToBudgetTracksDynamicMode(t *testing.T) {
+	gpu := gpuWithUsage("g", "p", "100", "10Gi", tfv1.UsedByTensorFusion)
+	gpu.Status.IsolationPolicy = tfv1.IsolationModePolicyDynamic
+	nb := &nodeBudget{gpus: map[string]*tfv1.GPU{gpu.Name: gpu}, totalGPUs: 1}
+	req := &tfv1.AllocRequest{
+		Isolation: tfv1.IsolationModeSoft,
+		Request: tfv1.Resource{
+			Tflops: resource.MustParse("30"),
+			Vram:   resource.MustParse("2Gi"),
+		},
+	}
+
+	applyGPUPlacementToBudget(nb, []*tfv1.GPU{{ObjectMeta: metav1.ObjectMeta{Name: gpu.Name}}}, req)
+	if gpu.Status.ActiveIsolationMode != tfv1.IsolationModeSoft {
+		t.Fatalf("active isolation mode = %q, want soft", gpu.Status.ActiveIsolationMode)
+	}
+	if nb.usedGPUs != 1 {
+		t.Fatalf("used GPUs = %d, want 1", nb.usedGPUs)
+	}
+}
+
+func TestSubtractGPURequestSharedConsumesWholeGPU(t *testing.T) {
+	gpu := gpuWithUsage("g", "p", "100", "10Gi", tfv1.UsedByTensorFusion)
+	subtractGPURequest(gpu, &tfv1.AllocRequest{
+		Isolation: tfv1.IsolationModeShared,
+		Request: tfv1.Resource{
+			Tflops: resource.MustParse("10"),
+			Vram:   resource.MustParse("1Gi"),
+		},
+	})
+	if !gpu.Status.Available.Tflops.IsZero() || !gpu.Status.Available.Vram.IsZero() {
+		t.Fatalf("shared placement did not consume the whole GPU: %#v", gpu.Status.Available)
+	}
+}
+
 // ---- evictWorkerPods with fake clientset ------------------------------
 
 const (
@@ -2730,6 +2765,7 @@ func TestBuildDefragNodeBudgets_ReportsDirtyFreeAndExclusions(t *testing.T) {
 	}
 	if buddyAcct == nil {
 		t.Fatalf("buddy accounting missing, got %+v", accounting)
+		return
 	}
 	// Only the healthy used GPU counts toward the tally; the dirty free GPU is
 	// invisible to placement, so Free must be 0 while Dirty is 1.

--- a/internal/gang/manager.go
+++ b/internal/gang/manager.go
@@ -1218,29 +1218,52 @@ func (m *Manager) CleanupPodGroup(groupKey PodGroupKey) {
 }
 
 func (m *Manager) collectActivatablePods(
+	ctx context.Context,
 	currentPod *corev1.Pod,
 	targetKey PodGroupKey,
 	targetMode groupKeyMode,
 ) (map[string]*corev1.Pod, error) {
 	podsToActivate := make(map[string]*corev1.Pod)
-	if m.podLister == nil || currentPod == nil {
+	if currentPod == nil {
 		return podsToActivate, nil
 	}
 
-	pods, err := m.podLister.Pods(currentPod.Namespace).List(gangLabelSelector(currentPod, targetMode))
-	if err != nil {
-		return nil, fmt.Errorf("list pods for activation in gang %s/%s: %w", currentPod.Namespace, targetKey, err)
+	var pods []*corev1.Pod
+	if m.podLister != nil {
+		listedPods, err := m.podLister.Pods(currentPod.Namespace).List(gangLabelSelector(currentPod, targetMode))
+		if err != nil {
+			return nil, fmt.Errorf("list pods for activation in gang %s/%s: %w", currentPod.Namespace, targetKey, err)
+		}
+		pods = listedPods
 	}
 
-	for _, peerPod := range pods {
+	collect := func(peerPod *corev1.Pod) {
 		if !isActivePod(peerPod) || peerPod.UID == currentPod.UID || peerPod.Spec.NodeName != "" {
-			continue
+			return
 		}
 		key, mode := resolveGroupKeyFromAnnotationsOrPod(peerPod)
 		if key == "" || mode != targetMode || key != targetKey {
-			continue
+			return
 		}
 		podsToActivate[peerPod.Namespace+"/"+peerPod.Name] = peerPod
+	}
+	for _, peerPod := range pods {
+		collect(peerPod)
+	}
+	if len(podsToActivate) > 0 {
+		return podsToActivate, nil
+	}
+
+	if liveClient := m.getClient(); liveClient != nil {
+		podList := &corev1.PodList{}
+		if err := liveClient.List(ctx, podList,
+			client.InNamespace(currentPod.Namespace),
+			client.MatchingLabelsSelector{Selector: gangLabelSelector(currentPod, targetMode)}); err != nil {
+			return nil, fmt.Errorf("list live pods for activation in gang %s/%s: %w", currentPod.Namespace, targetKey, err)
+		}
+		for i := range podList.Items {
+			collect(&podList.Items[i])
+		}
 	}
 	return podsToActivate, nil
 }
@@ -1251,11 +1274,12 @@ func (m *Manager) activateUnscheduledPods(
 	targetKey PodGroupKey,
 	targetMode groupKeyMode,
 ) int {
-	if m.frameworkHandle == nil {
+	frameworkHandle := m.frameworkHandle
+	if frameworkHandle == nil {
 		return 0
 	}
 
-	podsToActivate, err := m.collectActivatablePods(currentPod, targetKey, targetMode)
+	podsToActivate, err := m.collectActivatablePods(ctx, currentPod, targetKey, targetMode)
 	if err != nil {
 		log.Error(err, "Failed to collect activatable gang pods",
 			"pod", currentPod.Name,
@@ -1266,7 +1290,10 @@ func (m *Manager) activateUnscheduledPods(
 		return 0
 	}
 
-	m.frameworkHandle.Activate(klog.FromContext(ctx), podsToActivate)
+	logger := klog.FromContext(ctx)
+	// Permit runs inside a scheduling cycle. Activate takes the scheduling queue
+	// lock, so run it after Permit can return and release the current cycle.
+	go frameworkHandle.Activate(logger, podsToActivate)
 	return len(podsToActivate)
 }
 

--- a/internal/gang/manager_test.go
+++ b/internal/gang/manager_test.go
@@ -72,6 +72,22 @@ func createTestPod(name, workloadName string, gangMinMembers int32, gangTimeout 
 	return pod
 }
 
+func TestCollectActivatablePodsFallsBackToLiveClient(t *testing.T) {
+	current := createTestPod("worker-0", "gang-workload", 2, "")
+	peer := createTestPod("worker-1", "gang-workload", 2, "")
+	manager := NewManager(nil, nil, "test")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	manager.SetClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(current, peer).Build())
+
+	groupKey, mode := resolveGroupKeyFromAnnotationsOrPod(current)
+	pods, err := manager.collectActivatablePods(context.Background(), current, groupKey, mode)
+
+	require.NoError(t, err)
+	require.Contains(t, pods, peer.Namespace+"/"+peer.Name)
+}
+
 func createTestAllocReq(pod *corev1.Pod, gpuNames []string) *tfv1.AllocRequest {
 	return &tfv1.AllocRequest{
 		PoolName: "test-pool",

--- a/internal/gpuallocator/filter/gpu_isolation_mode_filter.go
+++ b/internal/gpuallocator/filter/gpu_isolation_mode_filter.go
@@ -29,6 +29,15 @@ func (f *GPUIsolationModeFilter) Filter(ctx context.Context, workerPodKey tfv1.N
 		if !isIsolationSupportedByCapabilities(extractVirtualizationCapabilities(gpu), f.requiredIsolationMode) {
 			continue
 		}
+		if gpu.Status.IsolationPolicy == tfv1.IsolationModePolicyDynamic {
+			if gpu.Status.DynamicIsolationConflict {
+				continue
+			}
+			if gpu.Status.ActiveIsolationMode == "" || gpu.Status.ActiveIsolationMode == f.requiredIsolationMode {
+				filtered = append(filtered, gpu)
+			}
+			continue
+		}
 		// Shared is a whole-GPU allocation policy rather than a node runtime mode.
 		// Allow idle whole GPUs from every node isolation mode; normal allocator
 		// scoring decides placement without preferring shared-labelled nodes.

--- a/internal/gpuallocator/filter/gpu_isolation_mode_filter_test.go
+++ b/internal/gpuallocator/filter/gpu_isolation_mode_filter_test.go
@@ -120,6 +120,23 @@ func TestGPUIsolationModeFilter_SharedAcceptsAnyNodeRuntimeMode(t *testing.T) {
 	}
 }
 
+func TestGPUIsolationModeFilter_DynamicUsesRecoveredActiveMode(t *testing.T) {
+	filter := NewGPUIsolationModeFilter(tfv1.IsolationModeSoft)
+	gpus := []*tfv1.GPU{
+		{Status: tfv1.GPUStatus{UUID: "idle", IsolationPolicy: tfv1.IsolationModePolicyDynamic}},
+		{Status: tfv1.GPUStatus{UUID: "soft", IsolationPolicy: tfv1.IsolationModePolicyDynamic, ActiveIsolationMode: tfv1.IsolationModeSoft}},
+		{Status: tfv1.GPUStatus{UUID: "hard", IsolationPolicy: tfv1.IsolationModePolicyDynamic, ActiveIsolationMode: tfv1.IsolationModeHard}},
+		{Status: tfv1.GPUStatus{UUID: "conflict", IsolationPolicy: tfv1.IsolationModePolicyDynamic, DynamicIsolationConflict: true}},
+	}
+	filtered, err := filter.Filter(context.Background(), tfv1.NameNamespace{}, gpus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 2 || filtered[0].Status.UUID != "idle" || filtered[1].Status.UUID != "soft" {
+		t.Fatalf("unexpected Dynamic candidates: %#v", filtered)
+	}
+}
+
 func TestSharedWholeGPUFilter_OnlyKeepsIdleUnpartitionedGPUs(t *testing.T) {
 	res := func(tflops, vram string) *tfv1.Resource {
 		return &tfv1.Resource{Tflops: resource.MustParse(tflops), Vram: resource.MustParse(vram)}

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -288,6 +288,9 @@ type GpuAllocator struct {
 	syncInterval    time.Duration
 	cancel          context.CancelFunc
 	ctx             context.Context
+	// isolationPolicy is the scheduler-wide policy. Static is the compatible
+	// default; Dynamic is enabled by the operator command line.
+	isolationPolicy tfv1.IsolationModePolicyType
 
 	// Queue for tracking modified GPUs that need to be synced
 	dirtyQueue     map[types.NamespacedName]struct{}
@@ -325,6 +328,27 @@ type GpuAllocator struct {
 	// timestamp. Wired from cmd/main.go to avoid a gang→allocator package
 	// dependency. nil → no gang awareness (treat every entry uniformly).
 	gangWaitingProbe func(podUID string) bool
+}
+
+// SetIsolationPolicy configures the scheduler-wide isolation policy. The
+// policy is intentionally global in the first implementation; GPUPool-level
+// policy selection is reserved for a future API extension.
+func (s *GpuAllocator) SetIsolationPolicy(policy tfv1.IsolationModePolicyType) {
+	if policy != tfv1.IsolationModePolicyDynamic {
+		policy = tfv1.IsolationModePolicyStatic
+	}
+	s.storeMutex.Lock()
+	s.isolationPolicy = policy
+	s.storeMutex.Unlock()
+}
+
+func (s *GpuAllocator) IsolationPolicy() tfv1.IsolationModePolicyType {
+	s.storeMutex.RLock()
+	defer s.storeMutex.RUnlock()
+	if s.isolationPolicy == "" {
+		return tfv1.IsolationModePolicyStatic
+	}
+	return s.isolationPolicy
 }
 
 func NewGpuAllocator(
@@ -514,6 +538,9 @@ func (s *GpuAllocator) applyAssumedAllocationsToGPUCopies(gpuIndex map[string]*t
 			if err := s.applyAllocationToGPU(gpu, req, gpuName); err != nil {
 				log.FromContext(s.ctx).Error(err, "Failed to apply assumed allocation to GPU snapshot", "podUID", podUID, "gpu", gpuName)
 			}
+			if gpu.Status.IsolationPolicy == tfv1.IsolationModePolicyDynamic && gpu.Status.ActiveIsolationMode == "" && req.Isolation != tfv1.IsolationModePartitioned {
+				gpu.Status.ActiveIsolationMode = req.Isolation
+			}
 		}
 	}
 }
@@ -612,6 +639,10 @@ func (s *GpuAllocator) Filter(
 	toFilterGPUs []*tfv1.GPU,
 	isSimulateSchedule bool,
 ) ([]*tfv1.GPU, []filter.FilterDetail, error) {
+	if s.IsolationPolicy() == tfv1.IsolationModePolicyDynamic && req.Isolation == tfv1.IsolationModePartitioned {
+		return nil, nil, fmt.Errorf("dynamic policy does not support partitioned allocation")
+	}
+	toFilterGPUs = filterGPUsForIsolationPolicy(toFilterGPUs, s.IsolationPolicy(), req.Isolation)
 	// Filter order: index -> isolation -> partition -> resource -> (model, vendor, nodeAffinity) -> sameNode
 	filterRegistry := s.filterRegistry
 
@@ -666,16 +697,63 @@ func (s *GpuAllocator) Filter(
 	return filteredGPUs, filterDetails, nil
 }
 
+func filterGPUsForIsolationPolicy(
+	gpus []*tfv1.GPU,
+	expectedPolicy tfv1.IsolationModePolicyType,
+	requested tfv1.IsolationModeType,
+) []*tfv1.GPU {
+	filtered := make([]*tfv1.GPU, 0, len(gpus))
+	for _, gpu := range gpus {
+		if isGPUIsolationCompatible(expectedPolicy, gpu, requested) {
+			filtered = append(filtered, gpu)
+		}
+	}
+	return filtered
+}
+
+func isGPUIsolationCompatible(
+	expectedPolicy tfv1.IsolationModePolicyType,
+	gpu *tfv1.GPU,
+	requested tfv1.IsolationModeType,
+) bool {
+	if gpu == nil {
+		return false
+	}
+	if expectedPolicy == tfv1.IsolationModePolicyDynamic {
+		if gpu.Status.IsolationPolicy != tfv1.IsolationModePolicyDynamic || gpu.Status.DynamicIsolationConflict {
+			return false
+		}
+		return gpu.Status.ActiveIsolationMode == "" || gpu.Status.ActiveIsolationMode == requested
+	}
+	if gpu.Status.IsolationPolicy != "" && gpu.Status.IsolationPolicy != tfv1.IsolationModePolicyStatic {
+		return false
+	}
+	if requested == "" || requested == tfv1.IsolationModeShared {
+		return true
+	}
+	return gpu.Status.IsolationMode == "" || gpu.Status.IsolationMode == requested
+}
+
+// IsGPUIsolationCompatible reports whether a GPU may participate in placement
+// and scoring for the scheduler-wide policy and requested isolation mode.
+func (s *GpuAllocator) IsGPUIsolationCompatible(gpu *tfv1.GPU, requested tfv1.IsolationModeType) bool {
+	return isGPUIsolationCompatible(s.IsolationPolicy(), gpu, requested)
+}
+
 func (s *GpuAllocator) FilterWithPreempt(
 	req *tfv1.AllocRequest,
 	preemptAllocRequests []*tfv1.AllocRequest,
 	targetNodeNames ...string,
 ) ([]*tfv1.GPU, []filter.FilterDetail, error) {
+	if s.IsolationPolicy() == tfv1.IsolationModePolicyDynamic && req.Isolation == tfv1.IsolationModePartitioned {
+		return nil, nil, fmt.Errorf("dynamic policy does not support partitioned allocation")
+	}
 	gpuStore, nodeGpuStore := s.snapshotStoresForPreempt()
 	toFilterGPUs, err := s.buildPreemptFilterInput(gpuStore, nodeGpuStore, preemptAllocRequests, targetNodeNames)
 	if err != nil {
 		return nil, nil, err
 	}
+	toFilterGPUs = filterGPUsForIsolationPolicy(toFilterGPUs, s.IsolationPolicy(), req.Isolation)
 
 	filterRegistry := s.buildPreemptFilterRegistry(req)
 	filteredGPUs, filterDetails, err := filterRegistry.Apply(s.ctx, req.WorkloadNameNamespace, toFilterGPUs, false)
@@ -1132,6 +1210,23 @@ func (s *GpuAllocator) Assume(gpuNames []string, req *tfv1.AllocRequest) error {
 
 	gpuCopies := make(map[string]*tfv1.GPU, len(gpuNames))
 	gpuNodeName := ""
+	newDynamicLocks := make([]string, 0, len(gpuNames))
+	clearNewDynamicLocks := func() {
+		if s.isolationPolicy != tfv1.IsolationModePolicyDynamic {
+			return
+		}
+		for _, gpuName := range newDynamicLocks {
+			if s.clearDynamicModeIfUnusedLocked(gpuName) {
+				s.markGPUDirty(types.NamespacedName{Name: gpuName})
+			}
+		}
+	}
+	assumeCompleted := false
+	defer func() {
+		if !assumeCompleted {
+			clearNewDynamicLocks()
+		}
+	}()
 	for _, gpuName := range gpuNames {
 		gpu := s.gpuStore[types.NamespacedName{Name: gpuName}]
 		if gpu == nil {
@@ -1140,13 +1235,39 @@ func (s *GpuAllocator) Assume(gpuNames []string, req *tfv1.AllocRequest) error {
 		if gpuNodeName == "" {
 			gpuNodeName = gpu.Status.NodeSelector[constants.KubernetesHostNameLabel]
 		}
+		if s.isolationPolicy == tfv1.IsolationModePolicyDynamic &&
+			gpu.Status.IsolationPolicy != tfv1.IsolationModePolicyDynamic {
+			return fmt.Errorf("GPU %s has not advertised Dynamic isolation policy", gpuName)
+		}
+		if s.isolationPolicy != tfv1.IsolationModePolicyDynamic &&
+			!isGPUIsolationCompatible(s.isolationPolicy, gpu, req.Isolation) {
+			return fmt.Errorf("GPU %s is incompatible with %s isolation policy and mode %s",
+				gpuName, s.isolationPolicy, req.Isolation)
+		}
 		gpuCopies[gpuName] = gpu.DeepCopy()
+		if s.isolationPolicy == tfv1.IsolationModePolicyDynamic {
+			if req.Isolation == tfv1.IsolationModePartitioned {
+				return fmt.Errorf("dynamic policy does not support partitioned allocation")
+			}
+			if gpuCopies[gpuName].Status.DynamicIsolationConflict {
+				return fmt.Errorf("GPU %s has a Dynamic isolation conflict", gpuName)
+			}
+			active := gpuCopies[gpuName].Status.ActiveIsolationMode
+			if active != "" && active != req.Isolation {
+				return fmt.Errorf("GPU %s is locked to isolation mode %s", gpuName, active)
+			}
+			if active == "" {
+				gpuCopies[gpuName].Status.ActiveIsolationMode = req.Isolation
+				newDynamicLocks = append(newDynamicLocks, gpuName)
+			}
+		}
 	}
 
 	s.applyAssumedAllocationsToGPUCopies(gpuCopies, s.assumedAllocation)
 
 	for _, gpuName := range gpuNames {
 		if err := s.applyAllocationToGPU(gpuCopies[gpuName], req, gpuName); err != nil {
+			clearNewDynamicLocks()
 			return err
 		}
 	}
@@ -1154,7 +1275,24 @@ func (s *GpuAllocator) Assume(gpuNames []string, req *tfv1.AllocRequest) error {
 	if s.maxWorkerPerNode > 0 {
 		workerCounts := s.effectiveNodeWorkerCountsLocked()
 		if workerCounts[gpuNodeName] >= s.maxWorkerPerNode {
+			clearNewDynamicLocks()
 			return fmt.Errorf("node %s reached max workers per node %d", gpuNodeName, s.maxWorkerPerNode)
+		}
+	}
+
+	// Publish the card-level mode lock only after the complete request has
+	// passed validation. Assume holds storeMutex, so no concurrent Assume can
+	// observe a partially locked multi-GPU request. The lock is kept in the
+	// real store while the request is assumed and is cleared by Forget/Rollback
+	// when no allocation still references the GPU.
+	if s.isolationPolicy == tfv1.IsolationModePolicyDynamic {
+		for _, gpuName := range gpuNames {
+			key := types.NamespacedName{Name: gpuName}
+			gpu := s.gpuStore[key]
+			if gpu != nil && gpu.Status.ActiveIsolationMode == "" {
+				gpu.Status.ActiveIsolationMode = req.Isolation
+				s.markGPUDirty(key)
+			}
 		}
 	}
 
@@ -1164,6 +1302,7 @@ func (s *GpuAllocator) Assume(gpuNames []string, req *tfv1.AllocRequest) error {
 	s.assumedAllocationTimestamps[podUID] = time.Now()
 	delete(s.uniqueDeallocation, podUID)
 	s.quotaStore.AssumeQuota(req.WorkloadNameNamespace.Namespace, assumedReq)
+	assumeCompleted = true
 
 	return nil
 }
@@ -1188,15 +1327,25 @@ func (s *GpuAllocator) Commit(podUID string) ([]*tfv1.GPU, error) {
 	// failure during commit. Keeps the invariant: a failed Commit leaves no
 	// assumed state behind, regardless of whether the caller also calls Forget.
 	rollbackOnCommitFailure := func(appliedGPUKeys []types.NamespacedName) {
+		// Remove the assumed ledger entry first so mode locks can be released
+		// for GPUs that were validated but never reached applyAllocation.
+		delete(s.assumedAllocation, podUID)
+		delete(s.assumedAllocationTimestamps, podUID)
 		for _, appliedKey := range appliedGPUKeys {
 			appliedGPU := s.gpuStore[appliedKey]
 			s.releaseAllocationFromGPU(appliedGPU, req, appliedKey.Name)
 			removeRunningApp(s.ctx, appliedGPU, req)
 			s.markGPUDirty(appliedKey)
 		}
+		if s.isolationPolicy == tfv1.IsolationModePolicyDynamic {
+			for _, gpuName := range req.GPUNames {
+				key := types.NamespacedName{Name: gpuName}
+				if s.clearDynamicModeIfUnusedLocked(gpuName) {
+					s.markGPUDirty(key)
+				}
+			}
+		}
 		s.quotaStore.ForgetAssumedQuota(req.WorkloadNameNamespace.Namespace, req)
-		delete(s.assumedAllocation, podUID)
-		delete(s.assumedAllocationTimestamps, podUID)
 	}
 
 	gpuNodeName := ""
@@ -1215,7 +1364,6 @@ func (s *GpuAllocator) Commit(podUID string) ([]*tfv1.GPU, error) {
 			rollbackOnCommitFailure(appliedGPUKeys)
 			return nil, err
 		}
-
 		addRunningApp(s.ctx, gpu, req)
 		s.markGPUDirty(key)
 		appliedGPUKeys = append(appliedGPUKeys, key)
@@ -1284,6 +1432,14 @@ func (s *GpuAllocator) Forget(podUID string) error {
 	s.quotaStore.ForgetAssumedQuota(req.WorkloadNameNamespace.Namespace, req)
 	delete(s.assumedAllocation, podUID)
 	delete(s.assumedAllocationTimestamps, podUID)
+	if s.isolationPolicy == tfv1.IsolationModePolicyDynamic {
+		for _, gpuName := range req.GPUNames {
+			key := types.NamespacedName{Name: gpuName}
+			if s.clearDynamicModeIfUnusedLocked(gpuName) {
+				s.markGPUDirty(key)
+			}
+		}
+	}
 	return nil
 }
 
@@ -1331,6 +1487,14 @@ func (s *GpuAllocator) Rollback(podUID string) error {
 		})
 	}
 	delete(s.uniqueAllocation, podUID)
+	if s.isolationPolicy == tfv1.IsolationModePolicyDynamic {
+		for _, gpuName := range request.GPUNames {
+			key := types.NamespacedName{Name: gpuName}
+			if s.clearDynamicModeIfUnusedLocked(gpuName) {
+				s.markGPUDirty(key)
+			}
+		}
+	}
 	delete(s.podNamespaceNsToPodUID, request.PodMeta.Namespace+"/"+request.PodMeta.Name)
 	s.quotaStore.DeallocateQuota(request.WorkloadNameNamespace.Namespace, request)
 
@@ -1344,6 +1508,22 @@ func (s *GpuAllocator) Rollback(podUID string) error {
 		"vram", request.Request.Vram.String())
 
 	return nil
+}
+
+// clearDynamicModeIfUnusedLocked releases a Dynamic card mode lock once no
+// committed or assumed request references the GPU. Caller must hold
+// storeMutex. It returns true when the GPU status was changed.
+func (s *GpuAllocator) clearDynamicModeIfUnusedLocked(gpuName string) bool {
+	if s.isolationPolicy != tfv1.IsolationModePolicyDynamic || s.dynamicGPUHasAllocationLocked(gpuName) {
+		return false
+	}
+	gpu := s.gpuStore[types.NamespacedName{Name: gpuName}]
+	if gpu == nil || (gpu.Status.ActiveIsolationMode == "" && !gpu.Status.DynamicIsolationConflict) {
+		return false
+	}
+	gpu.Status.ActiveIsolationMode = ""
+	gpu.Status.DynamicIsolationConflict = false
+	return true
 }
 
 // IsCommitted reports whether a committed allocation exists for podUID.
@@ -1382,10 +1562,21 @@ func (s *GpuAllocator) UnreserveOrRollback(podUID string) error {
 // Caller MUST hold storeMutex.Lock.
 func (s *GpuAllocator) sweepStaleAssumedAllocationsLocked(now time.Time) int {
 	swept := 0
+	clearDynamicLocks := func(req *tfv1.AllocRequest) {
+		if req == nil || s.isolationPolicy != tfv1.IsolationModePolicyDynamic {
+			return
+		}
+		for _, gpuName := range req.GPUNames {
+			if s.clearDynamicModeIfUnusedLocked(gpuName) {
+				s.markGPUDirty(types.NamespacedName{Name: gpuName})
+			}
+		}
+	}
 	for uid, assumedReq := range s.assumedAllocation {
 		if _, committed := s.uniqueAllocation[uid]; committed {
 			delete(s.assumedAllocation, uid)
 			delete(s.assumedAllocationTimestamps, uid)
+			clearDynamicLocks(assumedReq)
 			continue
 		}
 		ts, ok := s.assumedAllocationTimestamps[uid]
@@ -1408,6 +1599,7 @@ func (s *GpuAllocator) sweepStaleAssumedAllocationsLocked(now time.Time) int {
 			}
 			delete(s.assumedAllocation, uid)
 			delete(s.assumedAllocationTimestamps, uid)
+			clearDynamicLocks(assumedReq)
 			log.FromContext(s.ctx).Info("evicted stale assumed allocation past TTL",
 				"podUID", uid, "age", now.Sub(ts), "ttl", s.assumedAllocationTTL)
 			swept++
@@ -1615,6 +1807,14 @@ func (s *GpuAllocator) Dealloc(
 		delete(s.nodeWorkerStore, nodeName)
 	}
 	delete(s.uniqueAllocation, podUID)
+	if s.isolationPolicy == tfv1.IsolationModePolicyDynamic {
+		for _, gpuName := range gpus {
+			key := types.NamespacedName{Name: gpuName}
+			if s.clearDynamicModeIfUnusedLocked(gpuName) {
+				s.markGPUDirty(key)
+			}
+		}
+	}
 	delete(s.podNamespaceNsToPodUID, podMeta.Namespace+"/"+podMeta.Name)
 	s.uniqueDeallocation[podUID] = struct{}{}
 
@@ -1629,6 +1829,22 @@ func (s *GpuAllocator) Dealloc(
 		"gpuNames", gpus,
 		"tflops", request.Request.Tflops.String(),
 		"vram", request.Request.Vram.String())
+}
+
+// dynamicGPUHasAllocationLocked reports whether any committed or assumed
+// request still references a GPU. Caller must hold storeMutex.
+func (s *GpuAllocator) dynamicGPUHasAllocationLocked(gpuName string) bool {
+	for _, req := range s.uniqueAllocation {
+		if req != nil && slices.Contains(req.GPUNames, gpuName) {
+			return true
+		}
+	}
+	for _, req := range s.assumedAllocation {
+		if req != nil && slices.Contains(req.GPUNames, gpuName) {
+			return true
+		}
+	}
+	return false
 }
 
 // AdjustAllocation applies an in-place request/limit change to an existing
@@ -2298,6 +2514,7 @@ func syncGPUMetadataAndStatusFromCluster(old *tfv1.GPU, gpu *tfv1.GPU) {
 	}
 	old.Status.Index = gpu.Status.Index
 	old.Status.IsolationMode = gpu.Status.IsolationMode
+	old.Status.IsolationPolicy = gpu.Status.IsolationPolicy
 	// Don't overwrite AllocatedPartitions as that's managed by the allocator
 }
 
@@ -2447,6 +2664,8 @@ func (s *GpuAllocator) SyncGPUsToK8s() {
 			latest.Status.Available = gpu.Status.Available
 			latest.Status.RunningApps = gpu.Status.RunningApps
 			latest.Status.AllocatedPartitions = gpu.Status.AllocatedPartitions
+			latest.Status.ActiveIsolationMode = gpu.Status.ActiveIsolationMode
+			latest.Status.DynamicIsolationConflict = gpu.Status.DynamicIsolationConflict
 
 			// Attempt to update with the latest version
 			return s.Status().Update(s.ctx, latest)
@@ -2687,6 +2906,7 @@ func (s *GpuAllocator) CheckQuotaAndFilterSingleNodePreempt(
 func (s *GpuAllocator) reconcileAllocationState() {
 	ctx := s.ctx
 	logger := log.FromContext(ctx)
+	policy := s.IsolationPolicy()
 
 	workers := &v1.PodList{}
 	if err := s.List(ctx, workers, client.MatchingLabels(map[string]string{
@@ -2696,40 +2916,16 @@ func (s *GpuAllocator) reconcileAllocationState() {
 		return
 	}
 
-	// Filter rule (authoritative-annotation invariant):
-	//   - Pod must be scheduled (NodeName != "") AND not in the deleted-and-deallocated
-	//     state (deletion timestamp set without our finalizer).
-	//   - Pod must carry a non-empty gpu-device-ids annotation. Per the architecture,
-	//     PreBind is the single point that commits a TF allocation, and PreBind only
-	//     proceeds to Bind if that annotation was successfully patched. A scheduled
-	//     worker pod WITHOUT the annotation therefore did not commit an allocation —
-	//     registering it here would falsely inflate namespace quota (the request
-	//     resources are non-zero even when GPUNames is empty).
-	workers.Items = lo.Filter(workers.Items, func(worker v1.Pod, _ int) bool {
-		scheduled := worker.Spec.NodeName != ""
-		deletedAndDeAllocated := !worker.DeletionTimestamp.IsZero() &&
-			!controllerutil.ContainsFinalizer(&worker, constants.Finalizer)
-		hasGPUAnnotation := worker.Annotations[constants.GPUDeviceIDsAnnotation] != ""
+	workers.Items = s.filterAndRegisterExistingWorkers(workers.Items)
 
-		active := scheduled && !deletedAndDeAllocated && hasGPUAnnotation
-		if !active {
-			return false
-		}
-
-		allocRequest, msg, err := s.ComposeAllocationRequest(&worker)
-		if err != nil {
-			logger.Error(err, "Failed to compose allocation request for existing worker Pod, annotation may not be valid", "pod", worker.Name, "msg", msg)
-			return false
-		}
-		s.uniqueAllocation[string(worker.UID)] = allocRequest
-		s.podNamespaceNsToPodUID[worker.Namespace+"/"+worker.Name] = string(worker.UID)
-		s.addAllocationMap(worker.Spec.NodeName, worker.ObjectMeta)
-
-		if utils.IsPodPending(&worker) {
-			s.indexAllocator.ReconcileLockState(&worker)
-		}
-		return true
-	})
+	// Dynamic migration bridge: v1 Worker Pods already carry the GPU UUIDs and
+	// workload isolation annotations. Recover their per-GPU mode lock before
+	// rebuilding resource accounting; no v1 GPU status field is required.
+	recoveredModes := make(map[types.NamespacedName]tfv1.IsolationModeType)
+	modeConflicts := make(map[types.NamespacedName]bool)
+	if policy == tfv1.IsolationModePolicyDynamic {
+		recoveredModes, modeConflicts = recoverDynamicIsolationModes(workers.Items, s.uniqueAllocation)
+	}
 
 	actualAvailableMap := make(map[types.NamespacedName]*tfv1.Resource)
 	actualRunningAppsMap := make(map[types.NamespacedName][]*tfv1.RunningAppDetail)
@@ -2740,6 +2936,15 @@ func (s *GpuAllocator) reconcileAllocationState() {
 	s.sweepStaleAssumedAllocationsLocked(time.Now())
 
 	for gpuKey, gpu := range s.gpuStore {
+		if policy == tfv1.IsolationModePolicyDynamic {
+			if modeConflicts[gpuKey] {
+				gpu.Status.ActiveIsolationMode = ""
+				gpu.Status.DynamicIsolationConflict = true
+			} else {
+				gpu.Status.ActiveIsolationMode = recoveredModes[gpuKey]
+				gpu.Status.DynamicIsolationConflict = false
+			}
+		}
 		if gpu.Status.Capacity != nil {
 			actualAvailableMap[gpuKey] = gpu.Status.Capacity.DeepCopy()
 			actualRunningAppsMap[gpuKey] = gpu.Status.RunningApps
@@ -2851,6 +3056,66 @@ func (s *GpuAllocator) reconcileAllocationState() {
 	// reconcile quota store state
 	s.quotaStore.ReconcileQuotaStore(ctx, s.uniqueAllocation)
 	log.FromContext(ctx).Info("Quota store data reconciled")
+}
+
+// filterAndRegisterExistingWorkers rebuilds the allocator's authoritative
+// worker maps from scheduled worker Pods with committed GPU annotations.
+func (s *GpuAllocator) filterAndRegisterExistingWorkers(workers []v1.Pod) []v1.Pod {
+	logger := log.FromContext(s.ctx)
+	activeWorkers := make([]v1.Pod, 0, len(workers))
+	for _, worker := range workers {
+		scheduled := worker.Spec.NodeName != ""
+		deletedAndDeAllocated := !worker.DeletionTimestamp.IsZero() &&
+			!controllerutil.ContainsFinalizer(&worker, constants.Finalizer)
+		hasGPUAnnotation := worker.Annotations[constants.GPUDeviceIDsAnnotation] != ""
+		if !scheduled || deletedAndDeAllocated || !hasGPUAnnotation {
+			continue
+		}
+
+		allocRequest, msg, err := s.ComposeAllocationRequest(&worker)
+		if err != nil {
+			logger.Error(err, "Failed to compose allocation request for existing worker Pod, annotation may not be valid", "pod", worker.Name, "msg", msg)
+			continue
+		}
+		s.uniqueAllocation[string(worker.UID)] = allocRequest
+		s.podNamespaceNsToPodUID[worker.Namespace+"/"+worker.Name] = string(worker.UID)
+		s.addAllocationMap(worker.Spec.NodeName, worker.ObjectMeta)
+		if utils.IsPodPending(&worker) {
+			s.indexAllocator.ReconcileLockState(&worker)
+		}
+		activeWorkers = append(activeWorkers, worker)
+	}
+	return activeWorkers
+}
+
+func recoverDynamicIsolationModes(
+	workers []v1.Pod,
+	allocations map[string]*tfv1.AllocRequest,
+) (map[types.NamespacedName]tfv1.IsolationModeType, map[types.NamespacedName]bool) {
+	recoveredModes := make(map[types.NamespacedName]tfv1.IsolationModeType)
+	modeConflicts := make(map[types.NamespacedName]bool)
+	for _, worker := range workers {
+		alloc := allocations[string(worker.UID)]
+		for gpuID := range strings.SplitSeq(worker.Annotations[constants.GPUDeviceIDsAnnotation], ",") {
+			gpuID = strings.TrimSpace(gpuID)
+			if gpuID == "" {
+				continue
+			}
+			key := types.NamespacedName{Name: gpuID}
+			if alloc == nil || (alloc.Isolation != tfv1.IsolationModeShared &&
+				alloc.Isolation != tfv1.IsolationModeSoft &&
+				alloc.Isolation != tfv1.IsolationModeHard) {
+				modeConflicts[key] = true
+				continue
+			}
+			if previous := recoveredModes[key]; previous != "" && previous != alloc.Isolation {
+				modeConflicts[key] = true
+				continue
+			}
+			recoveredModes[key] = alloc.Isolation
+		}
+	}
+	return recoveredModes, modeConflicts
 }
 
 func (s *GpuAllocator) startWorkerCleanUpChecker() {

--- a/internal/gpuallocator/rollback_unit_test.go
+++ b/internal/gpuallocator/rollback_unit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/quota"
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -177,6 +178,27 @@ func TestRollback(t *testing.T) {
 			assert.False(t, ok)
 		})
 
+		t.Run("swept entry releases its Dynamic mode lock", func(t *testing.T) {
+			s := newTestAllocator()
+			s.isolationPolicy = tfv1.IsolationModePolicyDynamic
+			s.assumedAllocationTTL = 10 * time.Minute
+			gpu := makeGPU("gpu-dynamic", "100", "24Gi", "100", "24Gi")
+			gpu.Status.IsolationPolicy = tfv1.IsolationModePolicyDynamic
+			gpu.Status.ActiveIsolationMode = tfv1.IsolationModeSoft
+			s.gpuStore[types.NamespacedName{Name: gpu.Name}] = gpu
+			s.assumedAllocation["stale-dynamic"] = &tfv1.AllocRequest{
+				PodMeta:               metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "stale-dynamic"},
+				WorkloadNameNamespace: tfv1.NameNamespace{Name: "wl", Namespace: "ns"},
+				GPUNames:              []string{gpu.Name},
+				Isolation:             tfv1.IsolationModeSoft,
+			}
+			s.assumedAllocationTimestamps["stale-dynamic"] = time.Now().Add(-20 * time.Minute)
+
+			swept := s.sweepStaleAssumedAllocationsLocked(time.Now())
+			assert.Equal(t, 1, swept)
+			assert.Empty(t, gpu.Status.ActiveIsolationMode)
+		})
+
 		t.Run("already-committed entry is dropped without TTL check", func(t *testing.T) {
 			s := newTestAllocator()
 			req := &tfv1.AllocRequest{
@@ -253,4 +275,160 @@ func TestRollback(t *testing.T) {
 		_, ok := s.uniqueAllocation["pod-p-uid"]
 		assert.False(t, ok)
 	})
+}
+
+func TestDynamicGangAssumptions(t *testing.T) {
+	newDynamicGPU := func() *tfv1.GPU {
+		gpu := makeGPU("gpu-1", "100", "24Gi", "100", "24Gi")
+		gpu.Status.NodeSelector = map[string]string{constants.KubernetesHostNameLabel: "node-1"}
+		gpu.Status.IsolationPolicy = tfv1.IsolationModePolicyDynamic
+		return gpu
+	}
+	newGangRequest := func(uid string, isolation tfv1.IsolationModeType) *tfv1.AllocRequest {
+		return &tfv1.AllocRequest{
+			PodMeta:               metav1.ObjectMeta{Name: uid, Namespace: "ns", UID: types.UID(uid)},
+			Request:               tfv1.Resource{Tflops: qty("10"), Vram: qty("1Gi")},
+			Limit:                 tfv1.Resource{Tflops: qty("10"), Vram: qty("1Gi")},
+			WorkloadNameNamespace: tfv1.NameNamespace{Name: "gang", Namespace: "ns"},
+			Isolation:             isolation,
+		}
+	}
+
+	t.Run("same-mode members retain the lock until the last unreserve", func(t *testing.T) {
+		s := newTestAllocator()
+		s.isolationPolicy = tfv1.IsolationModePolicyDynamic
+		gpu := newDynamicGPU()
+		s.gpuStore[types.NamespacedName{Name: gpu.Name}] = gpu
+
+		assert.NoError(t, s.Assume([]string{gpu.Name}, newGangRequest("gang-1", tfv1.IsolationModeSoft)))
+		assert.Equal(t, tfv1.IsolationModeType(tfv1.IsolationModeSoft), gpu.Status.ActiveIsolationMode)
+		assert.NoError(t, s.Assume([]string{gpu.Name}, newGangRequest("gang-2", tfv1.IsolationModeSoft)))
+
+		assert.NoError(t, s.UnreserveOrRollback("gang-1"))
+		assert.Equal(t, tfv1.IsolationModeType(tfv1.IsolationModeSoft), gpu.Status.ActiveIsolationMode,
+			"the remaining gang assumption must retain the GPU mode lock")
+
+		assert.NoError(t, s.UnreserveOrRollback("gang-2"))
+		assert.Empty(t, gpu.Status.ActiveIsolationMode,
+			"the final gang unreserve must release the GPU mode lock")
+	})
+
+	t.Run("different-mode member cannot reserve a locked GPU", func(t *testing.T) {
+		s := newTestAllocator()
+		s.isolationPolicy = tfv1.IsolationModePolicyDynamic
+		gpu := newDynamicGPU()
+		s.gpuStore[types.NamespacedName{Name: gpu.Name}] = gpu
+
+		assert.NoError(t, s.Assume([]string{gpu.Name}, newGangRequest("gang-soft", tfv1.IsolationModeSoft)))
+		err := s.Assume([]string{gpu.Name}, newGangRequest("gang-hard", tfv1.IsolationModeHard))
+		assert.ErrorContains(t, err, "locked to isolation mode soft")
+	})
+}
+
+func TestIsolationPolicyCompatibility(t *testing.T) {
+	gpu := func(policy tfv1.IsolationModePolicyType, runtimeMode, activeMode tfv1.IsolationModeType, conflict bool) *tfv1.GPU {
+		return &tfv1.GPU{Status: tfv1.GPUStatus{
+			IsolationPolicy:          policy,
+			IsolationMode:            runtimeMode,
+			ActiveIsolationMode:      activeMode,
+			DynamicIsolationConflict: conflict,
+		}}
+	}
+
+	tests := []struct {
+		name      string
+		expected  tfv1.IsolationModePolicyType
+		gpu       *tfv1.GPU
+		requested tfv1.IsolationModeType
+		want      bool
+	}{
+		{name: "Static accepts legacy empty policy", expected: tfv1.IsolationModePolicyStatic, gpu: gpu("", tfv1.IsolationModeSoft, "", false), requested: tfv1.IsolationModeSoft, want: true},
+		{name: "Static rejects Dynamic GPU", expected: tfv1.IsolationModePolicyStatic, gpu: gpu(tfv1.IsolationModePolicyDynamic, "", "", false), requested: tfv1.IsolationModeSoft, want: false},
+		{name: "Static rejects runtime mode mismatch", expected: tfv1.IsolationModePolicyStatic, gpu: gpu(tfv1.IsolationModePolicyStatic, tfv1.IsolationModeHard, "", false), requested: tfv1.IsolationModeSoft, want: false},
+		{name: "Dynamic accepts idle Dynamic GPU", expected: tfv1.IsolationModePolicyDynamic, gpu: gpu(tfv1.IsolationModePolicyDynamic, "", "", false), requested: tfv1.IsolationModeHard, want: true},
+		{name: "Dynamic accepts matching active mode", expected: tfv1.IsolationModePolicyDynamic, gpu: gpu(tfv1.IsolationModePolicyDynamic, "", tfv1.IsolationModeSoft, false), requested: tfv1.IsolationModeSoft, want: true},
+		{name: "Dynamic rejects missing advertised policy", expected: tfv1.IsolationModePolicyDynamic, gpu: gpu("", "", "", false), requested: tfv1.IsolationModeSoft, want: false},
+		{name: "Dynamic rejects conflicting active mode", expected: tfv1.IsolationModePolicyDynamic, gpu: gpu(tfv1.IsolationModePolicyDynamic, "", tfv1.IsolationModeHard, false), requested: tfv1.IsolationModeSoft, want: false},
+		{name: "Dynamic rejects recovered conflict", expected: tfv1.IsolationModePolicyDynamic, gpu: gpu(tfv1.IsolationModePolicyDynamic, "", "", true), requested: tfv1.IsolationModeSoft, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isGPUIsolationCompatible(tt.expected, tt.gpu, tt.requested))
+		})
+	}
+}
+
+func TestAssumeRevalidatesAdvertisedIsolationPolicy(t *testing.T) {
+	newRequest := func(uid string) *tfv1.AllocRequest {
+		return &tfv1.AllocRequest{
+			PodMeta:               metav1.ObjectMeta{Name: uid, Namespace: "ns", UID: types.UID(uid)},
+			Request:               tfv1.Resource{Tflops: qty("10"), Vram: qty("1Gi")},
+			Limit:                 tfv1.Resource{Tflops: qty("10"), Vram: qty("1Gi")},
+			WorkloadNameNamespace: tfv1.NameNamespace{Name: "wl", Namespace: "ns"},
+			Isolation:             tfv1.IsolationModeSoft,
+		}
+	}
+
+	t.Run("Static scheduler rejects Dynamic GPU", func(t *testing.T) {
+		s := newTestAllocator()
+		s.isolationPolicy = tfv1.IsolationModePolicyStatic
+		gpu := makeGPU("gpu-dynamic", "100", "24Gi", "100", "24Gi")
+		gpu.Status.IsolationPolicy = tfv1.IsolationModePolicyDynamic
+		gpu.Status.NodeSelector = map[string]string{constants.KubernetesHostNameLabel: "node-1"}
+		s.gpuStore[types.NamespacedName{Name: gpu.Name}] = gpu
+
+		assert.ErrorContains(t, s.Assume([]string{gpu.Name}, newRequest("static-request")), "incompatible")
+	})
+
+	t.Run("Dynamic scheduler rejects GPU that has not advertised Dynamic", func(t *testing.T) {
+		s := newTestAllocator()
+		s.isolationPolicy = tfv1.IsolationModePolicyDynamic
+		gpu := makeGPU("gpu-static", "100", "24Gi", "100", "24Gi")
+		gpu.Status.IsolationPolicy = tfv1.IsolationModePolicyStatic
+		gpu.Status.NodeSelector = map[string]string{constants.KubernetesHostNameLabel: "node-1"}
+		s.gpuStore[types.NamespacedName{Name: gpu.Name}] = gpu
+
+		assert.ErrorContains(t, s.Assume([]string{gpu.Name}, newRequest("dynamic-request")), "has not advertised Dynamic")
+	})
+}
+
+func TestRecoverDynamicIsolationModes(t *testing.T) {
+	workers := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{UID: "soft", Annotations: map[string]string{constants.GPUDeviceIDsAnnotation: "gpu-soft"}}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "hard", Annotations: map[string]string{constants.GPUDeviceIDsAnnotation: "gpu-hard"}}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "partitioned", Annotations: map[string]string{constants.GPUDeviceIDsAnnotation: "gpu-partitioned"}}},
+		{ObjectMeta: metav1.ObjectMeta{UID: "conflicting", Annotations: map[string]string{constants.GPUDeviceIDsAnnotation: "gpu-soft"}}},
+	}
+	allocations := map[string]*tfv1.AllocRequest{
+		"soft":        {Isolation: tfv1.IsolationModeSoft},
+		"hard":        {Isolation: tfv1.IsolationModeHard},
+		"partitioned": {Isolation: tfv1.IsolationModePartitioned},
+		"conflicting": {Isolation: tfv1.IsolationModeHard},
+	}
+
+	modes, conflicts := recoverDynamicIsolationModes(workers, allocations)
+	assert.Equal(t, tfv1.IsolationModeType(tfv1.IsolationModeSoft), modes[types.NamespacedName{Name: "gpu-soft"}])
+	assert.Equal(t, tfv1.IsolationModeType(tfv1.IsolationModeHard), modes[types.NamespacedName{Name: "gpu-hard"}])
+	assert.True(t, conflicts[types.NamespacedName{Name: "gpu-soft"}])
+	assert.True(t, conflicts[types.NamespacedName{Name: "gpu-partitioned"}])
+}
+
+func TestSyncGPUMetadataPreservesSchedulerOwnedDynamicStatus(t *testing.T) {
+	old := &tfv1.GPU{Status: tfv1.GPUStatus{
+		IsolationPolicy:          tfv1.IsolationModePolicyDynamic,
+		ActiveIsolationMode:      tfv1.IsolationModeSoft,
+		DynamicIsolationConflict: true,
+	}}
+	incoming := &tfv1.GPU{Status: tfv1.GPUStatus{
+		IsolationPolicy:          tfv1.IsolationModePolicyDynamic,
+		ActiveIsolationMode:      tfv1.IsolationModeHard,
+		DynamicIsolationConflict: false,
+		Message:                  "managed",
+	}}
+
+	syncGPUMetadataAndStatusFromCluster(old, incoming)
+	assert.Equal(t, tfv1.IsolationModeType(tfv1.IsolationModeSoft), old.Status.ActiveIsolationMode)
+	assert.True(t, old.Status.DynamicIsolationConflict)
+	assert.Equal(t, "managed", old.Status.Message)
 }

--- a/internal/gpuallocator/shared_allocation_unit_test.go
+++ b/internal/gpuallocator/shared_allocation_unit_test.go
@@ -144,6 +144,38 @@ func TestSharedPreemptionSimulationRestoresWholeGPUOnlyForSharedVictim(t *testin
 	assert.Empty(t, filtered, "releasing one slice must not make a still-used GPU eligible for shared")
 }
 
+func TestDynamicPreemptionOnlyReusesSameModeGPU(t *testing.T) {
+	gpu := sharedTestGPU("gpu-soft-victim", "node-1", tfv1.IsolationModeSoft)
+	gpu.Status.IsolationPolicy = tfv1.IsolationModePolicyDynamic
+	gpu.Status.ActiveIsolationMode = tfv1.IsolationModeSoft
+	gpu.Status.Available = &tfv1.Resource{Tflops: qty("20"), Vram: qty("4Gi")}
+	s := newTestAllocator()
+	s.isolationPolicy = tfv1.IsolationModePolicyDynamic
+	s.gpuStore[types.NamespacedName{Name: gpu.Name}] = gpu
+	s.nodeGpuStore = map[string]map[string]*tfv1.GPU{"node-1": {gpu.Name: gpu}}
+	victim := &tfv1.AllocRequest{
+		Isolation: tfv1.IsolationModeSoft,
+		GPUNames:  []string{gpu.Name},
+		Request:   tfv1.Resource{Tflops: qty("80"), Vram: qty("20Gi")},
+	}
+	incoming := func(mode tfv1.IsolationModeType) *tfv1.AllocRequest {
+		return &tfv1.AllocRequest{
+			Isolation: mode,
+			Count:     1,
+			Request:   tfv1.Resource{Tflops: qty("90"), Vram: qty("22Gi")},
+		}
+	}
+
+	filtered, _, err := s.FilterWithPreempt(incoming(tfv1.IsolationModeSoft), []*tfv1.AllocRequest{victim})
+	assert.NoError(t, err)
+	assert.Len(t, filtered, 1, "same-mode preemption should reuse the released GPU")
+	assert.Equal(t, tfv1.IsolationModeType(tfv1.IsolationModeSoft), filtered[0].Status.ActiveIsolationMode)
+
+	filtered, _, err = s.FilterWithPreempt(incoming(tfv1.IsolationModeHard), []*tfv1.AllocRequest{victim})
+	assert.NoError(t, err)
+	assert.Empty(t, filtered, "cross-mode preemption must not change the GPU mode lock")
+}
+
 func TestCompactPlacementKeepsExistingGPUAndNodeBinpackWithoutSharedPriority(t *testing.T) {
 	usedHard := sharedTestGPU("hard-used", "node-used", tfv1.IsolationModeHard)
 	usedHard.Status.Available = &tfv1.Resource{Tflops: qty("50"), Vram: qty("12Gi")}

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -391,6 +391,13 @@ func (e *NodeExpander) prepareNewNodesForScheduleAttempt(
 		gpuCopy := gpu.DeepCopy()
 		gpuCopy.Name = "gpu-" + rand.String(12)
 		gpuCopy.Status.Available = gpuCopy.Status.Capacity.DeepCopy()
+		gpuCopy.Status.IsolationPolicy = e.allocator.IsolationPolicy()
+		gpuCopy.Status.ActiveIsolationMode = ""
+		gpuCopy.Status.DynamicIsolationConflict = false
+		if gpuCopy.Status.NodeSelector == nil {
+			gpuCopy.Status.NodeSelector = make(map[string]string, 1)
+		}
+		gpuCopy.Status.NodeSelector[constants.KubernetesHostNameLabel] = newPreparedNode.Name
 		newPreparedGPUs = append(newPreparedGPUs, gpuCopy)
 	}
 	return newPreparedNode, newPreparedGPUs
@@ -456,23 +463,7 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 	e.mu.RUnlock()
 
 	for _, alloc := range preScheduleSnapshot {
-		preScheduledPodPreAllocated := false
-		for _, gpu := range inflightSnapshot {
-			if gpu == nil || gpu.Status.Capacity == nil || gpu.Status.Available == nil {
-				continue
-			}
-			reqTflops := alloc.Request.Tflops
-			if !alloc.Request.ComputePercent.IsZero() {
-				reqTflops = *utils.ComputePercentToTflops(gpu.Status.Capacity.Tflops, alloc.Request)
-			}
-			if gpu.Status.Available.Tflops.Cmp(reqTflops) >= 0 &&
-				gpu.Status.Available.Vram.Cmp(alloc.Request.Vram) >= 0 {
-				gpu.Status.Available.Tflops.Sub(reqTflops)
-				gpu.Status.Available.Vram.Sub(alloc.Request.Vram)
-				preScheduledPodPreAllocated = true
-				break
-			}
-		}
+		preScheduledPodPreAllocated := applyPreScheduledAllocationToInflightGPUs(e.allocator, alloc, inflightSnapshot)
 		// this is unexpected, all pre-scheduled pod should be able to place into inFlight node
 		// possible happen when new node added to cluster and removed from inFlight nodes, simultaneously,
 		// new Pods added and also unschedulable, trigger node expansion before previous Pod scheduled
@@ -532,6 +523,74 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 		}
 	}
 	return allocRequest, true, false, onlyCanBeFlightGPU
+}
+
+func applyPreScheduledAllocationToInflightGPUs(
+	allocator *gpuallocator.GpuAllocator,
+	alloc *tfv1.AllocRequest,
+	inflight map[string]*tfv1.GPU,
+) bool {
+	if allocator == nil || alloc == nil {
+		return false
+	}
+	working := make(map[string]*tfv1.GPU, len(inflight))
+	for name, gpu := range inflight {
+		if gpu != nil {
+			working[name] = gpu.DeepCopy()
+		}
+	}
+
+	remaining := int(alloc.Count)
+	if remaining < 1 {
+		remaining = 1
+	}
+	for _, gpu := range working {
+		if remaining == 0 {
+			break
+		}
+		if gpu.Status.Capacity == nil || gpu.Status.Available == nil ||
+			!allocator.IsGPUIsolationCompatible(gpu, alloc.Isolation) {
+			continue
+		}
+
+		if alloc.Isolation == tfv1.IsolationModeShared {
+			if len(gpu.Status.AllocatedPartitions) > 0 ||
+				gpu.Status.Available.Tflops.Cmp(gpu.Status.Capacity.Tflops) != 0 ||
+				gpu.Status.Available.Vram.Cmp(gpu.Status.Capacity.Vram) != 0 {
+				continue
+			}
+			gpu.Status.Available.Tflops = resource.Quantity{}
+			gpu.Status.Available.Vram = resource.Quantity{}
+		} else {
+			reqTflops := alloc.Request.Tflops
+			if !alloc.Request.ComputePercent.IsZero() {
+				reqTflops = *utils.ComputePercentToTflops(gpu.Status.Capacity.Tflops, alloc.Request)
+			}
+			if gpu.Status.Available.Tflops.Cmp(reqTflops) < 0 ||
+				gpu.Status.Available.Vram.Cmp(alloc.Request.Vram) < 0 {
+				continue
+			}
+			gpu.Status.Available.Tflops.Sub(reqTflops)
+			gpu.Status.Available.Vram.Sub(alloc.Request.Vram)
+		}
+		if allocator.IsolationPolicy() == tfv1.IsolationModePolicyDynamic && gpu.Status.ActiveIsolationMode == "" {
+			gpu.Status.ActiveIsolationMode = alloc.Isolation
+		}
+		remaining--
+	}
+	if remaining != 0 {
+		return false
+	}
+
+	for name, gpu := range working {
+		original := inflight[name]
+		if original == nil {
+			continue
+		}
+		original.Status.Available = gpu.Status.Available.DeepCopy()
+		original.Status.ActiveIsolationMode = gpu.Status.ActiveIsolationMode
+	}
+	return true
 }
 
 func (e *NodeExpander) checkGPUFitForNewNode(pod *corev1.Pod, gpus []*tfv1.GPU) bool {

--- a/internal/scheduler/expander/handler_test.go
+++ b/internal/scheduler/expander/handler_test.go
@@ -761,3 +761,95 @@ func createTestTensorFusionPod(name, namespace, tflops, vram string) *corev1.Pod
 
 	return pod
 }
+
+func TestDynamicInflightPreSchedulingRespectsModeAndCount(t *testing.T) {
+	if err := tfv1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	allocator := gpuallocator.NewGpuAllocator(context.Background(), nil,
+		fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(), time.Second)
+	allocator.SetIsolationPolicy(tfv1.IsolationModePolicyDynamic)
+	inflight := map[string]*tfv1.GPU{
+		"gpu-0": createTestGPU("gpu-0", "future-node", "100", "10Gi"),
+		"gpu-1": createTestGPU("gpu-1", "future-node", "100", "10Gi"),
+		"gpu-2": createTestGPU("gpu-2", "future-node", "100", "10Gi"),
+	}
+	for _, gpu := range inflight {
+		gpu.Status.IsolationPolicy = tfv1.IsolationModePolicyDynamic
+	}
+
+	soft := &tfv1.AllocRequest{
+		Count:     2,
+		Isolation: tfv1.IsolationModeSoft,
+		Request: tfv1.Resource{
+			Tflops: resource.MustParse("25"),
+			Vram:   resource.MustParse("2Gi"),
+		},
+	}
+	if !applyPreScheduledAllocationToInflightGPUs(allocator, soft, inflight) {
+		t.Fatal("expected two-GPU soft pre-scheduling to succeed")
+	}
+	softLocked := 0
+	idle := 0
+	for _, gpu := range inflight {
+		switch gpu.Status.ActiveIsolationMode {
+		case tfv1.IsolationModeSoft:
+			softLocked++
+			if got := gpu.Status.Available.Tflops.String(); got != "75" {
+				t.Fatalf("soft-allocated GPU has %s TFLOPS available, want 75", got)
+			}
+		case "":
+			idle++
+		}
+	}
+	if softLocked != 2 || idle != 1 {
+		t.Fatalf("unexpected Dynamic locks: soft=%d idle=%d", softLocked, idle)
+	}
+
+	hardTwo := &tfv1.AllocRequest{
+		Count:     2,
+		Isolation: tfv1.IsolationModeHard,
+		Request: tfv1.Resource{
+			Tflops: resource.MustParse("10"),
+			Vram:   resource.MustParse("1Gi"),
+		},
+	}
+	if applyPreScheduledAllocationToInflightGPUs(allocator, hardTwo, inflight) {
+		t.Fatal("expected hard pre-scheduling to fail when only one idle GPU remains")
+	}
+	for _, gpu := range inflight {
+		if gpu.Status.ActiveIsolationMode == tfv1.IsolationModeHard {
+			t.Fatal("failed multi-GPU pre-scheduling must not leave a partial hard lock")
+		}
+	}
+}
+
+func TestPrepareNewNodeResetsDynamicTemplateState(t *testing.T) {
+	if err := tfv1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	allocator := gpuallocator.NewGpuAllocator(context.Background(), nil,
+		fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(), time.Second)
+	allocator.SetIsolationPolicy(tfv1.IsolationModePolicyDynamic)
+	expander := &NodeExpander{allocator: allocator}
+	templateGPU := createTestGPU("gpu-template", "old-node", "100", "10Gi")
+	templateGPU.Status.IsolationPolicy = tfv1.IsolationModePolicyDynamic
+	templateGPU.Status.ActiveIsolationMode = tfv1.IsolationModeHard
+	templateGPU.Status.DynamicIsolationConflict = true
+
+	newNode, gpus := expander.prepareNewNodesForScheduleAttempt(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "old-node", Labels: map[string]string{}}},
+		map[string]*tfv1.GPU{templateGPU.Name: templateGPU},
+	)
+	if len(gpus) != 1 {
+		t.Fatalf("got %d prepared GPUs, want 1", len(gpus))
+	}
+	prepared := gpus[0]
+	if prepared.Status.IsolationPolicy != tfv1.IsolationModePolicyDynamic ||
+		prepared.Status.ActiveIsolationMode != "" || prepared.Status.DynamicIsolationConflict {
+		t.Fatalf("prepared GPU retained stale Dynamic state: %#v", prepared.Status)
+	}
+	if got := prepared.Status.NodeSelector[constants.KubernetesHostNameLabel]; got != newNode.Name {
+		t.Fatalf("prepared GPU hostname = %q, want %q", got, newNode.Name)
+	}
+}

--- a/internal/scheduler/expander/unsched_queue.go
+++ b/internal/scheduler/expander/unsched_queue.go
@@ -9,6 +9,8 @@ import (
 	"github.com/NexusGPU/tensor-fusion/internal/utils"
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -138,7 +140,13 @@ func (h *UnscheduledPodHandler) processQueuedPod(qp *queuedPod) {
 		}
 	}
 
-	if err := h.nodeExpander.ProcessExpansion(h.ctx, qp.pod); err != nil {
+	currentPod, proceed := h.currentPodForExpansion(qp.pod)
+	if !proceed {
+		h.removePendingPod(qp.pod)
+		return
+	}
+
+	if err := h.nodeExpander.ProcessExpansion(h.ctx, currentPod); err != nil {
 		h.logger.Error(err, "Failed to process node expansion after buffer",
 			"pod", klog.KObj(qp.pod))
 	} else {
@@ -146,6 +154,31 @@ func (h *UnscheduledPodHandler) processQueuedPod(qp *queuedPod) {
 			"pod", klog.KObj(qp.pod))
 	}
 	h.removePendingPod(qp.pod)
+}
+
+func (h *UnscheduledPodHandler) currentPodForExpansion(queuedPod *corev1.Pod) (*corev1.Pod, bool) {
+	currentPod := &corev1.Pod{}
+	err := h.nodeExpander.client.Get(h.ctx, types.NamespacedName{
+		Namespace: queuedPod.Namespace,
+		Name:      queuedPod.Name,
+	}, currentPod)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			h.logger.Error(err, "Failed to refresh pod before node expansion", "pod", klog.KObj(queuedPod))
+		}
+		return nil, false
+	}
+
+	if currentPod.UID != queuedPod.UID || currentPod.Spec.NodeName != "" ||
+		!currentPod.DeletionTimestamp.IsZero() || currentPod.Status.NominatedNodeName != "" {
+		h.logger.V(4).Info("Pod no longer requires node expansion",
+			"pod", klog.KObj(currentPod),
+			"node", currentPod.Spec.NodeName,
+			"nominatedNode", currentPod.Status.NominatedNodeName)
+		return nil, false
+	}
+
+	return currentPod, true
 }
 
 // removePendingPod removes a pod from the pending map

--- a/internal/scheduler/expander/unsched_queue_test.go
+++ b/internal/scheduler/expander/unsched_queue_test.go
@@ -3,18 +3,42 @@ package expander
 import (
 	"context"
 	"sync"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 )
+
+func TestCurrentPodForExpansionUsesLiveNominatedState(t *testing.T) {
+	queuedPod := createTensorFusionWorkerPod("worker-pod", "uid-nominated")
+	currentPod := queuedPod.DeepCopy()
+	currentPod.Status.NominatedNodeName = "node-a"
+
+	handler := &UnscheduledPodHandler{
+		ctx:    context.Background(),
+		logger: log.FromContext(context.Background()),
+		nodeExpander: &NodeExpander{client: clientfake.NewClientBuilder().
+			WithScheme(clientgoscheme.Scheme).
+			WithObjects(currentPod).
+			Build()},
+	}
+
+	refreshed, proceed := handler.currentPodForExpansion(queuedPod)
+
+	require.Nil(t, refreshed)
+	require.False(t, proceed)
+}
 
 // createTestPod creates a test pod with configurable labels
 func createTestPod(name, namespace string, uid types.UID, labels map[string]string, nodeName string) *corev1.Pod {

--- a/internal/scheduler/gpuresources/gpuresources.go
+++ b/internal/scheduler/gpuresources/gpuresources.go
@@ -277,6 +277,9 @@ func (s *GPUFit) PreFilter(ctx context.Context, state fwk.CycleState, pod *v1.Po
 		// range if it's not in validNodesValidGPUs, add to validNodeNonMatchingGPUs
 		validNodeNonMatchingGPUs[k] = make([]*tfv1.GPU, 0, preAllocSize)
 		for gpuName, gpu := range allGPUs {
+			if !s.allocator.IsGPUIsolationCompatible(gpu, allocRequest.Isolation) {
+				continue
+			}
 			seen := false
 			// just loop because the number always <= 8/16
 			for _, matchedGPU := range matchedGPUs {
@@ -421,10 +424,6 @@ func (s *GPUFit) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, 
 
 // checkNominatedPodsGPUReservation checks if there are nominated TensorFusion pods
 // on this node and reserves their resources to prevent scheduling conflicts.
-// Strategy:
-// - Only **higher** priority nominated pods will have their resources reserved
-// - Equal or lower priority nominated pods are ignored (current pod has equal/higher right)
-// - Current pod can be scheduled if remaining resources (after reservation) are sufficient
 func (s *GPUFit) checkNominatedPodsGPUReservation(pod *v1.Pod, nodeName string, schedulingData *GPUSchedulingStateData) *fwk.Status {
 	nominatedPodInfos := s.fh.NominatedPodsForNode(nodeName)
 	if len(nominatedPodInfos) == 0 {
@@ -473,10 +472,8 @@ func (s *GPUFit) checkNominatedPodsGPUReservation(pod *v1.Pod, nodeName string, 
 			nominatedPodPriority = *nominatedPod.Spec.Priority
 		}
 
-		// Only reserve resources for higher priority nominated pods
-		// Equal or lower priority pods should not block the current pod
-		if nominatedPodPriority <= currentPodPriority {
-			s.logger.V(4).Info("Skipping equal/lower priority nominated pod (no reservation needed)",
+		if !shouldReserveForNominatedPod(pod, nominatedPod) {
+			s.logger.V(4).Info("Skipping nominated pod resource reservation",
 				"currentPod", pod.Name,
 				"nominatedPod", nominatedPod.Name,
 				"nominatedPriority", nominatedPodPriority,
@@ -492,7 +489,6 @@ func (s *GPUFit) checkNominatedPodsGPUReservation(pod *v1.Pod, nodeName string, 
 			continue
 		}
 
-		// Reserve resources for higher priority nominated pods
 		// Calculate total resources needed (multiply by GPU count for multi-GPU pods)
 		// Handle both Tflops and ComputePercent (use GPU capacity to convert)
 		var nominatedTflopsPerGPU *resource.Quantity
@@ -511,7 +507,7 @@ func (s *GPUFit) checkNominatedPodsGPUReservation(pod *v1.Pod, nodeName string, 
 		nominatedVramTotal.Mul(int64(nominatedAllocReq.Count))
 		reservedVram.Add(nominatedVramTotal)
 
-		s.logger.V(4).Info("Reserving GPU resources for higher priority nominated pod",
+		s.logger.V(4).Info("Reserving GPU resources for nominated pod",
 			"currentPod", pod.Name,
 			"nominatedPod", nominatedPod.Name,
 			"nominatedPriority", nominatedPodPriority,
@@ -568,10 +564,32 @@ func (s *GPUFit) checkNominatedPodsGPUReservation(pod *v1.Pod, nodeName string, 
 			"requiredVram", currentVramTotal.String(),
 			"currentGPUCount", currentAllocReq.Count)
 		return fwk.NewStatus(fwk.Unschedulable,
-			fmt.Sprintf("GPU resources reserved for higher priority nominated pods on node %s", nodeName))
+			fmt.Sprintf("GPU resources reserved for nominated pods on node %s", nodeName))
 	}
 
 	return fwk.NewStatus(fwk.Success, "")
+}
+
+func shouldReserveForNominatedPod(currentPod, nominatedPod *v1.Pod) bool {
+	currentPriority := int32(0)
+	if currentPod.Spec.Priority != nil {
+		currentPriority = *currentPod.Spec.Priority
+	}
+	nominatedPriority := int32(0)
+	if nominatedPod.Spec.Priority != nil {
+		nominatedPriority = *nominatedPod.Spec.Priority
+	}
+
+	if nominatedPriority > currentPriority {
+		return true
+	}
+	if nominatedPriority != currentPriority {
+		return false
+	}
+
+	currentGroup := currentPod.Annotations[constants.GangGroupKeyAnnotation]
+	nominatedGroup := nominatedPod.Annotations[constants.GangGroupKeyAnnotation]
+	return currentGroup != "" && currentGroup == nominatedGroup
 }
 
 func (s *GPUFit) Score(
@@ -735,6 +753,10 @@ func (s *GPUFit) PostFilter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, 
 		// Non-gang TensorFusion pod — nothing to do at the group level; let the
 		// framework continue with default unschedulable handling.
 		return nil, fwk.NewStatus(fwk.Unschedulable, "non-gang pod, no group action")
+	}
+	if pod.Status.NominatedNodeName != "" {
+		return nil, fwk.NewStatus(fwk.Unschedulable,
+			fmt.Sprintf("gang member is waiting for preemption on nominated node %s", pod.Status.NominatedNodeName))
 	}
 
 	// Distinguish PreFilter-stage failure (peers not yet present → transient,

--- a/internal/scheduler/gpuresources/prefilter_gang_no_pool_slot_check_test.go
+++ b/internal/scheduler/gpuresources/prefilter_gang_no_pool_slot_check_test.go
@@ -22,6 +22,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
+	fwk "k8s.io/kube-scheduler/framework"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
@@ -30,6 +31,8 @@ import (
 	tffwk "k8s.io/kubernetes/pkg/scheduler/testing/framework"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+const testGangNodeName = "node-a"
 
 // TestPreFilterDoesNotPoolSlotRejectGangAcrossIsolationModes is the regression
 // guard for the removed `checkGangPoolFeasibility` shortcut.
@@ -65,12 +68,12 @@ func TestPreFilterDoesNotPoolSlotRejectGangAcrossIsolationModes(t *testing.T) {
 					Name: "gpu-1",
 					Labels: map[string]string{
 						constants.GpuPoolKey:    poolName,
-						constants.LabelKeyOwner: "node-a",
+						constants.LabelKeyOwner: testGangNodeName,
 					},
 				},
 				Status: tfv1.GPUStatus{
 					Phase:        tfv1.TensorFusionGPUPhaseRunning,
-					NodeSelector: map[string]string{constants.KubernetesHostNameLabel: "node-a"},
+					NodeSelector: map[string]string{constants.KubernetesHostNameLabel: testGangNodeName},
 					UsedBy:       tfv1.UsedByTensorFusion,
 					Capacity:     &tfv1.Resource{Tflops: resource.MustParse("1000"), Vram: resource.MustParse("80Gi")},
 					Available:    &tfv1.Resource{Tflops: resource.MustParse("1000"), Vram: resource.MustParse("80Gi")},
@@ -133,6 +136,50 @@ func TestPreFilterDoesNotPoolSlotRejectGangAcrossIsolationModes(t *testing.T) {
 				require.NotContains(t, msg, "gang requires", "PreFilter must not reject on physical-GPU-count grounds for mode %s", mode)
 				require.NotContains(t, msg, "slot", "PreFilter must not reject on physical-GPU-count grounds for mode %s", mode)
 			}
+		})
+	}
+}
+
+func TestPostFilterDefersStrictRejectForNominatedGangPod(t *testing.T) {
+	manager := gang.NewManager(nil, nil, Name)
+	pod := makeGangPeerPod("ns1", "wl1", "ns1/wl1", tfv1.IsolationModeSoft, 2, 0)
+	pod.Status.NominatedNodeName = testGangNodeName
+	plugin := &GPUFit{gangManager: manager}
+
+	_, status := plugin.PostFilter(context.Background(), framework.NewCycleState(), pod, nil)
+
+	require.Equal(t, fwk.Unschedulable, status.Code())
+	require.Contains(t, status.Message(), "waiting for preemption on nominated node node-a")
+	require.NoError(t, manager.PreEnqueue(context.Background(), pod), "nominated pod must not put the gang into backoff")
+}
+
+func TestShouldReserveForNominatedPod(t *testing.T) {
+	priority := func(value int32) *int32 { return &value }
+	gangPod := func(priorityValue int32, group string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				constants.GangGroupKeyAnnotation: group,
+			}},
+			Spec: corev1.PodSpec{Priority: priority(priorityValue)},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		current   *corev1.Pod
+		nominated *corev1.Pod
+		want      bool
+	}{
+		{name: "higher priority", current: gangPod(50, "ns/gang-a"), nominated: gangPod(100, ""), want: true},
+		{name: "lower priority", current: gangPod(100, "ns/gang-a"), nominated: gangPod(50, "ns/gang-a"), want: false},
+		{name: "equal priority unrelated", current: gangPod(100, "ns/gang-a"), nominated: gangPod(100, "ns/gang-b"), want: false},
+		{name: "equal priority without gang", current: gangPod(100, ""), nominated: gangPod(100, ""), want: false},
+		{name: "equal priority same gang", current: gangPod(100, "ns/gang-a"), nominated: gangPod(100, "ns/gang-a"), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldReserveForNominatedPod(tt.current, tt.nominated))
 		})
 	}
 }

--- a/internal/scheduler/gputopo/gpu_network_topo.go
+++ b/internal/scheduler/gputopo/gpu_network_topo.go
@@ -260,7 +260,7 @@ func (s *GPUNetworkTopologyAware) Filter(ctx context.Context, state fwk.CycleSta
 	if !plan.ModeSatisfied {
 		return fwk.NewStatus(fwk.Unschedulable,
 			fmt.Sprintf("GPU topology constraint not satisfied: %s (tier=%d, maxAllowed=%d)",
-				plan.Reason, plan.Tier, s.cfg.GetMaxAllowedTier()))
+				plan.Reason, plan.Tier, maxTier))
 	}
 
 	return fwk.NewStatus(fwk.Success, "")

--- a/internal/scheduler/gputopo/gpu_network_topo_mode_test.go
+++ b/internal/scheduler/gputopo/gpu_network_topo_mode_test.go
@@ -1,11 +1,56 @@
 package scheduler
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/NexusGPU/tensor-fusion/internal/config"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fwk "k8s.io/kube-scheduler/framework"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
+
+func TestFilterUsesPerPodMaxTierInDiagnostic(t *testing.T) {
+	plugin := &GPUNetworkTopologyAware{
+		cfg: &config.GPUNetworkTopologyAwareConfig{
+			Mode:           TopologyModeHard,
+			TopologySource: TopologySourceAuto,
+			MaxAllowedTier: 1,
+		},
+	}
+	state := framework.NewCycleState()
+	state.Write(CycleStateGPUTopologyResult, &GPUTopologyStateData{
+		Plans: map[string]*NodeTopologyPlan{
+			"node-a": {
+				Tier:          TierSameNUMA,
+				ModeSatisfied: false,
+				Reason:        "test topology",
+			},
+		},
+	})
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.LabelComponent: constants.ComponentWorker},
+			Annotations: map[string]string{
+				AnnotationRequireTopology: AnnotationBoolTrue,
+				AnnotationTopologyMaxTier: "0",
+			},
+		},
+	}
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+
+	status := plugin.Filter(context.Background(), state, pod, nodeInfo)
+	if status.Code() != fwk.Unschedulable {
+		t.Fatalf("Filter() code = %v, want Unschedulable", status.Code())
+	}
+	if want := "maxAllowed=0"; !strings.Contains(status.Message(), want) {
+		t.Fatalf("Filter() message = %q, want %q", status.Message(), want)
+	}
+}
 
 func TestResolvePerPodConfig_DefaultsToSoftWithoutAnnotation(t *testing.T) {
 	plugin := &GPUNetworkTopologyAware{

--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -1449,8 +1449,24 @@ func SetWorkerContainerSpec(
 // includes every ProviderConfig revision so a provider change starts the
 // existing GPUPool batched update state machine.
 func HypervisorTemplateHash(pool *tfv1.GPUPool) string {
+	return hypervisorTemplateHash(pool, true)
+}
+
+// HypervisorTemplateHashWithPolicy computes the pool component hash while
+// honoring the isolation policy. Dynamic policy deliberately excludes static
+// node isolation rules: those rules do not select the Hypervisor process mode
+// and changing them must not trigger a rollout.
+func HypervisorTemplateHashWithPolicy(pool *tfv1.GPUPool, policy tfv1.IsolationModePolicyType) string {
+	return hypervisorTemplateHash(pool, policy != tfv1.IsolationModePolicyDynamic)
+}
+
+func hypervisorTemplateHash(pool *tfv1.GPUPool, includeNodeIsolation bool) string {
 	spec := hypervisorTemplateSpec(pool)
 	revisions := ProviderConfigRevisions(pool)
+	var nodeIsolationPolicy string
+	if includeNodeIsolation {
+		nodeIsolationPolicy = NodeIsolationPolicyHash(pool.Spec.NodeManagerConfig)
+	}
 	return GetObjectHash(struct {
 		Spec                v1.PodSpec
 		ProviderRevisions   map[string]string
@@ -1458,7 +1474,7 @@ func HypervisorTemplateHash(pool *tfv1.GPUPool) string {
 	}{
 		Spec:                spec,
 		ProviderRevisions:   revisions,
-		NodeIsolationPolicy: NodeIsolationPolicyHash(pool.Spec.NodeManagerConfig),
+		NodeIsolationPolicy: nodeIsolationPolicy,
 	})
 }
 

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -1,7 +1,10 @@
 package constants
 
 // Controller itself envs
-const NamespaceEnv = "OPERATOR_NAMESPACE"
+const (
+	NamespaceEnv           = "OPERATOR_NAMESPACE"
+	IsolationModePolicyEnv = "TF_ISOLATION_MODE_POLICY"
+)
 
 // Scheduler preemption: when PreemptClusterWideFromEnv is enabled, effective value is read from this env.
 // "true" = cluster-wide preemption; "false" = same-tenant (same namespace) only.

--- a/pkg/hypervisor/api/device_types.go
+++ b/pkg/hypervisor/api/device_types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package api
 
+import tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+
 // DeviceInfo represents discovered GPU device information
 // +k8s:deepcopy-gen=true
 type DeviceInfo struct {
@@ -40,7 +42,8 @@ type DeviceInfo struct {
 	// Env to inject to guest
 	DeviceEnv map[string]string
 
-	IsolationMode IsolationMode
+	IsolationMode   IsolationMode
+	IsolationPolicy tfv1.IsolationModePolicyType
 }
 
 // DeviceTopology represents normalized topology metadata for a device.

--- a/pkg/hypervisor/backend/kubernetes/kubernetes_backend.go
+++ b/pkg/hypervisor/backend/kubernetes/kubernetes_backend.go
@@ -359,6 +359,7 @@ func (b *KubeletBackend) mutateGPUResourceState(
 	gpu.Status.NUMANode = ptr.To(device.NUMANode)
 	gpu.Status.Topology = convertDeviceTopologyToStatus(device.Topology)
 	gpu.Status.IsolationMode = device.IsolationMode
+	gpu.Status.IsolationPolicy = device.IsolationPolicy
 	gpu.Status.NodeSelector = map[string]string{
 		constants.KubernetesHostNameLabel: b.nodeName,
 	}

--- a/pkg/hypervisor/device/controller.go
+++ b/pkg/hypervisor/device/controller.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/pkg/hypervisor/api"
 	"github.com/NexusGPU/tensor-fusion/pkg/hypervisor/framework"
 	"github.com/NexusGPU/tensor-fusion/pkg/hypervisor/metrics"
@@ -31,6 +32,7 @@ type Controller struct {
 	discoveryInterval    time.Duration
 	deviceUpdateHandlers []framework.DeviceChangeHandler
 	isolationMode        api.IsolationMode
+	isolationPolicy      tfv1.IsolationModePolicyType
 
 	// allocationController is set after creation to provide allocation data for telemetry
 	allocationController framework.WorkerAllocationController
@@ -60,9 +62,19 @@ func NewController(
 		discoveryInterval:    discoveryInterval,
 		deviceUpdateHandlers: make([]framework.DeviceChangeHandler, 2),
 		isolationMode:        api.IsolationMode(isolationMode),
+		isolationPolicy:      tfv1.IsolationModePolicyStatic,
 	}
 
 	return ctrl, nil
+}
+
+func (m *Controller) SetIsolationPolicy(policy tfv1.IsolationModePolicyType) {
+	if policy != tfv1.IsolationModePolicyDynamic {
+		policy = tfv1.IsolationModePolicyStatic
+	}
+	m.mu.Lock()
+	m.isolationPolicy = policy
+	m.mu.Unlock()
 }
 
 // SetAllocationController sets the allocation controller for telemetry purposes
@@ -103,6 +115,7 @@ func (m *Controller) discoverDevices() error {
 		// Kubernetes resource name has to be lowercase
 		device.UUID = strings.ToLower(device.UUID)
 		device.IsolationMode = m.isolationMode
+		device.IsolationPolicy = m.isolationPolicy
 		newDevicesMap[device.UUID] = device
 		newNativeUUIDs[device.UUID] = nativeUUID
 	}

--- a/pkg/hypervisor/framework/framework.go
+++ b/pkg/hypervisor/framework/framework.go
@@ -1,8 +1,6 @@
 package framework
 
-import (
-	"github.com/NexusGPU/tensor-fusion/pkg/hypervisor/api"
-)
+import "github.com/NexusGPU/tensor-fusion/pkg/hypervisor/api"
 
 type DeviceController interface {
 	Start() error
@@ -44,7 +42,7 @@ type WorkerAllocationController interface {
 
 	// RecoverPartitionedWorker rebuilds allocation state for an existing partitioned worker
 	// after hypervisor restart. partitionUUIDs is a comma-separated string of "partitionUUID:parentGPU" pairs.
-	RecoverPartitionedWorker(request *api.WorkerInfo, partitionUUIDs string)
+	RecoverPartitionedWorker(request *api.WorkerInfo, partitionUUIDs string) error
 
 	// GetWorkerAllocation returns the allocation for a specific worker
 	GetWorkerAllocation(workerUID string) (*api.WorkerAllocation, bool)

--- a/pkg/hypervisor/server/handlers/legacy_test.go
+++ b/pkg/hypervisor/server/handlers/legacy_test.go
@@ -48,7 +48,8 @@ func (f *fakeAllocationController) AllocateWorkerDevices(
 
 func (f *fakeAllocationController) DeallocateWorker(workerUID string) error { return nil }
 
-func (f *fakeAllocationController) RecoverPartitionedWorker(request *hyperapi.WorkerInfo, partitionUUIDs string) {
+func (f *fakeAllocationController) RecoverPartitionedWorker(request *hyperapi.WorkerInfo, partitionUUIDs string) error {
+	return nil
 }
 
 func (f *fakeAllocationController) GetWorkerAllocation(workerUID string) (*hyperapi.WorkerAllocation, bool) {

--- a/pkg/hypervisor/worker/allocation.go
+++ b/pkg/hypervisor/worker/allocation.go
@@ -21,6 +21,7 @@ import (
 // This is a shared dependency between DeviceController, WorkerController, and Backend
 type AllocationController struct {
 	deviceController framework.DeviceController
+	isolationPolicy  tfv1.IsolationModePolicyType
 
 	mu                sync.RWMutex
 	workerAllocations map[string]*api.WorkerAllocation
@@ -38,9 +39,19 @@ type visibleDeviceRef struct {
 func NewAllocationController(deviceController framework.DeviceController) *AllocationController {
 	return &AllocationController{
 		deviceController:  deviceController,
+		isolationPolicy:   tfv1.IsolationModePolicyStatic,
 		workerAllocations: make(map[string]*api.WorkerAllocation, 32),
 		deviceAllocations: make(map[string][]*api.WorkerAllocation, 32),
 	}
+}
+
+func (a *AllocationController) SetIsolationPolicy(policy tfv1.IsolationModePolicyType) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if policy != tfv1.IsolationModePolicyDynamic {
+		policy = tfv1.IsolationModePolicyStatic
+	}
+	a.isolationPolicy = policy
 }
 
 // AllocateWorkerDevices allocates devices for a worker request
@@ -56,6 +67,9 @@ func (a *AllocationController) AllocateWorkerDevices(request *api.WorkerInfo) (*
 	if a.workerAllocations[request.WorkerUID] != nil {
 		klog.Infof("worker %s already allocated, skipping", request.WorkerUID)
 		return a.workerAllocations[request.WorkerUID], nil
+	}
+	if err := a.validateDynamicAllocationLocked(request); err != nil {
+		return nil, err
 	}
 
 	deviceInfos := make([]*api.DeviceInfo, 0, len(request.AllocatedDevices))
@@ -234,12 +248,15 @@ func (a *AllocationController) DeallocateWorker(workerUID string) error {
 
 // RecoverPartitionedWorker rebuilds allocation state for an existing partitioned worker
 // after hypervisor restart. partitionUUIDs is a comma-separated string of "partitionUUID:parentGPU" pairs.
-func (a *AllocationController) RecoverPartitionedWorker(request *api.WorkerInfo, partitionUUIDs string) {
+func (a *AllocationController) RecoverPartitionedWorker(request *api.WorkerInfo, partitionUUIDs string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.isolationPolicy == tfv1.IsolationModePolicyDynamic {
+		return fmt.Errorf("dynamic isolation policy does not support partitioned worker %s", request.WorkerUID)
+	}
 
 	if a.workerAllocations[request.WorkerUID] != nil {
-		return // already allocated, skip
+		return nil // already allocated, skip
 	}
 
 	var deviceInfos []*api.DeviceInfo
@@ -270,7 +287,7 @@ func (a *AllocationController) RecoverPartitionedWorker(request *api.WorkerInfo,
 
 	if len(deviceInfos) == 0 {
 		klog.Warningf("no valid partition UUIDs to recover for worker %s", request.WorkerUID)
-		return
+		return nil
 	}
 
 	allocation := &api.WorkerAllocation{
@@ -282,6 +299,41 @@ func (a *AllocationController) RecoverPartitionedWorker(request *api.WorkerInfo,
 		a.addDeviceAllocation(deviceUUID, allocation)
 	}
 	klog.Infof("recovered partitioned worker %s with %d partition(s)", request.WorkerUID, len(deviceInfos))
+	return nil
+}
+
+func (a *AllocationController) validateDynamicAllocationLocked(request *api.WorkerInfo) error {
+	if a.isolationPolicy != tfv1.IsolationModePolicyDynamic {
+		return nil
+	}
+	if request.IsolationMode == tfv1.IsolationModePartitioned {
+		return fmt.Errorf("dynamic isolation policy does not support partitioned worker %s", request.WorkerUID)
+	}
+	if request.IsolationMode != tfv1.IsolationModeShared &&
+		request.IsolationMode != tfv1.IsolationModeSoft &&
+		request.IsolationMode != tfv1.IsolationModeHard {
+		return fmt.Errorf("worker %s has invalid dynamic isolation mode %q", request.WorkerUID, request.IsolationMode)
+	}
+
+	for _, deviceUUID := range request.AllocatedDevices {
+		allocations := a.deviceAllocations[deviceUUID]
+		if request.IsolationMode == tfv1.IsolationModeShared && len(allocations) > 0 {
+			return fmt.Errorf(
+				"device %s is already allocated and cannot be used by shared worker %s",
+				deviceUUID, request.WorkerUID,
+			)
+		}
+		for _, allocation := range allocations {
+			if allocation == nil || allocation.WorkerInfo == nil {
+				return fmt.Errorf("device %s has an unknown existing allocation", deviceUUID)
+			}
+			existingMode := allocation.WorkerInfo.IsolationMode
+			if existingMode != request.IsolationMode {
+				return fmt.Errorf("device %s is already allocated in isolation mode %s", deviceUUID, existingMode)
+			}
+		}
+	}
+	return nil
 }
 
 // GetWorkerAllocation returns the allocation for a specific worker

--- a/pkg/hypervisor/worker/allocation_test.go
+++ b/pkg/hypervisor/worker/allocation_test.go
@@ -30,6 +30,57 @@ func TestAllocateWorkerDevicesRejectsMissingAllocatedDevices(t *testing.T) {
 	}
 }
 
+func TestAllocateWorkerDevicesEnforcesDynamicIsolationPerDevice(t *testing.T) {
+	t.Parallel()
+
+	controller := NewAllocationController(&fakeDeviceController{
+		devices: map[string]*api.DeviceInfo{
+			"gpu-0": {UUID: "GPU-aaa", Vendor: constants.AcceleratorVendorNvidia},
+			"gpu-1": {UUID: "GPU-bbb", Vendor: constants.AcceleratorVendorNvidia},
+		},
+	})
+	controller.SetIsolationPolicy(tfv1.IsolationModePolicyDynamic)
+
+	allocate := func(uid string, mode tfv1.IsolationModeType, devices ...string) error {
+		_, err := controller.AllocateWorkerDevices(&api.WorkerInfo{
+			WorkerUID:        uid,
+			AllocatedDevices: devices,
+			IsolationMode:    mode,
+		})
+		return err
+	}
+
+	if err := allocate("soft-1", tfv1.IsolationModeSoft, "gpu-0"); err != nil {
+		t.Fatalf("first soft allocation failed: %v", err)
+	}
+	if err := allocate("soft-2", tfv1.IsolationModeSoft, "gpu-0"); err != nil {
+		t.Fatalf("same-mode allocation failed: %v", err)
+	}
+	if err := allocate("hard-conflict", tfv1.IsolationModeHard, "gpu-0"); err == nil {
+		t.Fatal("expected hard allocation to conflict with existing soft allocations")
+	}
+	if err := allocate("shared-conflict", tfv1.IsolationModeShared, "gpu-0"); err == nil {
+		t.Fatal("expected shared allocation to require an idle GPU")
+	}
+
+	if err := allocate("shared", tfv1.IsolationModeShared, "gpu-1"); err != nil {
+		t.Fatalf("shared allocation on idle GPU failed: %v", err)
+	}
+	if err := allocate("second-shared", tfv1.IsolationModeShared, "gpu-1"); err == nil {
+		t.Fatal("expected a second shared allocation to be rejected")
+	}
+	if err := allocate("multi-gpu", tfv1.IsolationModeSoft, "gpu-0", "gpu-1"); err == nil {
+		t.Fatal("expected multi-GPU allocation to fail when one device has a conflicting mode")
+	}
+	if _, exists := controller.GetWorkerAllocation("multi-gpu"); exists {
+		t.Fatal("failed multi-GPU allocation must not leave partial worker state")
+	}
+
+	if err := allocate("partitioned", tfv1.IsolationModePartitioned, "gpu-0"); err == nil {
+		t.Fatal("expected partitioned allocation to be rejected in Dynamic policy")
+	}
+}
+
 func TestAllocateWorkerDevicesPinsNvidiaVisibleDevicesByUUID(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hypervisor/worker/controller.go
+++ b/pkg/hypervisor/worker/controller.go
@@ -27,6 +27,7 @@ const (
 
 type WorkerController struct {
 	mode    api.IsolationMode
+	policy  tfv1.IsolationModePolicyType
 	backend framework.Backend
 
 	deviceController     framework.DeviceController
@@ -50,12 +51,25 @@ func NewWorkerController(
 	mode api.IsolationMode,
 	backend framework.Backend,
 ) framework.WorkerController {
+	return NewWorkerControllerWithPolicy(
+		deviceController, allocationController, mode, tfv1.IsolationModePolicyStatic, backend,
+	)
+}
+
+func NewWorkerControllerWithPolicy(
+	deviceController framework.DeviceController,
+	allocationController framework.WorkerAllocationController,
+	mode api.IsolationMode,
+	policy tfv1.IsolationModePolicyType,
+	backend framework.Backend,
+) framework.WorkerController {
 	quotaController := computing.NewQuotaController(deviceController, backend)
 
 	wc := &WorkerController{
 		deviceController:     deviceController,
 		allocationController: allocationController,
 		mode:                 mode,
+		policy:               policy,
 		backend:              backend,
 		quotaController:      quotaController,
 
@@ -129,7 +143,7 @@ func (w *WorkerController) Start() error {
 	}
 
 	// Only soft isolation consumes the shared-memory ERL token bucket.
-	if usesSoftLimiterSharedMemory(w.mode) {
+	if w.policy == tfv1.IsolationModePolicyDynamic || usesSoftLimiterSharedMemory(w.mode) {
 		if err := w.quotaController.StartSoftQuotaLimiter(); err != nil {
 			klog.Fatalf("Failed to start soft quota limiter: %v", err)
 		}
@@ -164,7 +178,10 @@ func (w *WorkerController) recoverExistingWorkerAllocation(worker *api.WorkerInf
 
 	if worker.IsolationMode == tfv1.IsolationModePartitioned && worker.PartitionTemplateID != "" {
 		if partitionUUIDs := worker.Annotations[constants.PartitionUUIDsAnnotation]; partitionUUIDs != "" {
-			w.allocationController.RecoverPartitionedWorker(worker, partitionUUIDs)
+			if err := w.allocationController.RecoverPartitionedWorker(worker, partitionUUIDs); err != nil {
+				klog.Errorf("Failed to recover partitioned allocation for existing worker %s/%s: %v",
+					worker.Namespace, worker.WorkerName, err)
+			}
 		}
 		return
 	}

--- a/pkg/hypervisor/worker/controller_test.go
+++ b/pkg/hypervisor/worker/controller_test.go
@@ -81,8 +81,11 @@ func (f *fakeWorkerAllocationController) AllocateWorkerDevices(request *api.Work
 
 func (f *fakeWorkerAllocationController) DeallocateWorker(string) error { return nil }
 
-func (f *fakeWorkerAllocationController) RecoverPartitionedWorker(request *api.WorkerInfo, partitionUUIDs string) {
+func (f *fakeWorkerAllocationController) RecoverPartitionedWorker(
+	request *api.WorkerInfo, partitionUUIDs string,
+) error {
 	f.recoveredRequests = append(f.recoveredRequests, request)
+	return nil
 }
 
 func (f *fakeWorkerAllocationController) GetWorkerAllocation(workerUID string) (*api.WorkerAllocation, bool) {


### PR DESCRIPTION
 ## Summary

  Add scheduling-domain Dynamic GPU isolation while preserving the existing Static behavior and v1 rollback compatibility.

  Dynamic mode allows each idle GPU to select its isolation mode from the first workload allocation instead of binding the
  entire node to a predefined isolation mode.

  ## Changes

  - Add `Static` and `Dynamic` isolation policy types.
  - Add GPU status fields for the effective policy and card-level active mode.
  - Support Dynamic allocation for:
    - `soft`
    - `hard`
    - `shared`
  - Reject `partitioned/MIG` allocations in Dynamic mode.
  - Lock each Dynamic GPU to one active isolation mode while allocations exist.
  - Automatically release the mode lock after the final allocation is removed.
  - Recover allocation accounting and mode locks from existing worker Pods after Operator restart.
  - Preserve Scheduler-owned GPU state during Hypervisor reconciliation.
  - Add Dynamic-aware allocation rollback, preemption, Gang scheduling, defrag protection and queue activation.
  - Preserve placement modes and topology-aware GPU selection.
  - Correct topology failure events to report the Pod annotation override for `max-tier`.
  - Keep `GPUResourcesFit` PreEnqueue registration for pending-resource wakeups.
  - Add the Dynamic isolation design document.

  ## Configuration

  The Operator now reads the policy from an environment variable:

  ```yaml
  - name: TF_ISOLATION_MODE_POLICY
    value: dynamic

  Helm configuration:

  controller:
    isolationModePolicy: dynamic

  The new Chart defaults to Dynamic:

  version: 1.8.7
  appVersion: "2.17.0"

  The CLI argument -isolation-mode-policy is no longer generated.

  When the environment variable is absent, the new Operator binary defaults to Static. Older v1 images safely ignore the
  environment variable, allowing image rollback without failing on an unknown command-line flag.

  ## Static and Dynamic behavior

  - Static continues using defaultIsolationMode and ordered isolationModeRules.
  - Dynamic ignores those static node rules and selects the mode per GPU allocation.
  - Static and Dynamic cannot coexist in the same scheduling domain in this version.
  - Switching policies requires draining TensorFusion workloads first.
  - Dynamic supports soft, hard and shared.
  - Dynamic does not currently support partitioned/MIG or cross-mode preemption.

  ## Compatibility

  - Existing v1 soft/hard worker Pods can be recovered from their allocation annotations.
  - Existing Static deployments remain Static when the environment variable is absent.
  - v1 Operator images ignore TF_ISOLATION_MODE_POLICY.
  - A complete v1 rollback must also restore the v1 Scheduler ConfigMap because newer scheduler plugin registrations are not
    compatible with the v1 scheduler binary.

  ## Validation

  Local validation:

  - make test
  - helm lint charts/tensor-fusion
  - Helm rendering with default Dynamic and explicit Static overrides
  - Changed-scope golangci-lint: 0 issues

  Cluster validation:

  - Dynamic local and remote soft, hard and shared
  - Real NVML and nvidia-smi calls
  - Card-level mode locking, same-mode sharing and release/reuse
  - NodeCompactGPULowLoad, CompactFirst and LowLoadFirst
  - Topology tier rejection and acceptance
  - Gang scheduling and Gang preemption
  - Operator restart recovery
  - Hypervisor recreation recovery
  - Static local/remote regression tests
  - Static Gang scheduling and preemption
  - v1 Operator rollback while retaining TF_ISOLATION_MODE_POLICY=dynamic
  - Restoration to Dynamic with both RTX 3090 GPUs healthy and no stale allocations

  ## Limitations

  - Dynamic partitioned/MIG is not supported.
  - Static/Dynamic coexistence in one scheduling domain is deferred.
  - Native GPU/DRA coexistence remains incomplete.
  - Cross-node defrag and real NVLink grouping were not physically validated because the test cluster has one two-GPU NVIDIA node.