### PR TITLE
fix(scheduler): 根据 GPU 放置策略恢复拓扑评分

### DIFF
--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -907,6 +907,8 @@ schedulerConfig:
         enabled:
         - name: GPUResourcesFit
           weight: 5
+        - name: GPUNetworkTopologyAware
+          weight: 3
       postFilter:
         # Only GPUResourcesFit is listed here. DefaultPreemption stays enabled
         # through the scheduler's default MultiPoint plugin set.
@@ -940,7 +942,7 @@ schedulerConfig:
     - name: GPUNetworkTopologyAware
       args:
         # Topology enforcement mode:
-        #   soft (default) — only score; never reject a node
+        #   soft (default) — never reject; score nodes unless placement is CompactFirst
         #   hard           — reject nodes whose best combination exceeds maxAllowedTier
         # NOTE: this `mode` is the scheduler plugin mode, unrelated to Pod IsolationMode
         # (shared / soft / hard / partitioned).

--- a/config/manager/configs/scheduler-config.yaml
+++ b/config/manager/configs/scheduler-config.yaml
@@ -23,6 +23,8 @@ profiles:
       enabled:
       - name: GPUResourcesFit
         weight: 5
+      - name: GPUNetworkTopologyAware
+        weight: 3
     postFilter:
       # Only GPUResourcesFit is listed here. DefaultPreemption stays enabled
       # through the scheduler's default MultiPoint plugin set.
@@ -56,8 +58,8 @@ profiles:
   - name: GPUNetworkTopologyAware
     args:
       # Topology enforcement mode:
-      #   soft (default) - only score; never reject a node
-      #   hard           - reject nodes whose best combination exceeds maxAllowedTier
+      #   soft (default) — never reject; score nodes unless placement is CompactFirst
+      #   hard           — reject nodes whose best combination exceeds maxAllowedTier
       # NOTE: this `mode` is the scheduler plugin mode, unrelated to Pod IsolationMode
       # (shared / soft / hard / partitioned).
       mode: soft

--- a/config/samples/scheduler-config.yaml
+++ b/config/samples/scheduler-config.yaml
@@ -23,6 +23,8 @@ profiles:
       enabled:
       - name: GPUResourcesFit
         weight: 5
+      - name: GPUNetworkTopologyAware
+        weight: 3
     postFilter:
       # Only GPUResourcesFit is listed here. DefaultPreemption stays enabled
       # through the scheduler's default MultiPoint plugin set.
@@ -56,8 +58,8 @@ profiles:
   - name: GPUNetworkTopologyAware
     args:
       # Topology enforcement mode:
-      #   soft (default) - only score; never reject a node
-      #   hard           - reject nodes whose best combination exceeds maxAllowedTier
+      #   soft (default) — never reject; score nodes unless placement is CompactFirst
+      #   hard           — reject nodes whose best combination exceeds maxAllowedTier
       # NOTE: this `mode` is the scheduler plugin mode, unrelated to Pod IsolationMode
       # (shared / soft / hard / partitioned).
       mode: soft

--- a/internal/config/scheduler_config.go
+++ b/internal/config/scheduler_config.go
@@ -10,7 +10,8 @@ type GPUFitConfig struct {
 type GPUNetworkTopologyAwareConfig struct {
 	// Mode controls the topology enforcement behavior.
 	// "hard": reject nodes that don't satisfy the topology constraint.
-	// "soft" (default): allow all nodes but prefer better topology via scoring.
+	// "soft" (default): allow all nodes and score topology for non-CompactFirst
+	// placement modes. CompactFirst preserves placement-only node ordering.
 	Mode string `json:"mode"`
 
 	// TopologySource controls which data source the evaluator uses.

--- a/internal/scheduler/gputopo/gpu_network_topo.go
+++ b/internal/scheduler/gputopo/gpu_network_topo.go
@@ -10,6 +10,7 @@ import (
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/config"
+	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator"
 	"github.com/NexusGPU/tensor-fusion/internal/metrics"
 	"github.com/NexusGPU/tensor-fusion/internal/scheduler/gpuresources"
 	"github.com/NexusGPU/tensor-fusion/internal/utils"
@@ -266,14 +267,38 @@ func (s *GPUNetworkTopologyAware) Filter(ctx context.Context, state fwk.CycleSta
 	return fwk.NewStatus(fwk.Success, "")
 }
 
-// Score is retained for compatibility with existing scheduler configs that
-// list this plugin at the Score extension point. Node ordering is owned by
-// GPUResourcesFit's placement mode, so topology contributes no node score.
-func (s *GPUNetworkTopologyAware) Score(_ context.Context, _ fwk.CycleState, pod *v1.Pod, _ fwk.NodeInfo) (int64, *fwk.Status) {
+// Score contributes topology preference for non-CompactFirst placement modes.
+// CompactFirst keeps placement-only node ordering so topology cannot break
+// bin-packing behavior.
+func (s *GPUNetworkTopologyAware) Score(_ context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
 	if !utils.IsTensorFusionWorker(pod) {
 		return 0, fwk.NewStatus(fwk.Success, "")
 	}
-	return 0, fwk.NewStatus(fwk.Success, "node ordering is controlled by placement mode")
+
+	schedulingResultRaw, err := state.Read(gpuresources.CycleStateGPUSchedulingResult)
+	if err != nil {
+		return 0, fwk.NewStatus(fwk.Success, "no GPU scheduling result")
+	}
+	schedulingResult := schedulingResultRaw.(*gpuresources.GPUSchedulingStateData)
+	if schedulingResult.ScoringStrategy == nil {
+		return 0, fwk.NewStatus(fwk.Success, "no GPU placement strategy")
+	}
+	switch schedulingResult.ScoringStrategy.(type) {
+	case gpuallocator.CompactFirst, *gpuallocator.CompactFirst:
+		return 0, fwk.NewStatus(fwk.Success, "topology score disabled for CompactFirst placement")
+	}
+
+	topoStateRaw, err := state.Read(CycleStateGPUTopologyResult)
+	if err != nil {
+		return 0, fwk.NewStatus(fwk.Success, "no GPU topology result")
+	}
+	topoState := topoStateRaw.(*GPUTopologyStateData)
+	plan, exists := topoState.Plans[nodeInfo.Node().Name]
+	if !exists {
+		return 0, fwk.NewStatus(fwk.Success, "no GPU topology plan for node")
+	}
+
+	return plan.Score, fwk.NewStatus(fwk.Success, "")
 }
 
 func (s *GPUNetworkTopologyAware) ScoreExtensions() fwk.ScoreExtensions {

--- a/internal/scheduler/gputopo/placement_order_test.go
+++ b/internal/scheduler/gputopo/placement_order_test.go
@@ -7,6 +7,7 @@ import (
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/config"
 	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator"
+	"github.com/NexusGPU/tensor-fusion/internal/scheduler/gpuresources"
 	"github.com/NexusGPU/tensor-fusion/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -124,17 +125,43 @@ func TestBetterTopologyWinsBeforePlacementScore(t *testing.T) {
 	}
 }
 
-func TestTopologyScoreDoesNotChangeNodePlacement(t *testing.T) {
+func TestTopologyScoreDependsOnPlacementMode(t *testing.T) {
 	plugin := &GPUNetworkTopologyAware{}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{constants.LabelComponent: constants.ComponentWorker},
 	}}
+	nodeInfo := framework.NewNodeInfo()
+	nodeInfo.SetNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
 
-	score, status := plugin.Score(context.Background(), framework.NewCycleState(), pod, nil)
-	if !status.IsSuccess() {
-		t.Fatalf("Score() status = %v", status)
+	tests := []struct {
+		name string
+		mode tfv1.PlacementMode
+		want int64
+	}{
+		{name: "compact first keeps placement-only node ordering", mode: tfv1.PlacementModeCompactFirst, want: 0},
+		{name: "node compact gpu low load includes topology", mode: tfv1.PlacementModeNodeCompactGPULowLoad, want: 87},
+		{name: "low load first includes topology", mode: tfv1.PlacementModeLowLoadFirst, want: 87},
 	}
-	if score != 0 {
-		t.Fatalf("Score() = %d, want 0 so placement owns node ordering", score)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := framework.NewCycleState()
+			state.Write(gpuresources.CycleStateGPUSchedulingResult, &gpuresources.GPUSchedulingStateData{
+				ScoringStrategy: gpuallocator.NewStrategy(tt.mode, &config.GPUFitConfig{}, nil),
+			})
+			state.Write(CycleStateGPUTopologyResult, &GPUTopologyStateData{
+				Plans: map[string]*NodeTopologyPlan{
+					"node-a": {Score: 87},
+				},
+			})
+
+			score, status := plugin.Score(context.Background(), state, pod, nodeInfo)
+			if !status.IsSuccess() {
+				t.Fatalf("Score() status = %v", status)
+			}
+			if score != tt.want {
+				t.Fatalf("Score() = %d, want %d", score, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
 ## 背景

  PR #759 为避免 GPU 拓扑评分破坏 `CompactFirst` 的 bin-pack 行为，取消了 `GPUNetworkTopologyAware` 的节点评分。

  但这也导致 `NodeCompactGPULowLoad` 和 `LowLoadFirst` 模式无法利用 GPU 网络拓扑选择更优节点。

  ## 修改内容

  - 恢复 `GPUNetworkTopologyAware` Score 插件的默认配置，权重为 `3`
  - 根据 Pod 使用的 GPU 放置策略决定是否进行拓扑评分：
    - `CompactFirst`：返回 0，不参与节点排序，保持 bin-pack 优先
    - `NodeCompactGPULowLoad`：参与拓扑评分
    - `LowLoadFirst`：参与拓扑评分
  - 保持 topology hard 模式的节点过滤逻辑不变
  - 保持节点内部 GPU 拓扑选择逻辑不变
  - 增加单元测试，覆盖三种放置模式

  ## 兼容性

  该修改不会改变 `CompactFirst` 的现有调度行为，也不会影响静态资源池。

  只有非 `CompactFirst` 模式会在节点打分阶段加入 GPU 拓扑分数。

  ## 验证结果

  已完成以下验证：

  - 相关 scheduler/gpuallocator 单元测试通过
  - 全仓库编译检查通过
  - `make lint` 通过，0 issues
  - Helm 模板渲染通过
  - `git diff --check` 通过
  - 集群端到端验证通过：
    - `CompactFirst` 仍优先选择符合 bin-pack 的节点
    - `NodeCompactGPULowLoad` 能选择拓扑更优节点
    - `LowLoadFirst` 能选择拓扑更优节点