### PR TITLE
 fix(expander): 支持 Karpenter NodeClaim 按偏好回退重试

### DIFF
--- a/charts/tensor-fusion/Chart.yaml
+++ b/charts/tensor-fusion/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.7
+version: 1.8.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.17.0"
+appVersion: "2.17.3"

--- a/charts/tensor-fusion/templates/rbac.yaml
+++ b/charts/tensor-fusion/templates/rbac.yaml
@@ -209,6 +209,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - karpenter.sh
+  resources:
+  - nodepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets

--- a/cmd/sched/setup.go
+++ b/cmd/sched/setup.go
@@ -159,7 +159,7 @@ func SetupScheduler(
 	// Initialize node expander
 	if enableNodeExpander {
 		unschedHandler, nodeExpander := expander.NewUnscheduledPodHandler(
-			ctx, sched, allocator,
+			ctx, sched, allocator, mgr.GetAPIReader(),
 			mgr.GetEventRecorder("TensorFusionScheduler"),
 		)
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -210,6 +210,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - karpenter.sh
+  resources:
+  - nodepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets

--- a/internal/controller/gpunodeclaim_controller.go
+++ b/internal/controller/gpunodeclaim_controller.go
@@ -48,6 +48,7 @@ type GPUNodeClaimReconciler struct {
 // +kubebuilder:rbac:groups=tensor-fusion.ai,resources=gpunodeclaims/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=tensor-fusion.ai,resources=gpunodeclaims/finalizers,verbs=update
 // +kubebuilder:rbac:groups=karpenter.sh,resources=nodeclaims,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=karpenter.sh,resources=nodepools,verbs=get;list;watch
 
 // GPUNodeClaim is responsible for creating cloud vendor GPU nodes
 func (r *GPUNodeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -85,6 +85,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		if errors.IsNotFound(err) {
 			if r.Expander != nil {
 				_ = r.Expander.RemovePreSchedulePod(req.Name, true)
+				r.Expander.ClearFailedExpansionCandidatesForPod(req.Namespace, req.Name)
 			}
 			r.Allocator.DeallocByPodIdentifier(ctx, req.NamespacedName)
 			metrics.RemoveWorkerMetrics(req.Name, time.Now())
@@ -103,11 +104,16 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if pod.Labels == nil {
 		pod.Labels = map[string]string{}
 	}
+	if !pod.DeletionTimestamp.IsZero() && r.Expander != nil {
+		_ = r.Expander.RemovePreSchedulePod(pod.Name, true)
+		r.Expander.ClearFailedExpansionCandidatesForPod(pod.Namespace, pod.Name)
+	}
 	// Release GPU resources when pod is in Failed or Succeeded (Complete) state
 	// Only for worker pods that have allocated GPU resources
 	if pod.Labels[constants.LabelComponent] == constants.ComponentWorker && utils.IsPodStopped(pod) {
 		if r.Expander != nil {
 			_ = r.Expander.RemovePreSchedulePod(pod.Name, true)
+			r.Expander.ClearFailedExpansionCandidatesForPod(pod.Namespace, pod.Name)
 		}
 		r.Allocator.DeallocByPodIdentifier(ctx, req.NamespacedName)
 		metrics.RemoveWorkerMetrics(pod.Name, time.Now())

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -3,6 +3,8 @@ package expander
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -19,8 +21,10 @@ import (
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/events"
+	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler"
@@ -32,40 +36,59 @@ import (
 
 const (
 	WaitingInFlightNodesPeriod = 20 * time.Second
+	insufficientCapacityReason = "InsufficientCapacityError"
 )
 
 type NodeExpander struct {
-	client             client.Client
-	scheduler          *scheduler.Scheduler
-	allocator          *gpuallocator.GpuAllocator
-	logger             klog.Logger
-	inFlightNodes      map[string][]*tfv1.GPU
-	inFlightNodeClaims sync.Map
-	preSchedulePods    map[string]*tfv1.AllocRequest
-	preScheduleTimers  map[string]*time.Timer
-	eventRecorder      events.EventRecorder
-	mu                 sync.RWMutex
-	ctx                context.Context
+	client                    client.Client
+	scheduler                 *scheduler.Scheduler
+	allocator                 *gpuallocator.GpuAllocator
+	logger                    klog.Logger
+	inFlightNodes             map[string][]*tfv1.GPU
+	inFlightNodeClaims        sync.Map
+	failedExpansionCandidates map[string]map[string]struct{}
+	preSchedulePods           map[string]*tfv1.AllocRequest
+	preScheduleTimers         map[string]*time.Timer
+	eventRecorder             events.EventRecorder
+	eventReader               client.Reader
+	activatePod               func(*corev1.Pod)
+	mu                        sync.RWMutex
+	ctx                       context.Context
+}
+
+type inFlightNodeClaim struct {
+	podKey       client.ObjectKey
+	podUID       types.UID
+	nodeClaimUID types.UID
+	candidate    string
 }
 
 func NewNodeExpander(
 	ctx context.Context,
 	allocator *gpuallocator.GpuAllocator,
 	scheduler *scheduler.Scheduler,
+	eventReader client.Reader,
 	recorder events.EventRecorder,
 ) *NodeExpander {
 
 	expander := &NodeExpander{
-		client:             allocator.Client,
-		scheduler:          scheduler,
-		allocator:          allocator,
-		logger:             log.FromContext(ctx).WithValues("component", "NodeExpander"),
-		inFlightNodes:      make(map[string][]*tfv1.GPU, 10),
-		preSchedulePods:    make(map[string]*tfv1.AllocRequest, 20),
-		preScheduleTimers:  make(map[string]*time.Timer, 20),
-		inFlightNodeClaims: sync.Map{},
-		eventRecorder:      recorder,
-		ctx:                ctx,
+		client:                    allocator.Client,
+		scheduler:                 scheduler,
+		allocator:                 allocator,
+		logger:                    log.FromContext(ctx).WithValues("component", "NodeExpander"),
+		inFlightNodes:             make(map[string][]*tfv1.GPU, 10),
+		failedExpansionCandidates: make(map[string]map[string]struct{}),
+		preSchedulePods:           make(map[string]*tfv1.AllocRequest, 20),
+		preScheduleTimers:         make(map[string]*time.Timer, 20),
+		inFlightNodeClaims:        sync.Map{},
+		eventRecorder:             recorder,
+		eventReader:               eventReader,
+		ctx:                       ctx,
+	}
+	if scheduler != nil {
+		expander.activatePod = func(pod *corev1.Pod) {
+			scheduler.SchedulingQueue.Activate(expander.logger, map[string]*corev1.Pod{string(pod.UID): pod})
+		}
 	}
 	allocator.RegisterBindHandler(func(req *tfv1.AllocRequest) {
 		obj := &corev1.ObjectReference{
@@ -79,6 +102,7 @@ func NewNodeExpander(
 
 		removed := expander.RemovePreSchedulePod(req.PodMeta.Name, true)
 		if removed {
+			expander.clearFailedExpansionCandidates(req.PodMeta.Namespace, req.PodMeta.Name, req.PodMeta.UID)
 			recorder.Eventf(obj, nil, corev1.EventTypeNormal, "NodeExpansionCheck", "Scheduled",
 				"new node provisioned and pod scheduled successfully")
 		}
@@ -94,13 +118,12 @@ func NewNodeExpander(
 				return
 			case <-ticker.C:
 			}
-			expander.inFlightNodeClaims.Range(func(key, _ any) bool {
+			expander.inFlightNodeClaims.Range(func(key, value any) bool {
 				karpenterNodeClaim := &karpv1.NodeClaim{}
 				name := key.(string)
 				if err := expander.client.Get(expander.ctx, client.ObjectKey{Name: name}, karpenterNodeClaim); err != nil {
 					if errors.IsNotFound(err) {
-						expander.inFlightNodeClaims.Delete(key)
-						expander.RemoveInFlightNode(name)
+						expander.handleTerminatedInFlightNodeClaim(name, value, expander.hasInsufficientCapacityEvent(name, value))
 						expander.logger.Info("karpenter node claim not found, remove from inFlightNodeClaims and inFlightNodes", "nodeClaimName", name)
 						return true
 					}
@@ -120,24 +143,98 @@ func (e *NodeExpander) cleanupInFlightNodeClaim(nodeClaim *karpv1.NodeClaim) {
 	if nodeClaim == nil {
 		return
 	}
-	if !nodeClaim.DeletionTimestamp.IsZero() {
-		e.inFlightNodeClaims.Delete(nodeClaim.Name)
-		e.RemoveInFlightNode(nodeClaim.Name)
-		e.logger.Info("karpenter node claim is deleted, remove from inFlightNodeClaims and inFlightNodes", "nodeClaimName", nodeClaim.Name)
-		return
-	}
 	if nodeClaim.StatusConditions().IsTrue(status.ConditionReady) || nodeClaim.Status.NodeName != "" {
+		value, _ := e.inFlightNodeClaims.Load(nodeClaim.Name)
 		e.inFlightNodeClaims.Delete(nodeClaim.Name)
 		e.RemoveInFlightNode(nodeClaim.Name)
+		e.clearFailedExpansionCandidatesForClaim(value)
 		e.logger.Info("karpenter node claim ready, remove from inFlightNodeClaims and inFlightNodes", "nodeClaimName", nodeClaim.Name)
 		return
 	}
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if _, ok := e.inFlightNodes[nodeClaim.Name]; !ok {
+	if !nodeClaim.DeletionTimestamp.IsZero() {
+		value, _ := e.inFlightNodeClaims.Load(nodeClaim.Name)
+		e.handleTerminatedInFlightNodeClaim(nodeClaim.Name, value, e.hasInsufficientCapacityEvent(nodeClaim.Name, value))
+		e.logger.Info("karpenter node claim is deleted, remove from inFlightNodeClaims and inFlightNodes", "nodeClaimName", nodeClaim.Name)
+		return
+	}
+	e.mu.RLock()
+	_, inFlight := e.inFlightNodes[nodeClaim.Name]
+	e.mu.RUnlock()
+	if !inFlight {
+		value, _ := e.inFlightNodeClaims.Load(nodeClaim.Name)
 		e.inFlightNodeClaims.Delete(nodeClaim.Name)
+		e.clearFailedExpansionCandidatesForClaim(value)
 		e.logger.Info("karpenter node claim has been provisioned, remove from inFlightNodeClaims", "nodeClaimName", nodeClaim.Name)
 	}
+}
+
+func (e *NodeExpander) handleTerminatedInFlightNodeClaim(name string, value any, insufficientCapacity bool) {
+	e.inFlightNodeClaims.Delete(name)
+	e.RemoveInFlightNode(name)
+
+	claim, ok := value.(inFlightNodeClaim)
+	if !ok {
+		return
+	}
+	_ = e.RemovePreSchedulePod(claim.podKey.Name, true)
+
+	pod := &corev1.Pod{}
+	if err := e.client.Get(e.ctx, claim.podKey, pod); err != nil || pod.UID != claim.podUID {
+		e.clearFailedExpansionCandidates(claim.podKey.Namespace, claim.podKey.Name, claim.podUID)
+		return
+	}
+	if insufficientCapacity {
+		e.addFailedExpansionCandidate(claim.podKey, claim.podUID, claim.candidate)
+		e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, "NodeExpansionCandidateFailed", "InsufficientCapacity",
+			"Karpenter NodeClaim %s failed due to insufficient capacity; trying the next expansion preference", name)
+	}
+	if e.activatePod != nil {
+		e.activatePod(pod)
+		e.logger.Info("reactivated pod after Karpenter NodeClaim terminated",
+			"pod", klog.KObj(pod), "nodeClaimName", name, "insufficientCapacity", insufficientCapacity)
+	}
+}
+
+func (e *NodeExpander) hasInsufficientCapacityEvent(name string, value any) bool {
+	claim, ok := value.(inFlightNodeClaim)
+	if !ok || e.eventReader == nil {
+		return false
+	}
+	matchingFields := client.MatchingFields{
+		"reason":              insufficientCapacityReason,
+		"involvedObject.kind": constants.KarpenterNodeClaimKind,
+	}
+	if claim.nodeClaimUID != "" {
+		matchingFields["involvedObject.uid"] = string(claim.nodeClaimUID)
+	} else {
+		matchingFields["involvedObject.name"] = name
+	}
+	events := &corev1.EventList{}
+	if err := e.eventReader.List(e.ctx, events, matchingFields, client.Limit(1)); err != nil {
+		e.logger.Error(err, "failed to list events for terminated Karpenter NodeClaim", "nodeClaimName", name)
+		return false
+	}
+	for i := range events.Items {
+		event := &events.Items[i]
+		if event.InvolvedObject.Kind != constants.KarpenterNodeClaimKind {
+			continue
+		}
+		if claim.nodeClaimUID != "" && event.InvolvedObject.UID == claim.nodeClaimUID {
+			return true
+		}
+		if claim.nodeClaimUID == "" && event.InvolvedObject.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *NodeExpander) clearFailedExpansionCandidatesForClaim(value any) {
+	claim, ok := value.(inFlightNodeClaim)
+	if !ok {
+		return
+	}
+	e.clearFailedExpansionCandidates(claim.podKey.Namespace, claim.podKey.Name, claim.podUID)
 }
 
 func (e *NodeExpander) GetNodeScalerInfo() any {
@@ -169,14 +266,33 @@ func (e *NodeExpander) GetNodeScalerInfo() any {
 
 	inFlightNodeClaimSnapshot := make(map[string]any)
 	e.inFlightNodeClaims.Range(func(key, value any) bool {
-		inFlightNodeClaimSnapshot[key.(string)] = value
+		claim, ok := value.(inFlightNodeClaim)
+		if !ok {
+			inFlightNodeClaimSnapshot[key.(string)] = value
+			return true
+		}
+		inFlightNodeClaimSnapshot[key.(string)] = map[string]string{
+			"pod":       claim.podKey.String(),
+			"podUID":    string(claim.podUID),
+			"candidate": claim.candidate,
+		}
 		return true
 	})
+	failedExpansionCandidatesCopy := make(map[string][]string, len(e.failedExpansionCandidates))
+	for podKey, candidates := range e.failedExpansionCandidates {
+		values := make([]string, 0, len(candidates))
+		for candidate := range candidates {
+			values = append(values, candidate)
+		}
+		sort.Strings(values)
+		failedExpansionCandidatesCopy[podKey] = values
+	}
 	return map[string]any{
-		"inFlightNodes":       inFlightNodesCopy,
-		"inFlightNodeClaims":  inFlightNodeClaimSnapshot,
-		"preSchedulePods":     preSchedulePodsCopy,
-		"preScheduleTimerNum": len(e.preScheduleTimers),
+		"inFlightNodes":             inFlightNodesCopy,
+		"inFlightNodeClaims":        inFlightNodeClaimSnapshot,
+		"failedExpansionCandidates": failedExpansionCandidatesCopy,
+		"preSchedulePods":           preSchedulePodsCopy,
+		"preScheduleTimerNum":       len(e.preScheduleTimers),
 	}
 }
 
@@ -302,6 +418,239 @@ func (e *NodeExpander) ProcessExpansion(ctx context.Context, pod *corev1.Pod) er
 	return nil
 }
 
+func expansionPodKey(namespace, name string, uid types.UID) string {
+	return expansionPodPrefix(namespace, name) + string(uid)
+}
+
+func expansionPodPrefix(namespace, name string) string {
+	return namespace + "/" + name + "/"
+}
+
+func (e *NodeExpander) addFailedExpansionCandidate(podKey client.ObjectKey, podUID types.UID, candidate string) {
+	if candidate == "" {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	key := expansionPodKey(podKey.Namespace, podKey.Name, podUID)
+	if e.failedExpansionCandidates[key] == nil {
+		e.failedExpansionCandidates[key] = make(map[string]struct{})
+	}
+	e.failedExpansionCandidates[key][candidate] = struct{}{}
+}
+
+func (e *NodeExpander) clearFailedExpansionCandidates(namespace, name string, uid types.UID) {
+	e.mu.Lock()
+	delete(e.failedExpansionCandidates, expansionPodKey(namespace, name, uid))
+	e.mu.Unlock()
+}
+
+// ClearFailedExpansionCandidatesForPod removes all candidate history for a
+// deleted Pod, including entries left by an older UID with the same name.
+func (e *NodeExpander) ClearFailedExpansionCandidatesForPod(namespace, name string) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	prefix := expansionPodPrefix(namespace, name)
+	for key := range e.failedExpansionCandidates {
+		if strings.HasPrefix(key, prefix) {
+			delete(e.failedExpansionCandidates, key)
+		}
+	}
+}
+
+const relaxedExpansionCandidate = "<relaxed>"
+
+type expansionCandidate struct {
+	candidate    string
+	requirements map[string][]string
+}
+
+func preferredExpansionCandidates(pod *corev1.Pod) []expansionCandidate {
+	if pod == nil || pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
+		return []expansionCandidate{{candidate: relaxedExpansionCandidate}}
+	}
+	terms := append([]corev1.PreferredSchedulingTerm(nil),
+		pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	sort.SliceStable(terms, func(i, j int) bool {
+		return terms[i].Weight > terms[j].Weight
+	})
+
+	candidates := make([]expansionCandidate, 0, len(terms)+1)
+	seen := make(map[string]struct{}, len(terms)+1)
+	for _, term := range terms {
+		requirements := make(map[string][]string)
+		for _, expression := range term.Preference.MatchExpressions {
+			if expression.Operator != corev1.NodeSelectorOpIn ||
+				!isExpansionRequirementKey(expression.Key) {
+				continue
+			}
+			requirements[expression.Key] = append([]string(nil), expression.Values...)
+		}
+		candidate := expansionRequirementsKey(requirements)
+		if candidate == "" {
+			continue
+		}
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		candidates = append(candidates, expansionCandidate{candidate: candidate, requirements: requirements})
+	}
+	candidates = append(candidates, expansionCandidate{candidate: relaxedExpansionCandidate})
+	return candidates
+}
+
+func requiredExpansionCandidates(pod *corev1.Pod) []expansionCandidate {
+	if pod == nil || pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil ||
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return []expansionCandidate{{}}
+	}
+	terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) == 0 {
+		return []expansionCandidate{{}}
+	}
+
+	candidates := make([]expansionCandidate, 0, len(terms))
+	seen := make(map[string]struct{}, len(terms))
+	for _, term := range terms {
+		requirements := make(map[string][]string)
+		compatible := true
+		for _, expression := range term.MatchExpressions {
+			if expression.Operator != corev1.NodeSelectorOpIn || !isExpansionRequirementKey(expression.Key) {
+				continue
+			}
+			var merged map[string][]string
+			merged, compatible = mergeExpansionRequirementValues(requirements, map[string][]string{
+				expression.Key: expression.Values,
+			})
+			if !compatible {
+				break
+			}
+			requirements = merged
+		}
+		if !compatible {
+			continue
+		}
+		candidate := expansionRequirementsKey(requirements)
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		candidates = append(candidates, expansionCandidate{candidate: candidate, requirements: requirements})
+	}
+	return candidates
+}
+
+func podExpansionCandidates(pod *corev1.Pod) []expansionCandidate {
+	baseRequirements := podKarpenterRequirementValues(pod)
+	requiredCandidates := requiredExpansionCandidates(pod)
+	preferredCandidates := preferredExpansionCandidates(pod)
+	candidates := make([]expansionCandidate, 0, len(requiredCandidates)*len(preferredCandidates))
+	seen := make(map[string]struct{}, cap(candidates))
+
+	// Preserve preferred weight order, then try required OR terms in their
+	// declaration order for each preference.
+	for _, preferred := range preferredCandidates {
+		for _, required := range requiredCandidates {
+			requirements, compatible := mergeExpansionRequirementValues(
+				baseRequirements, required.requirements, preferred.requirements,
+			)
+			if !compatible {
+				continue
+			}
+			candidate := expansionRequirementsKey(requirements)
+			if candidate == "" {
+				candidate = relaxedExpansionCandidate
+			}
+			if _, exists := seen[candidate]; exists {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			candidates = append(candidates, expansionCandidate{candidate: candidate, requirements: requirements})
+		}
+	}
+	return candidates
+}
+
+func mergeExpansionRequirementValues(requirementSets ...map[string][]string) (map[string][]string, bool) {
+	merged := make(map[string][]string)
+	for _, requirements := range requirementSets {
+		for key, values := range requirements {
+			values = uniqueStrings(values)
+			if len(values) == 0 {
+				return nil, false
+			}
+			current, exists := merged[key]
+			if !exists {
+				merged[key] = append([]string(nil), values...)
+				continue
+			}
+			allowed := make(map[string]struct{}, len(values))
+			for _, value := range values {
+				allowed[value] = struct{}{}
+			}
+			intersection := make([]string, 0, len(current))
+			for _, value := range current {
+				if _, ok := allowed[value]; ok {
+					intersection = append(intersection, value)
+				}
+			}
+			if len(intersection) == 0 {
+				return nil, false
+			}
+			merged[key] = intersection
+		}
+	}
+	return merged, true
+}
+
+func isExpansionRequirementKey(key string) bool {
+	return key == corev1.LabelInstanceTypeStable ||
+		key == corev1.LabelTopologyZone ||
+		key == corev1.LabelTopologyRegion
+}
+
+func expansionRequirementsKey(requirements map[string][]string) string {
+	keys := []string{corev1.LabelInstanceTypeStable, corev1.LabelTopologyZone, corev1.LabelTopologyRegion}
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		values := append([]string(nil), requirements[key]...)
+		if len(values) == 0 {
+			continue
+		}
+		sort.Strings(values)
+		parts = append(parts, key+"="+strings.Join(values, ","))
+	}
+	return strings.Join(parts, ";")
+}
+
+func (e *NodeExpander) expansionCandidatesToTry(pod *corev1.Pod) []expansionCandidate {
+	candidates := podExpansionCandidates(pod)
+	podKey := expansionPodKey(pod.Namespace, pod.Name, pod.UID)
+	prefix := expansionPodPrefix(pod.Namespace, pod.Name)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// A recreated Pod starts a new expansion attempt. Drop candidate history
+	// from older UIDs while preserving the current Pod's failures.
+	for key := range e.failedExpansionCandidates {
+		if strings.HasPrefix(key, prefix) && key != podKey {
+			delete(e.failedExpansionCandidates, key)
+		}
+	}
+	failed := e.failedExpansionCandidates[podKey]
+	remaining := make([]expansionCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if _, exists := failed[candidate.candidate]; !exists {
+			remaining = append(remaining, candidate)
+		}
+	}
+	return remaining
+}
+
 func (e *NodeExpander) addInFlightNode(node *corev1.Node, gpus []*tfv1.GPU) {
 	e.mu.Lock()
 	e.inFlightNodes[node.Name] = gpus
@@ -318,12 +667,18 @@ func (e *NodeExpander) addPreSchedulePod(allocRequest *tfv1.AllocRequest) {
 		currentPod := &corev1.Pod{}
 		err := e.client.Get(e.ctx, client.ObjectKey{Name: podMeta.Name, Namespace: podMeta.Namespace}, currentPod)
 		if err != nil {
-			if errors.IsNotFound(err) || !currentPod.DeletionTimestamp.IsZero() {
+			if errors.IsNotFound(err) {
 				_ = e.RemovePreSchedulePod(podMeta.Name, false)
+				e.clearFailedExpansionCandidates(podMeta.Namespace, podMeta.Name, podMeta.UID)
 			}
 			e.logger.Error(err, "failed to get pod for node expansion check",
 				"namespace", podMeta.Namespace, "pod", podMeta.Name)
 			_ = e.RemovePreSchedulePod(podMeta.Name, false)
+			return
+		}
+		if !currentPod.DeletionTimestamp.IsZero() {
+			_ = e.RemovePreSchedulePod(podMeta.Name, false)
+			e.clearFailedExpansionCandidates(podMeta.Namespace, podMeta.Name, podMeta.UID)
 			return
 		}
 		if currentPod.Spec.NodeName != "" {
@@ -333,6 +688,7 @@ func (e *NodeExpander) addPreSchedulePod(allocRequest *tfv1.AllocRequest) {
 			e.logger.Info("new node provisioned and pod scheduled successfully",
 				"namespace", podMeta.Namespace, "pod", podMeta.Name)
 			_ = e.RemovePreSchedulePod(podMeta.Name, false)
+			e.clearFailedExpansionCandidates(podMeta.Namespace, podMeta.Name, podMeta.UID)
 		} else {
 			// not scheduled, record warning event and remove pre-scheduled pod
 			e.eventRecorder.Eventf(currentPod, nil, corev1.EventTypeWarning, "NodeExpansionCheck", "ScheduleTimeout",
@@ -727,29 +1083,91 @@ func (e *NodeExpander) cloneGPUNodeClaim(ctx context.Context, pod *corev1.Pod, p
 // createKarpenterNodeClaimDirect creates a Karpenter NodeClaim directly with special label identifier
 // when running GPUPool in AutoSelect mode and Karpenter manage its Nodes, no GPUNodeClaim is created
 func (e *NodeExpander) createKarpenterNodeClaimDirect(ctx context.Context, pod *corev1.Pod, preparedNode *corev1.Node, nodeClaim *karpv1.NodeClaim) error {
+	spec := nodeClaim.DeepCopy().Spec
+	spec.Resources.Requests = nodeClaimRequestsForPod(pod)
+	labels := make(map[string]string, 4)
+	for _, owner := range nodeClaim.OwnerReferences {
+		if owner.Kind != constants.KarpenterNodePoolKind {
+			continue
+		}
+		nodePool := &karpv1.NodePool{}
+		if err := e.client.Get(ctx, client.ObjectKey{Name: owner.Name}, nodePool); err != nil {
+			return fmt.Errorf("failed to get Karpenter NodePool %s: %w", owner.Name, err)
+		}
+		poolRequirements := append([]karpv1.NodeSelectorRequirementWithMinValues(nil), nodePool.Spec.Template.Spec.Requirements...)
+		poolKeys := make(map[string]struct{}, len(poolRequirements))
+		for _, requirement := range poolRequirements {
+			poolKeys[requirement.Key] = struct{}{}
+		}
+		for key, value := range nodePool.Spec.Template.Labels {
+			labels[key] = value
+		}
+		labels[karpv1.NodePoolLabelKey] = nodePool.Name
+		if nodeClassRef := nodePool.Spec.Template.Spec.NodeClassRef; nodeClassRef != nil {
+			labels[karpv1.NodeClassLabelKey(nodeClassRef.GroupKind())] = nodeClassRef.Name
+		}
+		for key := range labels {
+			// Karpenter layers NodeClaim labels into its requirements. Do not
+			// append a stale requirement for the same key from the source claim.
+			poolKeys[key] = struct{}{}
+		}
+		for _, requirement := range spec.Requirements {
+			if _, exists := poolKeys[requirement.Key]; exists {
+				continue
+			}
+			// A source NodeClaim contains the concrete instance type and zone
+			// selected for that node. The replacement must use the NodePool's
+			// alternatives so Karpenter can select another available offering.
+			if requirement.Key == corev1.LabelInstanceTypeStable || requirement.Key == corev1.LabelTopologyZone {
+				continue
+			}
+			poolRequirements = append(poolRequirements, requirement)
+		}
+		spec.Requirements = poolRequirements
+		break
+	}
+	labelRequirements := make(map[string][]string, len(labels))
+	for key, value := range labels {
+		labelRequirements[key] = []string{value}
+	}
+	if !mergeKarpenterRequirements(&spec, labelRequirements) {
+		return fmt.Errorf("karpenter node pool labels do not intersect with its requirements")
+	}
+	var selectedCandidate expansionCandidate
+	candidateFound := false
+	for _, candidate := range e.expansionCandidatesToTry(pod) {
+		candidateSpec := (&karpv1.NodeClaim{Spec: spec}).DeepCopy().Spec
+		if !mergeKarpenterRequirements(&candidateSpec, candidate.requirements) {
+			continue
+		}
+		spec = candidateSpec
+		selectedCandidate = candidate
+		candidateFound = true
+		break
+	}
+	if !candidateFound {
+		e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, "NodeExpansionCandidatesExhausted", "Exhausted",
+			"all Karpenter expansion requirement candidates have failed")
+		return fmt.Errorf("all Karpenter expansion requirement candidates have failed for pod %s/%s", pod.Namespace, pod.Name)
+	}
+
 	// Create NodeClaim from the prepared node
 	newNodeClaim := &karpv1.NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            preparedNode.Name,
-			Labels:          make(map[string]string, 16),
+			Labels:          labels,
 			Annotations:     make(map[string]string, 4),
 			OwnerReferences: nodeClaim.OwnerReferences,
 		},
-		Spec: nodeClaim.Spec,
+		Spec: spec,
 	}
 	// Add special label to indicate this is for node expansion of "preparedNode"
 	// When GPUNode controller reconciles, check and call RemoveInFlightNode
 	newNodeClaim.Labels[constants.KarpenterExpansionLabel] = newNodeClaim.Name
 
-	// Pass through labels and annotations
-	for k, v := range nodeClaim.Labels {
-		if k == constants.KarpenterExpansionLabel {
-			continue
-		}
-		if isNotAutoAddedKarpenterKeys(k) {
-			newNodeClaim.Labels[k] = v
-		}
-	}
+	// Keep source annotations, but rebuild labels from the NodePool template.
+	// Source NodeClaim labels include provider-resolved instance properties that
+	// would constrain the replacement to the same offering.
 	for k, v := range nodeClaim.Annotations {
 		// Expansion copies should not inherit do-not-disrupt protection; otherwise reclaimed nodes can get stuck.
 		if shouldSkipAnnotationCopy(k, v) {
@@ -766,12 +1184,197 @@ func (e *NodeExpander) createKarpenterNodeClaimDirect(ctx context.Context, pod *
 			"failed to create new NodeClaim: %v", err)
 		return fmt.Errorf("failed to create NodeClaim: %w", err)
 	}
-	e.inFlightNodeClaims.Store(newNodeClaim.Name, true)
+	e.inFlightNodeClaims.Store(newNodeClaim.Name, inFlightNodeClaim{
+		podKey:       client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name},
+		podUID:       pod.UID,
+		nodeClaimUID: newNodeClaim.UID,
+		candidate:    selectedCandidate.candidate,
+	})
 	e.eventRecorder.Eventf(pod, nil, corev1.EventTypeNormal, "NodeExpansionCompleted", "Created",
 		"created new NodeClaim for node expansion: %s", newNodeClaim.Name)
 	e.logger.Info("created new NodeClaim for node expansion", "pod", pod.Name, "namespace", pod.Namespace, "nodeClaim", newNodeClaim.Name)
 
 	return nil
+}
+
+func nodeClaimRequestsForPod(pod *corev1.Pod) corev1.ResourceList {
+	requests := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
+	for name := range requests {
+		if strings.HasPrefix(string(name), constants.Domain+"/") {
+			delete(requests, name)
+		}
+	}
+	requests[corev1.ResourcePods] = resource.MustParse("1")
+	return requests
+}
+
+func podKarpenterRequirementValues(pod *corev1.Pod) map[string][]string {
+	valuesByKey := make(map[string][]string)
+	if pod == nil {
+		return valuesByKey
+	}
+	setValues := func(key string, values ...string) {
+		if key != corev1.LabelInstanceTypeStable && key != corev1.LabelTopologyZone {
+			return
+		}
+		unique := make([]string, 0, len(values))
+		seen := make(map[string]struct{}, len(values))
+		for _, value := range values {
+			if value != "" {
+				if _, exists := seen[value]; !exists {
+					unique = append(unique, value)
+					seen[value] = struct{}{}
+				}
+			}
+		}
+		if current, exists := valuesByKey[key]; exists {
+			allowed := make(map[string]struct{}, len(unique))
+			for _, value := range unique {
+				allowed[value] = struct{}{}
+			}
+			intersection := make([]string, 0, len(current))
+			for _, value := range current {
+				if _, ok := allowed[value]; ok {
+					intersection = append(intersection, value)
+				}
+			}
+			valuesByKey[key] = intersection
+			return
+		}
+		valuesByKey[key] = unique
+	}
+	for key, value := range pod.Spec.NodeSelector {
+		setValues(key, value)
+	}
+	return valuesByKey
+}
+
+func mergeKarpenterRequirements(spec *karpv1.NodeClaimSpec, valuesByKey map[string][]string) bool {
+	if spec == nil {
+		return false
+	}
+	merged := append([]karpv1.NodeSelectorRequirementWithMinValues(nil), spec.Requirements...)
+	for i := range merged {
+		merged[i].Values = append([]string(nil), merged[i].Values...)
+	}
+	for key, values := range valuesByKey {
+		values = uniqueStrings(values)
+		if len(values) == 0 {
+			continue
+		}
+		matched := false
+		minValues := 0
+		remaining := make([]karpv1.NodeSelectorRequirementWithMinValues, 0, len(merged)+1)
+		for _, requirement := range merged {
+			if requirement.Key != key {
+				remaining = append(remaining, requirement)
+				continue
+			}
+			matched = true
+			var compatible bool
+			values, compatible = intersectKarpenterRequirementValues(requirement, values)
+			if !compatible {
+				return false
+			}
+			if requirement.MinValues != nil && *requirement.MinValues > minValues {
+				minValues = *requirement.MinValues
+			}
+		}
+		if minValues > len(values) {
+			return false
+		}
+		sort.Strings(values)
+		mergedRequirement := karpv1.NodeSelectorRequirementWithMinValues{
+			NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+				Key: key, Operator: corev1.NodeSelectorOpIn, Values: values,
+			},
+		}
+		if matched && minValues > 0 {
+			mergedRequirement.MinValues = &minValues
+		}
+		merged = append(remaining, mergedRequirement)
+	}
+	spec.Requirements = merged
+	sort.Slice(spec.Requirements, func(i, j int) bool {
+		if spec.Requirements[i].Key == spec.Requirements[j].Key {
+			return spec.Requirements[i].Operator < spec.Requirements[j].Operator
+		}
+		return spec.Requirements[i].Key < spec.Requirements[j].Key
+	})
+	return true
+}
+
+func intersectKarpenterRequirementValues(requirement karpv1.NodeSelectorRequirementWithMinValues, values []string) ([]string, bool) {
+	allowed := make(map[string]struct{}, len(requirement.Values))
+	for _, value := range requirement.Values {
+		allowed[value] = struct{}{}
+	}
+	result := make([]string, 0, len(values))
+	switch requirement.Operator {
+	case corev1.NodeSelectorOpIn:
+		for _, value := range values {
+			if _, exists := allowed[value]; exists {
+				result = append(result, value)
+			}
+		}
+	case corev1.NodeSelectorOpNotIn:
+		for _, value := range values {
+			if _, excluded := allowed[value]; !excluded {
+				result = append(result, value)
+			}
+		}
+	case corev1.NodeSelectorOpExists:
+		result = append(result, values...)
+	case corev1.NodeSelectorOpDoesNotExist:
+		return nil, false
+	case corev1.NodeSelectorOpGt, corev1.NodeSelectorOpLt:
+		if len(requirement.Values) != 1 {
+			return nil, false
+		}
+		boundary, err := strconv.Atoi(requirement.Values[0])
+		if err != nil {
+			return nil, false
+		}
+		for _, value := range values {
+			number, err := strconv.Atoi(value)
+			if err != nil {
+				continue
+			}
+			if requirementMatchesNumber(requirement.Operator, number, boundary) {
+				result = append(result, value)
+			}
+		}
+	default:
+		return nil, false
+	}
+	return result, len(result) > 0
+}
+
+func requirementMatchesNumber(operator corev1.NodeSelectorOperator, value, boundary int) bool {
+	switch operator {
+	case corev1.NodeSelectorOpGt:
+		return value > boundary
+	case corev1.NodeSelectorOpLt:
+		return value < boundary
+	default:
+		return false
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	unique := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
 }
 
 func isNotAutoAddedKarpenterKeys(k string) bool {

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -1249,7 +1249,7 @@ func podKarpenterRequirementValues(pod *corev1.Pod) map[string][]string {
 		return valuesByKey
 	}
 	setValues := func(key string, values ...string) {
-		if key != corev1.LabelInstanceTypeStable && key != corev1.LabelTopologyZone {
+		if key != corev1.LabelInstanceTypeStable && key != corev1.LabelTopologyZone && key != corev1.LabelTopologyRegion {
 			return
 		}
 		unique := make([]string, 0, len(values))

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -185,6 +185,13 @@ func (e *NodeExpander) handleTerminatedInFlightNodeClaim(name string, value any,
 	}
 	if insufficientCapacity {
 		e.addFailedExpansionCandidate(claim.podKey, claim.podUID, claim.candidate)
+		if len(e.expansionCandidatesToTry(pod)) == 0 {
+			e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, "NodeExpansionCandidatesExhausted", "InsufficientCapacity",
+				"Karpenter NodeClaim %s failed due to insufficient capacity; all expansion candidates have failed, waiting for scheduler requeue", name)
+			e.logger.Info("all Karpenter expansion candidates failed, waiting for scheduler requeue",
+				"pod", klog.KObj(pod), "nodeClaimName", name)
+			return
+		}
 		e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, "NodeExpansionCandidateFailed", "InsufficientCapacity",
 			"Karpenter NodeClaim %s failed due to insufficient capacity; trying the next expansion preference", name)
 	}
@@ -649,6 +656,34 @@ func (e *NodeExpander) expansionCandidatesToTry(pod *corev1.Pod) []expansionCand
 		}
 	}
 	return remaining
+}
+
+// resetExpansionCandidatesForNewRound clears a fully exhausted candidate set.
+// It is called after the scheduler requeues and rejects the Pod again, so a
+// failed expansion round does not immediately restart itself.
+func (e *NodeExpander) resetExpansionCandidatesForNewRound(pod *corev1.Pod) bool {
+	if e == nil || pod == nil {
+		return false
+	}
+	candidates := podExpansionCandidates(pod)
+	if len(candidates) == 0 {
+		return false
+	}
+
+	podKey := expansionPodKey(pod.Namespace, pod.Name, pod.UID)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	failed, exists := e.failedExpansionCandidates[podKey]
+	if !exists {
+		return false
+	}
+	for _, candidate := range candidates {
+		if _, exists := failed[candidate.candidate]; !exists {
+			return false
+		}
+	}
+	delete(e.failedExpansionCandidates, podKey)
+	return true
 }
 
 func (e *NodeExpander) addInFlightNode(node *corev1.Node, gpus []*tfv1.GPU) {

--- a/internal/scheduler/expander/handler_test.go
+++ b/internal/scheduler/expander/handler_test.go
@@ -147,6 +147,10 @@ var _ = Describe("NodeExpander Unit Tests", func() {
 			testNonCapacityDeletion(suite)
 		})
 
+		It("should wait for scheduler requeue after exhausting expansion candidates", func() {
+			testExhaustedCandidatesWaitForSchedulerRequeue(suite)
+		})
+
 		It("should cleanup inflight node claim when node is ready", func() {
 			testCleanupReadyInFlightNodeClaim(suite)
 		})
@@ -475,6 +479,34 @@ func testNonCapacityDeletion(suite *NodeExpanderTestSuite) {
 	_, failed := suite.nodeExpander.failedExpansionCandidates[expansionPodKey(pod.Namespace, pod.Name, pod.UID)]
 	suite.nodeExpander.mu.RUnlock()
 	Expect(failed).To(BeFalse())
+}
+
+func testExhaustedCandidatesWaitForSchedulerRequeue(suite *NodeExpanderTestSuite) {
+	pod := createTestTensorFusionPod("exhausted-worker", suite.namespace, "100", "1Gi")
+	pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+			MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}},
+		}}},
+	}}
+	Expect(suite.k8sClient.Create(suite.ctx, pod)).To(Succeed())
+	defer func() { _ = suite.k8sClient.Delete(suite.ctx, pod) }()
+
+	candidates := suite.nodeExpander.expansionCandidatesToTry(pod)
+	Expect(candidates).To(HaveLen(1))
+	claim := inFlightNodeClaim{
+		podKey:    client.ObjectKeyFromObject(pod),
+		podUID:    pod.UID,
+		candidate: candidates[0].candidate,
+	}
+	activated := false
+	suite.nodeExpander.activatePod = func(*corev1.Pod) { activated = true }
+
+	suite.nodeExpander.handleTerminatedInFlightNodeClaim("exhausted-claim", claim, true)
+
+	Expect(activated).To(BeFalse())
+	Expect(suite.nodeExpander.expansionCandidatesToTry(pod)).To(BeEmpty())
 }
 
 func testCleanupReadyInFlightNodeClaim(suite *NodeExpanderTestSuite) {

--- a/internal/scheduler/expander/handler_test.go
+++ b/internal/scheduler/expander/handler_test.go
@@ -46,6 +46,18 @@ func (suite *NodeExpanderTestSuite) SetupSuite() {
 	// Setup fake client with scheme including TensorFusion types
 	suite.k8sClient = fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
+		WithIndex(&corev1.Event{}, "reason", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Event).Reason}
+		}).
+		WithIndex(&corev1.Event{}, "involvedObject.kind", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Event).InvolvedObject.Kind}
+		}).
+		WithIndex(&corev1.Event{}, "involvedObject.uid", func(obj client.Object) []string {
+			return []string{string(obj.(*corev1.Event).InvolvedObject.UID)}
+		}).
+		WithIndex(&corev1.Event{}, "involvedObject.name", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Event).InvolvedObject.Name}
+		}).
 		WithStatusSubresource(&tfv1.GPU{}, &tfv1.GPUNode{}, &tfv1.TensorFusionWorkload{}, &corev1.Pod{}, &corev1.Node{}).
 		Build()
 	suite.namespace = "expansion-test-ns"
@@ -73,7 +85,7 @@ func (suite *NodeExpanderTestSuite) SetupSuite() {
 
 	// Setup node expander and unscheduled pod handler
 	recorder := &events.FakeRecorder{}
-	suite.unschedHandler, suite.nodeExpander = NewUnscheduledPodHandler(ctx, nil, suite.allocator, recorder)
+	suite.unschedHandler, suite.nodeExpander = NewUnscheduledPodHandler(ctx, nil, suite.allocator, suite.k8sClient, recorder)
 }
 
 // TearDownSuite cleans up the test environment
@@ -123,6 +135,18 @@ var _ = Describe("NodeExpander Unit Tests", func() {
 			testDoNotDisruptAnnotationFiltered(suite)
 		})
 
+		It("should skip a preferred instance type outside the NodePool", func() {
+			testIncompatiblePreferenceSkipped(suite)
+		})
+
+		It("should classify insufficient capacity from the Karpenter event", func() {
+			testInsufficientCapacityEvent(suite)
+		})
+
+		It("should reactivate without failing a candidate for non-capacity deletion", func() {
+			testNonCapacityDeletion(suite)
+		})
+
 		It("should cleanup inflight node claim when node is ready", func() {
 			testCleanupReadyInFlightNodeClaim(suite)
 		})
@@ -162,6 +186,20 @@ func testKarpenterNodeClaimCreation(suite *NodeExpanderTestSuite) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-nodepool",
 		},
+		Spec: karpv1.NodePoolSpec{Template: karpv1.NodeClaimTemplate{
+			ObjectMeta: karpv1.ObjectMeta{Labels: map[string]string{"team": "inference"}},
+			Spec: karpv1.NodeClaimTemplateSpec{
+				Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+					testKarpenterRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn,
+						[]string{"g6.2xlarge", "g6.12xlarge"}),
+					testKarpenterRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn,
+						[]string{"us-east-1a", "us-east-1b"}),
+				},
+				NodeClassRef: &karpv1.NodeClassReference{
+					Group: "karpenter.k8s.aws", Kind: "EC2NodeClass", Name: "default",
+				},
+			},
+		}},
 	}
 	Expect(suite.k8sClient.Create(suite.ctx, nodePool)).To(Succeed())
 	defer func() { _ = suite.k8sClient.Delete(suite.ctx, nodePool) }()
@@ -170,6 +208,19 @@ func testKarpenterNodeClaimCreation(suite *NodeExpanderTestSuite) {
 	nodeClaim := &karpv1.NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-nodeclaim-1",
+			Labels: map[string]string{
+				corev1.LabelInstanceTypeStable:              "g6.12xlarge",
+				corev1.LabelTopologyZone:                    "us-east-1a",
+				corev1.LabelTopologyRegion:                  "us-east-1",
+				corev1.LabelHostname:                        "source-node",
+				corev1.LabelArchStable:                      "amd64",
+				corev1.LabelOSStable:                        "linux",
+				karpv1.CapacityTypeLabelKey:                 "on-demand",
+				"karpenter.k8s.aws/instance-family":         "g6",
+				"karpenter.k8s.aws/instance-generation":     "6",
+				"source.example.com/runtime-resolved-label": "drop-me",
+				"team": "source-value",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "karpenter.sh/v1",
@@ -180,17 +231,41 @@ func testKarpenterNodeClaimCreation(suite *NodeExpanderTestSuite) {
 				},
 			},
 		},
+		Spec: karpv1.NodeClaimSpec{Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+			testKarpenterRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, []string{"g6.12xlarge"}),
+			testKarpenterRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, []string{"us-east-1a"}),
+			testKarpenterRequirement("team", corev1.NodeSelectorOpIn, []string{"source-value"}),
+		}, Resources: karpv1.ResourceRequirements{Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4760m"),
+			corev1.ResourceMemory: resource.MustParse("48Gi"),
+			corev1.ResourcePods:   resource.MustParse("17"),
+		}}},
 	}
 	Expect(suite.k8sClient.Create(suite.ctx, nodeClaim)).To(Succeed())
 	defer func() { _ = suite.k8sClient.Delete(suite.ctx, nodeClaim) }()
 
 	// Create initial node owned by NodeClaim
 	node1 := createTestNode("node-1", nodeClaim)
+	// The only existing template is g6.12xlarge. The first expansion must still
+	// honor the Pod's higher-weight g6.2xlarge preference.
+	node1.Labels[corev1.LabelInstanceTypeStable] = "g6.12xlarge"
+	node1.Labels[corev1.LabelTopologyZone] = "us-east-1a"
 	Expect(suite.k8sClient.Create(suite.ctx, node1)).To(Succeed())
 	defer func() { _ = suite.k8sClient.Delete(suite.ctx, node1) }()
 
 	// Create test pod
 	pod := createTestTensorFusionPod("worker-1", suite.namespace, "1000", "8Gi")
+	pod.Spec.Containers[0].Resources.Requests[corev1.ResourceName(constants.PodIndexAnnotation)] = resource.MustParse("1")
+	pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+			{Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}}},
+			{Weight: 50, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+			}}}},
+		},
+	}}
 	Expect(suite.k8sClient.Create(suite.ctx, pod)).To(Succeed())
 	defer func() { _ = suite.k8sClient.Delete(suite.ctx, pod) }()
 
@@ -207,6 +282,61 @@ func testKarpenterNodeClaimCreation(suite *NodeExpanderTestSuite) {
 		}
 		return len(nodeClaimList.Items)
 	}, 10*time.Second, 200*time.Millisecond).Should(Equal(2))
+
+	created := &karpv1.NodeClaim{}
+	nodeClaimList := &karpv1.NodeClaimList{}
+	Expect(suite.k8sClient.List(suite.ctx, nodeClaimList)).To(Succeed())
+	for i := range nodeClaimList.Items {
+		if nodeClaimList.Items[i].Name != nodeClaim.Name {
+			created = &nodeClaimList.Items[i]
+			break
+		}
+	}
+	createdRequirements := make(map[string][]string)
+	for _, requirement := range created.Spec.Requirements {
+		createdRequirements[requirement.Key] = requirement.Values
+	}
+	Expect(createdRequirements[corev1.LabelInstanceTypeStable]).To(Equal([]string{"g6.2xlarge"}))
+	Expect(createdRequirements[corev1.LabelTopologyZone]).To(Equal([]string{"us-east-1a", "us-east-1b"}))
+	Expect(created.Spec.Resources.Requests.Cpu().String()).To(Equal("1"))
+	Expect(created.Spec.Resources.Requests.Memory().String()).To(Equal("4Gi"))
+	Expect(created.Spec.Resources.Requests.Pods().String()).To(Equal("1"))
+	Expect(created.Labels).NotTo(HaveKey(corev1.LabelInstanceTypeStable))
+	Expect(created.Labels).NotTo(HaveKey(corev1.LabelTopologyZone))
+	Expect(created.Labels).NotTo(HaveKey(corev1.LabelTopologyRegion))
+	Expect(created.Labels).NotTo(HaveKey(corev1.LabelHostname))
+	Expect(created.Labels).NotTo(HaveKey(corev1.LabelArchStable))
+	Expect(created.Labels).NotTo(HaveKey(corev1.LabelOSStable))
+	Expect(created.Labels).NotTo(HaveKey(karpv1.CapacityTypeLabelKey))
+	Expect(created.Labels).NotTo(HaveKey("karpenter.k8s.aws/instance-family"))
+	Expect(created.Labels).NotTo(HaveKey("karpenter.k8s.aws/instance-generation"))
+	Expect(created.Labels).NotTo(HaveKey("source.example.com/runtime-resolved-label"))
+	Expect(created.Labels["team"]).To(Equal("inference"))
+	Expect(created.Labels[karpv1.NodePoolLabelKey]).To(Equal(nodePool.Name))
+	Expect(created.Labels[karpv1.NodeClassLabelKey(nodePool.Spec.Template.Spec.NodeClassRef.GroupKind())]).To(Equal("default"))
+	Expect(createdRequirements["team"]).To(Equal([]string{"inference"}))
+	Expect(createdRequirements[karpv1.NodePoolLabelKey]).To(Equal([]string{nodePool.Name}))
+	Expect(createdRequirements[karpv1.NodeClassLabelKey(nodePool.Spec.Template.Spec.NodeClassRef.GroupKind())]).To(Equal([]string{"default"}))
+	_, hasTensorFusionIndex := created.Spec.Resources.Requests[corev1.ResourceName(constants.PodIndexAnnotation)]
+	Expect(hasTensorFusionIndex).To(BeFalse())
+
+	value, exists := suite.nodeExpander.inFlightNodeClaims.Load(created.Name)
+	Expect(exists).To(BeTrue())
+	activated := make(chan *corev1.Pod, 1)
+	suite.nodeExpander.activatePod = func(pod *corev1.Pod) { activated <- pod }
+	suite.nodeExpander.handleTerminatedInFlightNodeClaim(created.Name, value, true)
+	Eventually(activated).Should(Receive(Equal(pod)))
+
+	secondNode := node1.DeepCopy()
+	secondNode.Name = "node-2"
+	Expect(suite.nodeExpander.createGPUNodeClaim(suite.ctx, pod, secondNode)).To(Succeed())
+	secondClaim := &karpv1.NodeClaim{}
+	Expect(suite.k8sClient.Get(suite.ctx, client.ObjectKey{Name: secondNode.Name}, secondClaim)).To(Succeed())
+	secondRequirements := make(map[string][]string)
+	for _, requirement := range secondClaim.Spec.Requirements {
+		secondRequirements[requirement.Key] = requirement.Values
+	}
+	Expect(secondRequirements[corev1.LabelInstanceTypeStable]).To(Equal([]string{"g6.12xlarge"}))
 }
 
 func testExpansionLabelNotOverridden(suite *NodeExpanderTestSuite) {
@@ -231,7 +361,7 @@ func testExpansionLabelNotOverridden(suite *NodeExpanderTestSuite) {
 	newClaim := &karpv1.NodeClaim{}
 	Expect(suite.k8sClient.Get(suite.ctx, client.ObjectKey{Name: preparedNode.Name}, newClaim)).To(Succeed())
 	Expect(newClaim.Labels[constants.KarpenterExpansionLabel]).To(Equal(preparedNode.Name))
-	Expect(newClaim.Labels["env"]).To(Equal("prod"))
+	Expect(newClaim.Labels).NotTo(HaveKey("env"))
 }
 
 func testDoNotDisruptAnnotationFiltered(suite *NodeExpanderTestSuite) {
@@ -260,6 +390,93 @@ func testDoNotDisruptAnnotationFiltered(suite *NodeExpanderTestSuite) {
 	Expect(newClaim.Annotations["karpenter.sh/custom-note"]).To(Equal("keep-me"))
 }
 
+func testIncompatiblePreferenceSkipped(suite *NodeExpanderTestSuite) {
+	nodePool := &karpv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "fallback-nodepool"},
+		Spec: karpv1.NodePoolSpec{Template: karpv1.NodeClaimTemplate{Spec: karpv1.NodeClaimTemplateSpec{
+			Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+				testKarpenterRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, []string{"g6.12xlarge"}),
+			},
+		}}},
+	}
+	Expect(suite.k8sClient.Create(suite.ctx, nodePool)).To(Succeed())
+	defer func() { _ = suite.k8sClient.Delete(suite.ctx, nodePool) }()
+
+	source := &karpv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fallback-source",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "karpenter.sh/v1", Kind: constants.KarpenterNodePoolKind, Name: nodePool.Name,
+			}},
+		},
+		Spec: karpv1.NodeClaimSpec{Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+			testKarpenterRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, []string{"g6.12xlarge"}),
+		}},
+	}
+	pod := createTestTensorFusionPod("fallback-worker", suite.namespace, "100", "1Gi")
+	pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+			{Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}}},
+			{Weight: 50, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+			}}}},
+		},
+	}}
+	preparedNode := createTestNode("fallback-created", source)
+
+	Expect(suite.nodeExpander.createKarpenterNodeClaimDirect(suite.ctx, pod, preparedNode, source)).To(Succeed())
+	created := &karpv1.NodeClaim{}
+	Expect(suite.k8sClient.Get(suite.ctx, client.ObjectKey{Name: preparedNode.Name}, created)).To(Succeed())
+	for _, requirement := range created.Spec.Requirements {
+		if requirement.Key == corev1.LabelInstanceTypeStable {
+			Expect(requirement.Values).To(Equal([]string{"g6.12xlarge"}))
+			return
+		}
+	}
+	Fail("created NodeClaim did not contain an instance-type requirement")
+}
+
+func testInsufficientCapacityEvent(suite *NodeExpanderTestSuite) {
+	claim := inFlightNodeClaim{nodeClaimUID: "failed-claim-uid"}
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "insufficient-capacity", Namespace: suite.namespace},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: constants.KarpenterNodeClaimKind, Name: "failed-claim", UID: claim.nodeClaimUID,
+		},
+		Reason: insufficientCapacityReason,
+	}
+	Expect(suite.k8sClient.Create(suite.ctx, event)).To(Succeed())
+	Expect(suite.nodeExpander.hasInsufficientCapacityEvent("failed-claim", claim)).To(BeTrue())
+
+	event.Reason = "Disrupted"
+	Expect(suite.nodeExpander.hasInsufficientCapacityEvent("failed-claim", inFlightNodeClaim{nodeClaimUID: "other-uid"})).To(BeFalse())
+}
+
+func testNonCapacityDeletion(suite *NodeExpanderTestSuite) {
+	pod := createTestTensorFusionPod("non-capacity-worker", suite.namespace, "100", "1Gi")
+	Expect(suite.k8sClient.Create(suite.ctx, pod)).To(Succeed())
+	defer func() { _ = suite.k8sClient.Delete(suite.ctx, pod) }()
+
+	claim := inFlightNodeClaim{
+		podKey:    client.ObjectKeyFromObject(pod),
+		podUID:    pod.UID,
+		candidate: "candidate-a",
+	}
+	suite.nodeExpander.inFlightNodeClaims.Store("non-capacity-claim", claim)
+	activated := make(chan *corev1.Pod, 1)
+	suite.nodeExpander.activatePod = func(pod *corev1.Pod) { activated <- pod }
+
+	suite.nodeExpander.handleTerminatedInFlightNodeClaim("non-capacity-claim", claim, false)
+
+	Eventually(activated).Should(Receive(Equal(pod)))
+	suite.nodeExpander.mu.RLock()
+	_, failed := suite.nodeExpander.failedExpansionCandidates[expansionPodKey(pod.Namespace, pod.Name, pod.UID)]
+	suite.nodeExpander.mu.RUnlock()
+	Expect(failed).To(BeFalse())
+}
+
 func testCleanupReadyInFlightNodeClaim(suite *NodeExpanderTestSuite) {
 	nodeClaim := &karpv1.NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -268,6 +485,8 @@ func testCleanupReadyInFlightNodeClaim(suite *NodeExpanderTestSuite) {
 	}
 	nodeClaim.Status.NodeName = "ready-node"
 	nodeClaim.StatusConditions().SetTrue(status.ConditionReady)
+	now := metav1.Now()
+	nodeClaim.DeletionTimestamp = &now
 
 	gpu := &tfv1.GPU{
 		ObjectMeta: metav1.ObjectMeta{Name: "gpu-ready"},
@@ -283,7 +502,12 @@ func testCleanupReadyInFlightNodeClaim(suite *NodeExpanderTestSuite) {
 		},
 	}
 
-	suite.nodeExpander.inFlightNodeClaims.Store(nodeClaim.Name, true)
+	claim := inFlightNodeClaim{
+		podKey:    client.ObjectKey{Namespace: suite.namespace, Name: "ready-pod"},
+		candidate: "ready-candidate",
+	}
+	suite.nodeExpander.inFlightNodeClaims.Store(nodeClaim.Name, claim)
+	suite.nodeExpander.addFailedExpansionCandidate(claim.podKey, claim.podUID, claim.candidate)
 	suite.nodeExpander.addInFlightNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeClaim.Name}}, []*tfv1.GPU{gpu})
 
 	suite.nodeExpander.cleanupInFlightNodeClaim(nodeClaim)
@@ -293,8 +517,10 @@ func testCleanupReadyInFlightNodeClaim(suite *NodeExpanderTestSuite) {
 
 	suite.nodeExpander.mu.RLock()
 	_, exists := suite.nodeExpander.inFlightNodes[nodeClaim.Name]
+	_, failedExists := suite.nodeExpander.failedExpansionCandidates[expansionPodKey(claim.podKey.Namespace, claim.podKey.Name, claim.podUID)]
 	suite.nodeExpander.mu.RUnlock()
 	Expect(exists).To(BeFalse())
+	Expect(failedExists).To(BeFalse())
 }
 
 // Test inflight node management

--- a/internal/scheduler/expander/requirements_test.go
+++ b/internal/scheduler/expander/requirements_test.go
@@ -372,6 +372,36 @@ func TestFailedExpansionCandidateState(t *testing.T) {
 	require.Empty(t, expander.expansionCandidatesToTry(pod))
 }
 
+func TestResetExpansionCandidatesForNewRoundOnlyAfterExhaustion(t *testing.T) {
+	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "worker", UID: types.UID("worker-uid")},
+		Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+				}}},
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+				}}},
+			}},
+		}}},
+	}
+	podKey := client.ObjectKeyFromObject(pod)
+	candidates := expander.expansionCandidatesToTry(pod)
+	require.Len(t, candidates, 2)
+
+	expander.addFailedExpansionCandidate(podKey, pod.UID, candidates[0].candidate)
+	require.False(t, expander.resetExpansionCandidatesForNewRound(pod))
+	require.Len(t, expander.expansionCandidatesToTry(pod), 1)
+
+	expander.addFailedExpansionCandidate(podKey, pod.UID, candidates[1].candidate)
+	require.Empty(t, expander.expansionCandidatesToTry(pod))
+	require.True(t, expander.resetExpansionCandidatesForNewRound(pod))
+	require.Len(t, expander.expansionCandidatesToTry(pod), 2)
+	require.False(t, expander.resetExpansionCandidatesForNewRound(pod))
+}
+
 func TestFailedExpansionCandidateStateIsScopedByPodUID(t *testing.T) {
 	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "worker", UID: types.UID("old-uid")}}

--- a/internal/scheduler/expander/requirements_test.go
+++ b/internal/scheduler/expander/requirements_test.go
@@ -1,0 +1,437 @@
+package expander
+
+import (
+	"testing"
+	"time"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+func TestMergePodKarpenterRequirements(t *testing.T) {
+	spec := &karpv1.NodeClaimSpec{
+		Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+			testKarpenterRequirement("node.kubernetes.io/instance-type", corev1.NodeSelectorOpIn,
+				[]string{"g6.2xlarge", "g6.12xlarge"}),
+			testKarpenterRequirement("topology.kubernetes.io/zone", corev1.NodeSelectorOpIn,
+				[]string{"us-east-1a", "us-east-1b"}),
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "node.kubernetes.io/instance-type", Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge", "g6.12xlarge"}},
+						{Key: "topology.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a", "us-east-1b"}},
+					}}},
+				},
+			}},
+		},
+	}
+
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 1)
+	require.True(t, mergeKarpenterRequirements(spec, candidates[0].requirements))
+
+	require.ElementsMatch(t, []string{"g6.2xlarge", "g6.12xlarge"}, spec.Requirements[0].Values)
+	require.ElementsMatch(t, []string{"us-east-1a", "us-east-1b"}, spec.Requirements[1].Values)
+}
+
+func TestMergePodKarpenterRequirementsPreservesPoolIntersection(t *testing.T) {
+	spec := &karpv1.NodeClaimSpec{Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+		testKarpenterRequirement("node.kubernetes.io/instance-type", corev1.NodeSelectorOpIn,
+			[]string{"g6.2xlarge", "g6.12xlarge"}),
+		testKarpenterRequirement("topology.kubernetes.io/zone", corev1.NodeSelectorOpIn,
+			[]string{"us-east-1a", "us-east-1b"}),
+	}}
+	pod := &corev1.Pod{Spec: corev1.PodSpec{NodeSelector: map[string]string{
+		"node.kubernetes.io/instance-type": "g6.12xlarge",
+	}}}
+	require.True(t, mergeKarpenterRequirements(spec, podKarpenterRequirementValues(pod)))
+	require.Equal(t, []string{"g6.12xlarge"}, spec.Requirements[0].Values)
+	require.Equal(t, []string{"us-east-1a", "us-east-1b"}, spec.Requirements[1].Values)
+}
+
+func TestMergeKarpenterRequirementsRejectsEmptyIntersection(t *testing.T) {
+	spec := &karpv1.NodeClaimSpec{Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+		testKarpenterRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, []string{"g6.12xlarge"}),
+	}}
+
+	require.False(t, mergeKarpenterRequirements(spec, map[string][]string{
+		corev1.LabelInstanceTypeStable: {"g6.2xlarge"},
+	}))
+	require.Equal(t, []string{"g6.12xlarge"}, spec.Requirements[0].Values)
+}
+
+func TestMergeKarpenterRequirementsUsesKarpenterOperatorSemantics(t *testing.T) {
+	spec := &karpv1.NodeClaimSpec{Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+		testKarpenterRequirement("capacity", corev1.NodeSelectorOpNotIn, []string{"reserved"}),
+		testKarpenterRequirement("team", corev1.NodeSelectorOpExists, nil),
+	}}
+
+	require.True(t, mergeKarpenterRequirements(spec, map[string][]string{
+		"capacity": {"on-demand"},
+		"team":     {"inference"},
+	}))
+	require.Equal(t, map[string][]string{
+		"capacity": {"on-demand"},
+		"team":     {"inference"},
+	}, requirementValuesByKey(spec.Requirements))
+
+	require.False(t, mergeKarpenterRequirements(spec, map[string][]string{
+		"capacity": {"reserved"},
+	}))
+}
+
+func TestMergeKarpenterRequirementsPreservesMinValues(t *testing.T) {
+	minValues := 2
+	requirement := testKarpenterRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn,
+		[]string{"g6.2xlarge", "g6.12xlarge"})
+	requirement.MinValues = &minValues
+	spec := &karpv1.NodeClaimSpec{Requirements: []karpv1.NodeSelectorRequirementWithMinValues{requirement}}
+
+	require.False(t, mergeKarpenterRequirements(spec, map[string][]string{
+		corev1.LabelInstanceTypeStable: {"g6.2xlarge"},
+	}))
+	require.ElementsMatch(t, []string{"g6.2xlarge", "g6.12xlarge"}, spec.Requirements[0].Values)
+}
+
+func requirementValuesByKey(requirements []karpv1.NodeSelectorRequirementWithMinValues) map[string][]string {
+	values := make(map[string][]string, len(requirements))
+	for _, requirement := range requirements {
+		values[requirement.Key] = requirement.Values
+	}
+	return values
+}
+
+func testKarpenterRequirement(
+	key string,
+	operator corev1.NodeSelectorOperator,
+	values []string,
+) karpv1.NodeSelectorRequirementWithMinValues {
+	return karpv1.NodeSelectorRequirementWithMinValues{NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+		Key: key, Operator: operator, Values: values,
+	}}
+}
+
+func TestPodKarpenterRequirementValuesIntersectsSelectorAndAffinity(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{
+		NodeSelector: map[string]string{corev1.LabelInstanceTypeStable: "g6.12xlarge"},
+		Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge", "g6.12xlarge"},
+				}},
+			}}},
+		}},
+	}}
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 1)
+	require.Equal(t, []string{"g6.12xlarge"}, candidates[0].requirements[corev1.LabelInstanceTypeStable])
+}
+
+func TestPreferredExpansionCandidatesFollowWeight(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+			{Weight: 50, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+			}}}},
+			{Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}}},
+			{Weight: 75, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}}},
+		},
+	}}}}
+
+	candidates := preferredExpansionCandidates(pod)
+	require.Len(t, candidates, 3)
+	require.Equal(t, []string{"g6.2xlarge"}, candidates[0].requirements[corev1.LabelInstanceTypeStable])
+	require.Equal(t, []string{"g6.12xlarge"}, candidates[1].requirements[corev1.LabelInstanceTypeStable])
+	require.Equal(t, relaxedExpansionCandidate, candidates[2].candidate)
+
+}
+
+func TestPodKarpenterRequirementValuesIncludesRegion(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{
+		NodeSelector: map[string]string{corev1.LabelTopologyRegion: "us-west-2"},
+	}}
+
+	values := podKarpenterRequirementValues(pod)
+	require.Equal(t, []string{"us-west-2"}, values[corev1.LabelTopologyRegion])
+}
+
+func TestMergeRegionRequirementMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		podRegions  []string
+		poolRegions []string
+		wantRegions []string
+		wantValid   bool
+	}{
+		{
+			name:        "pod and pool use intersection",
+			podRegions:  []string{"us-east-1", "eu-west-1"},
+			poolRegions: []string{"us-east-1", "us-west-2"},
+			wantRegions: []string{"us-east-1"},
+			wantValid:   true,
+		},
+		{
+			name:        "pod region without pool region",
+			podRegions:  []string{"us-west-2"},
+			wantRegions: []string{"us-west-2"},
+			wantValid:   true,
+		},
+		{
+			name:        "single pool region without pod region",
+			poolRegions: []string{"us-east-1"},
+			wantRegions: []string{"us-east-1"},
+			wantValid:   true,
+		},
+		{
+			name:        "multiple pool regions stay in one requirement",
+			poolRegions: []string{"us-east-1", "us-west-2"},
+			wantRegions: []string{"us-east-1", "us-west-2"},
+			wantValid:   true,
+		},
+		{
+			name:      "no pod or pool region",
+			wantValid: true,
+		},
+		{
+			name:        "empty intersection is invalid",
+			podRegions:  []string{"us-west-2"},
+			poolRegions: []string{"us-east-1"},
+			wantValid:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &karpv1.NodeClaimSpec{}
+			if len(tt.poolRegions) > 0 {
+				spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{
+					testKarpenterRequirement(corev1.LabelTopologyRegion, corev1.NodeSelectorOpIn, tt.poolRegions),
+				}
+			}
+			podRequirements := make(map[string][]string)
+			if len(tt.podRegions) > 0 {
+				podRequirements[corev1.LabelTopologyRegion] = tt.podRegions
+			}
+
+			require.Equal(t, tt.wantValid, mergeKarpenterRequirements(spec, podRequirements))
+			if !tt.wantValid {
+				return
+			}
+			regions, exists := requirementValuesByKey(spec.Requirements)[corev1.LabelTopologyRegion]
+			if len(tt.wantRegions) == 0 {
+				require.False(t, exists)
+				return
+			}
+			require.ElementsMatch(t, tt.wantRegions, regions)
+		})
+	}
+}
+
+func TestPreferredExpansionCandidatesIncludeRegion(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+			{Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelTopologyRegion, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-west-2"},
+			}}}},
+		},
+	}}}}
+
+	candidates := preferredExpansionCandidates(pod)
+	require.Len(t, candidates, 2)
+	require.Equal(t, []string{"us-west-2"}, candidates[0].requirements[corev1.LabelTopologyRegion])
+	require.Equal(t, relaxedExpansionCandidate, candidates[1].candidate)
+}
+
+func TestRequiredExpansionCandidatesPreserveTermOrderAndCorrelation(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{MatchExpressions: []corev1.NodeSelectorRequirement{
+				{Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"}},
+				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"}},
+			}},
+			{MatchExpressions: []corev1.NodeSelectorRequirement{
+				{Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"}},
+				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1b"}},
+			}},
+		}},
+	}}}}
+
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 2)
+	require.Equal(t, []string{"g6.2xlarge"}, candidates[0].requirements[corev1.LabelInstanceTypeStable])
+	require.Equal(t, []string{"us-east-1a"}, candidates[0].requirements[corev1.LabelTopologyZone])
+	require.Equal(t, []string{"g6.12xlarge"}, candidates[1].requirements[corev1.LabelInstanceTypeStable])
+	require.Equal(t, []string{"us-east-1b"}, candidates[1].requirements[corev1.LabelTopologyZone])
+}
+
+func TestExpansionCandidatesCombinePreferredWeightWithRequiredTerms(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"},
+			}}},
+			{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1b"},
+			}}},
+		}},
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+			{Weight: 50, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+			}}}},
+			{Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}}},
+		},
+	}}}}
+
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 6)
+	want := [][2]string{
+		{"g6.2xlarge", "us-east-1a"},
+		{"g6.2xlarge", "us-east-1b"},
+		{"g6.12xlarge", "us-east-1a"},
+		{"g6.12xlarge", "us-east-1b"},
+		{"", "us-east-1a"},
+		{"", "us-east-1b"},
+	}
+	for i, expected := range want {
+		require.Equal(t, expected[1], candidates[i].requirements[corev1.LabelTopologyZone][0])
+		if expected[0] == "" {
+			require.NotContains(t, candidates[i].requirements, corev1.LabelInstanceTypeStable)
+		} else {
+			require.Equal(t, expected[0], candidates[i].requirements[corev1.LabelInstanceTypeStable][0])
+		}
+	}
+}
+
+func TestExpansionCandidatesSkipConflictingRequiredAndPreferredCombination(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+			MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+			}},
+		}}},
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
+			Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}},
+		}},
+	}}}}
+
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 1)
+	require.Equal(t, []string{"g6.12xlarge"}, candidates[0].requirements[corev1.LabelInstanceTypeStable])
+}
+
+func TestFailedExpansionCandidateState(t *testing.T) {
+	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "worker", UID: types.UID("worker-uid")}}
+	pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+			{Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}}},
+			{Weight: 50, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+			}}}},
+		},
+	}}
+	podKey := client.ObjectKeyFromObject(pod)
+	remaining := expander.expansionCandidatesToTry(pod)
+	require.Len(t, remaining, 3)
+	high := remaining[0]
+	require.Equal(t, []string{"g6.2xlarge"}, high.requirements[corev1.LabelInstanceTypeStable])
+
+	expander.addFailedExpansionCandidate(podKey, pod.UID, high.candidate)
+	remaining = expander.expansionCandidatesToTry(pod)
+	require.Len(t, remaining, 2)
+	low := remaining[0]
+	require.Equal(t, []string{"g6.12xlarge"}, low.requirements[corev1.LabelInstanceTypeStable])
+
+	expander.addFailedExpansionCandidate(podKey, pod.UID, low.candidate)
+	remaining = expander.expansionCandidatesToTry(pod)
+	require.Len(t, remaining, 1)
+	relaxed := remaining[0]
+	require.Equal(t, relaxedExpansionCandidate, relaxed.candidate)
+
+	expander.addFailedExpansionCandidate(podKey, pod.UID, relaxed.candidate)
+	require.Empty(t, expander.expansionCandidatesToTry(pod))
+}
+
+func TestFailedExpansionCandidateStateIsScopedByPodUID(t *testing.T) {
+	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "worker", UID: types.UID("old-uid")}}
+	pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+			{
+				Weight: 100,
+				Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      corev1.LabelInstanceTypeStable,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"g6.2xlarge"},
+					},
+				}},
+			},
+		},
+	}}
+
+	first := expander.expansionCandidatesToTry(pod)[0]
+	expander.addFailedExpansionCandidate(client.ObjectKeyFromObject(pod), pod.UID, first.candidate)
+
+	recreated := pod.DeepCopy()
+	recreated.UID = types.UID("new-uid")
+	require.Equal(t, first.candidate, expander.expansionCandidatesToTry(recreated)[0].candidate)
+	require.NotContains(t, expander.failedExpansionCandidates, expansionPodKey(pod.Namespace, pod.Name, pod.UID))
+}
+
+func TestClearFailedExpansionCandidatesForDeletedPod(t *testing.T) {
+	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
+	expander.addFailedExpansionCandidate(client.ObjectKey{Namespace: "default", Name: "worker"}, "old-uid", "old")
+	expander.addFailedExpansionCandidate(client.ObjectKey{Namespace: "default", Name: "worker"}, "new-uid", "new")
+	expander.addFailedExpansionCandidate(client.ObjectKey{Namespace: "default", Name: "other"}, "other-uid", "other")
+
+	expander.ClearFailedExpansionCandidatesForPod("default", "worker")
+
+	require.NotContains(t, expander.failedExpansionCandidates, expansionPodKey("default", "worker", "old-uid"))
+	require.NotContains(t, expander.failedExpansionCandidates, expansionPodKey("default", "worker", "new-uid"))
+	require.Contains(t, expander.failedExpansionCandidates, expansionPodKey("default", "other", "other-uid"))
+}
+
+func TestNodeScalerInfoExposesExpansionState(t *testing.T) {
+	expander := &NodeExpander{
+		inFlightNodes:             make(map[string][]*tfv1.GPU),
+		failedExpansionCandidates: make(map[string]map[string]struct{}),
+		preSchedulePods:           make(map[string]*tfv1.AllocRequest),
+		preScheduleTimers:         make(map[string]*time.Timer),
+	}
+	claim := inFlightNodeClaim{
+		podKey:    client.ObjectKey{Namespace: "default", Name: "worker"},
+		podUID:    "worker-uid",
+		candidate: "candidate-a",
+	}
+	expander.inFlightNodeClaims.Store("claim-a", claim)
+	expander.addFailedExpansionCandidate(claim.podKey, claim.podUID, claim.candidate)
+
+	info := expander.GetNodeScalerInfo().(map[string]any)
+	inFlight := info["inFlightNodeClaims"].(map[string]any)
+	require.Equal(t, map[string]string{
+		"pod": "default/worker", "podUID": "worker-uid", "candidate": "candidate-a",
+	}, inFlight["claim-a"])
+	failed := info["failedExpansionCandidates"].(map[string][]string)
+	require.Equal(t, []string{"candidate-a"}, failed[expansionPodKey("default", "worker", "worker-uid")])
+}

--- a/internal/scheduler/expander/unsched_queue.go
+++ b/internal/scheduler/expander/unsched_queue.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -33,8 +34,9 @@ type UnscheduledPodHandler struct {
 }
 
 func NewUnscheduledPodHandler(ctx context.Context, scheduler *scheduler.Scheduler,
-	allocator *gpuallocator.GpuAllocator, recorder events.EventRecorder) (*UnscheduledPodHandler, *NodeExpander) {
-	nodeExpander := NewNodeExpander(ctx, allocator, scheduler, recorder)
+	allocator *gpuallocator.GpuAllocator, eventReader client.Reader,
+	recorder events.EventRecorder) (*UnscheduledPodHandler, *NodeExpander) {
+	nodeExpander := NewNodeExpander(ctx, allocator, scheduler, eventReader, recorder)
 	h := &UnscheduledPodHandler{
 		pending:      make(map[string]*corev1.Pod),
 		queue:        make(chan *queuedPod, 256),

--- a/internal/scheduler/expander/unsched_queue.go
+++ b/internal/scheduler/expander/unsched_queue.go
@@ -72,6 +72,10 @@ func (h *UnscheduledPodHandler) HandleRejectedPod(ctx context.Context, podInfo f
 
 	// take snapshot to avoid modify origin Pod info
 	pod = pod.DeepCopy()
+	if h.nodeExpander.resetExpansionCandidatesForNewRound(pod) {
+		h.logger.Info("scheduler requeued pod after all Karpenter expansion candidates failed, starting a new expansion round",
+			"pod", klog.KObj(pod))
+	}
 
 	h.mu.Lock()
 	if _, ok := h.pending[string(pod.UID)]; ok {

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -704,7 +704,7 @@ var _ = Describe("Compose Utils", func() {
 					Expect(container.Command[2]).To(ContainSubstring("exec ./tensor-fusion-worker"), "should exec worker")
 					Expect(container.Command[2]).To(ContainSubstring("-n shmem"), "should use shmem mode")
 					Expect(container.Command[2]).To(ContainSubstring("-m tf_shm"), "should specify shared memory name")
-					Expect(container.Command[2]).To(ContainSubstring("-M 1024"), "should specify shared memory size")
+					Expect(container.Command[2]).To(ContainSubstring("-M "+constants.ConnectionSharedMemSize), "should specify shared memory size")
 				}
 			},
 			Entry("hard worker: no LD_PRELOAD, no NVIDIA_VISIBLE_DEVICES=all (device plugin allocates UUID)", "NVIDIA", "worker:latest", "", false, tfv1.IsolationModeType(tfv1.IsolationModeHard), []string{
@@ -720,7 +720,7 @@ var _ = Describe("Compose Utils", func() {
 			Entry("worker with shared memory mode (hard)", "NVIDIA", "worker:latest", "", true, tfv1.IsolationModeType(tfv1.IsolationModeHard), []string{
 				"/bin/bash",
 				"-c",
-				"touch /dev/shm/tf_shm && chmod 666 /dev/shm/tf_shm && exec ./tensor-fusion-worker -n shmem -m tf_shm -M 1024",
+				"touch /dev/shm/tf_shm && chmod 666 /dev/shm/tf_shm && exec ./tensor-fusion-worker -n shmem -m tf_shm -M 2048",
 			}, false, false),
 			Entry("worker with disabled start-worker feature (hard)", "NVIDIA", "worker:latest", "start-worker", false, tfv1.IsolationModeType(tfv1.IsolationModeHard), []string{
 				"sleep",

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -100,7 +100,7 @@ const (
 	ConnectionNameEnv       = "TENSOR_FUSION_CONNECTION_NAME"
 	ConnectionNamespaceEnv  = "TENSOR_FUSION_CONNECTION_NAMESPACE"
 	DisableVMSharedMemEnv   = "TF_USE_IVSHMEM"
-	ConnectionSharedMemSize = "1024"
+	ConnectionSharedMemSize = "2048"
 	ConnectionSharedMemName = "tf_shm"
 
 	EnableCudaHooksEnv = "ENABLE_CUDA_HOOKS"


### PR DESCRIPTION
 ## 背景

  当 Karpenter 因云厂商库存不足删除 TensorFusion 创建的 NodeClaim 时，Node Expander 会持续使用原来的实例类型和可用区重新扩容，无法尝
  试 Pod 中优先级较低的备选机型或其他可用区。

  ## 修改内容

  - 按 Pod preferred node affinity 的 weight 顺序生成扩容候选项并去重
  - 当前候选因 `InsufficientCapacityError` 失败后，重新激活 Pod 并尝试下一个候选
  - 所有 preferred 候选失败后，执行一次放宽 preferred 条件的 fallback
  - 候选全部耗尽后停止重复创建相同 NodeClaim，等待 Pod 重建或新的资源缺口
  - 使用 APIReader 和服务端字段过滤查询容量不足 Event，避免缓存和遍历全集群 Event
  - 从当前 NodePool 模板重建 NodeClaim requirements 和 labels
  - 不再继承源 NodeClaim 已固化的实例类型、可用区及运行时 labels
  - 检测 requirement 空交集，避免创建非法的 `In + []` NodeClaim
  - 在 Pod 删除、UID 变化、扩容成功时清理失败候选状态
  - 优先判断 NodeClaim Ready/NodeName，避免将已成功扩容后删除的 NodeClaim误判为容量不足
  - 补充候选排序、去重、requirement 合并、状态清理及失败重试测试

  ## 兼容性

  - 保持 main 当前 Karpenter `v1.8.2`
  - 未修改 `go.mod`、`go.sum`、vendor、CRD 或 Helm 配置
  - 保留 main 的 Dynamic GPU isolation、scheduler vendor patch 和新版 EventRecorder 实现

  ## 验证

  - `go test ./internal/scheduler/expander ./cmd/sched`
  - Pod Controller 测试通过
  - `go test ./... -run '^$'`
  - `go vet ./internal/scheduler/expander ./cmd/sched ./internal/controller`
  - golangci-lint：`0 issues`