### PR TITLE
 fix(expander): 支持 Karpenter required affinity 多候选回退扩容

### DIFF
--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
 	resourcehelper "k8s.io/component-helpers/resource"
-	schedulingcorev1 "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler"
@@ -197,7 +196,7 @@ func (e *NodeExpander) handleTerminatedInFlightNodeClaim(name string, value any,
 	if insufficientCapacity {
 		e.addFailedExpansionCandidate(claim.podKey, claim.podUID, claim.candidate)
 		e.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "NodeExpansionCandidateFailed",
-			"Karpenter NodeClaim %s failed due to insufficient capacity; trying the next expansion preference", name)
+			"Karpenter NodeClaim %s failed due to insufficient capacity; trying the next expansion candidate", name)
 	}
 	if e.activatePod != nil {
 		e.activatePod(pod)
@@ -478,14 +477,14 @@ func (e *NodeExpander) ClearFailedExpansionCandidatesForPod(namespace, name stri
 
 const relaxedExpansionCandidate = "<relaxed>"
 
-type expansionPreference struct {
+type expansionCandidate struct {
 	candidate    string
 	requirements map[string][]string
 }
 
-func preferredExpansionCandidates(pod *corev1.Pod) []expansionPreference {
+func preferredExpansionCandidates(pod *corev1.Pod) []expansionCandidate {
 	if pod == nil || pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
-		return []expansionPreference{{candidate: relaxedExpansionCandidate}}
+		return []expansionCandidate{{candidate: relaxedExpansionCandidate}}
 	}
 	terms := append([]corev1.PreferredSchedulingTerm(nil),
 		pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
@@ -493,7 +492,7 @@ func preferredExpansionCandidates(pod *corev1.Pod) []expansionPreference {
 		return terms[i].Weight > terms[j].Weight
 	})
 
-	candidates := make([]expansionPreference, 0, len(terms)+1)
+	candidates := make([]expansionCandidate, 0, len(terms)+1)
 	seen := make(map[string]struct{}, len(terms)+1)
 	for _, term := range terms {
 		requirements := make(map[string][]string)
@@ -514,10 +513,120 @@ func preferredExpansionCandidates(pod *corev1.Pod) []expansionPreference {
 			continue
 		}
 		seen[candidate] = struct{}{}
-		candidates = append(candidates, expansionPreference{candidate: candidate, requirements: requirements})
+		candidates = append(candidates, expansionCandidate{candidate: candidate, requirements: requirements})
 	}
-	candidates = append(candidates, expansionPreference{candidate: relaxedExpansionCandidate})
+	candidates = append(candidates, expansionCandidate{candidate: relaxedExpansionCandidate})
 	return candidates
+}
+
+func requiredExpansionCandidates(pod *corev1.Pod) []expansionCandidate {
+	if pod == nil || pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil ||
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return []expansionCandidate{{}}
+	}
+	terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) == 0 {
+		return []expansionCandidate{{}}
+	}
+
+	candidates := make([]expansionCandidate, 0, len(terms))
+	seen := make(map[string]struct{}, len(terms))
+	for _, term := range terms {
+		requirements := make(map[string][]string)
+		compatible := true
+		for _, expression := range term.MatchExpressions {
+			if expression.Operator != corev1.NodeSelectorOpIn || !isExpansionRequirementKey(expression.Key) {
+				continue
+			}
+			var merged map[string][]string
+			merged, compatible = mergeExpansionRequirementValues(requirements, map[string][]string{
+				expression.Key: expression.Values,
+			})
+			if !compatible {
+				break
+			}
+			requirements = merged
+		}
+		if !compatible {
+			continue
+		}
+		candidate := expansionRequirementsKey(requirements)
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		candidates = append(candidates, expansionCandidate{candidate: candidate, requirements: requirements})
+	}
+	return candidates
+}
+
+func podExpansionCandidates(pod *corev1.Pod) []expansionCandidate {
+	baseRequirements := podKarpenterRequirementValues(pod)
+	requiredCandidates := requiredExpansionCandidates(pod)
+	preferredCandidates := preferredExpansionCandidates(pod)
+	candidates := make([]expansionCandidate, 0, len(requiredCandidates)*len(preferredCandidates))
+	seen := make(map[string]struct{}, cap(candidates))
+
+	// Preserve preferred weight order, then try required OR terms in their
+	// declaration order for each preference.
+	for _, preferred := range preferredCandidates {
+		for _, required := range requiredCandidates {
+			requirements, compatible := mergeExpansionRequirementValues(
+				baseRequirements, required.requirements, preferred.requirements,
+			)
+			if !compatible {
+				continue
+			}
+			candidate := expansionRequirementsKey(requirements)
+			if candidate == "" {
+				candidate = relaxedExpansionCandidate
+			}
+			if _, exists := seen[candidate]; exists {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			candidates = append(candidates, expansionCandidate{candidate: candidate, requirements: requirements})
+		}
+	}
+	return candidates
+}
+
+func mergeExpansionRequirementValues(requirementSets ...map[string][]string) (map[string][]string, bool) {
+	merged := make(map[string][]string)
+	for _, requirements := range requirementSets {
+		for key, values := range requirements {
+			values = uniqueStrings(values)
+			if len(values) == 0 {
+				return nil, false
+			}
+			current, exists := merged[key]
+			if !exists {
+				merged[key] = append([]string(nil), values...)
+				continue
+			}
+			allowed := make(map[string]struct{}, len(values))
+			for _, value := range values {
+				allowed[value] = struct{}{}
+			}
+			intersection := make([]string, 0, len(current))
+			for _, value := range current {
+				if _, ok := allowed[value]; ok {
+					intersection = append(intersection, value)
+				}
+			}
+			if len(intersection) == 0 {
+				return nil, false
+			}
+			merged[key] = intersection
+		}
+	}
+	return merged, true
+}
+
+func isExpansionRequirementKey(key string) bool {
+	return key == corev1.LabelInstanceTypeStable ||
+		key == corev1.LabelTopologyZone ||
+		key == corev1.LabelTopologyRegion
 }
 
 func expansionRequirementsKey(requirements map[string][]string) string {
@@ -534,8 +643,8 @@ func expansionRequirementsKey(requirements map[string][]string) string {
 	return strings.Join(parts, ";")
 }
 
-func (e *NodeExpander) expansionPreferencesToTry(pod *corev1.Pod) []expansionPreference {
-	candidates := preferredExpansionCandidates(pod)
+func (e *NodeExpander) expansionCandidatesToTry(pod *corev1.Pod) []expansionCandidate {
+	candidates := podExpansionCandidates(pod)
 	podKey := expansionPodKey(pod.Namespace, pod.Name, pod.UID)
 	prefix := expansionPodPrefix(pod.Namespace, pod.Name)
 
@@ -549,7 +658,7 @@ func (e *NodeExpander) expansionPreferencesToTry(pod *corev1.Pod) []expansionPre
 		}
 	}
 	failed := e.failedExpansionCandidates[podKey]
-	remaining := make([]expansionPreference, 0, len(candidates))
+	remaining := make([]expansionCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
 		if _, exists := failed[candidate.candidate]; !exists {
 			remaining = append(remaining, candidate)
@@ -925,7 +1034,6 @@ func (e *NodeExpander) cloneGPUNodeClaim(ctx context.Context, pod *corev1.Pod, p
 func (e *NodeExpander) createKarpenterNodeClaimDirect(ctx context.Context, pod *corev1.Pod, preparedNode *corev1.Node, nodeClaim *karpv1.NodeClaim) error {
 	spec := nodeClaim.DeepCopy().Spec
 	spec.Resources.Requests = nodeClaimRequestsForPod(pod)
-	podRequirements := podKarpenterRequirementValues(pod, preparedNode)
 	labels := make(map[string]string, 4)
 	for _, owner := range nodeClaim.OwnerReferences {
 		if owner.Kind != constants.KarpenterNodePoolKind {
@@ -977,26 +1085,22 @@ func (e *NodeExpander) createKarpenterNodeClaimDirect(ctx context.Context, pod *
 	if !mergeKarpenterRequirements(&spec, labelRequirements) {
 		return fmt.Errorf("karpenter node pool labels do not intersect with its requirements")
 	}
-	if !mergeKarpenterRequirements(&spec, podRequirements) {
-		return fmt.Errorf("pod requirements do not intersect with Karpenter NodePool requirements")
-	}
-
-	var preference expansionPreference
-	preferenceFound := false
-	for _, candidate := range e.expansionPreferencesToTry(pod) {
+	var selectedCandidate expansionCandidate
+	candidateFound := false
+	for _, candidate := range e.expansionCandidatesToTry(pod) {
 		candidateSpec := (&karpv1.NodeClaim{Spec: spec}).DeepCopy().Spec
 		if !mergeKarpenterRequirements(&candidateSpec, candidate.requirements) {
 			continue
 		}
 		spec = candidateSpec
-		preference = candidate
-		preferenceFound = true
+		selectedCandidate = candidate
+		candidateFound = true
 		break
 	}
-	if !preferenceFound {
+	if !candidateFound {
 		e.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "NodeExpansionCandidatesExhausted",
-			"all Karpenter expansion preferences, including the relaxed fallback, have failed")
-		return fmt.Errorf("all Karpenter expansion preferences have failed for pod %s/%s", pod.Namespace, pod.Name)
+			"all Karpenter expansion requirement candidates have failed")
+		return fmt.Errorf("all Karpenter expansion requirement candidates have failed for pod %s/%s", pod.Namespace, pod.Name)
 	}
 
 	// Create NodeClaim from the prepared node
@@ -1035,7 +1139,7 @@ func (e *NodeExpander) createKarpenterNodeClaimDirect(ctx context.Context, pod *
 		podKey:       client.ObjectKey{Namespace: pod.Namespace, Name: pod.Name},
 		podUID:       pod.UID,
 		nodeClaimUID: newNodeClaim.UID,
-		candidate:    preference.candidate,
+		candidate:    selectedCandidate.candidate,
 	})
 	e.eventRecorder.Eventf(pod, corev1.EventTypeNormal, "NodeExpansionCompleted", "created new NodeClaim for node expansion: %s", newNodeClaim.Name)
 	e.logger.Info("created new NodeClaim for node expansion", "pod", pod.Name, "namespace", pod.Namespace, "nodeClaim", newNodeClaim.Name)
@@ -1054,15 +1158,13 @@ func nodeClaimRequestsForPod(pod *corev1.Pod) corev1.ResourceList {
 	return requests
 }
 
-func podKarpenterRequirementValues(pod *corev1.Pod, preparedNode *corev1.Node) map[string][]string {
+func podKarpenterRequirementValues(pod *corev1.Pod) map[string][]string {
 	valuesByKey := make(map[string][]string)
 	if pod == nil {
 		return valuesByKey
 	}
 	setValues := func(key string, values ...string) {
-		if key != corev1.LabelInstanceTypeStable &&
-			key != corev1.LabelTopologyZone &&
-			key != corev1.LabelTopologyRegion {
+		if !isExpansionRequirementKey(key) {
 			return
 		}
 		unique := make([]string, 0, len(values))
@@ -1093,29 +1195,6 @@ func podKarpenterRequirementValues(pod *corev1.Pod, preparedNode *corev1.Node) m
 	}
 	for key, value := range pod.Spec.NodeSelector {
 		setValues(key, value)
-	}
-	if pod.Spec.Affinity != nil && pod.Spec.Affinity.NodeAffinity != nil &&
-		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-		for i := range terms {
-			if preparedNode != nil {
-				matches, err := schedulingcorev1.MatchNodeSelectorTerms(preparedNode, &corev1.NodeSelector{
-					NodeSelectorTerms: []corev1.NodeSelectorTerm{terms[i]},
-				})
-				if err != nil || !matches {
-					continue
-				}
-			}
-			for _, expression := range terms[i].MatchExpressions {
-				if expression.Operator == corev1.NodeSelectorOpIn {
-					setValues(expression.Key, expression.Values...)
-				}
-			}
-			// NodeSelectorTerms are ORed. A single NodeClaim expresses an AND
-			// set of requirements, so use the term represented by the prepared
-			// node instead of broadening the claim with values from all terms.
-			break
-		}
 	}
 	return valuesByKey
 }

--- a/internal/scheduler/expander/requirements_test.go
+++ b/internal/scheduler/expander/requirements_test.go
@@ -42,11 +42,9 @@ func TestMergePodKarpenterRequirements(t *testing.T) {
 		},
 	}
 
-	preparedNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-		"node.kubernetes.io/instance-type": "g6.12xlarge",
-		"topology.kubernetes.io/zone":      "us-east-1a",
-	}}}
-	require.True(t, mergeKarpenterRequirements(spec, podKarpenterRequirementValues(pod, preparedNode)))
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 1)
+	require.True(t, mergeKarpenterRequirements(spec, candidates[0].requirements))
 
 	require.ElementsMatch(t, []string{"g6.2xlarge", "g6.12xlarge"}, spec.Requirements[0].Values)
 	require.ElementsMatch(t, []string{"us-east-1a", "us-east-1b"}, spec.Requirements[1].Values)
@@ -60,7 +58,7 @@ func TestMergePodKarpenterRequirementsPreservesPoolIntersection(t *testing.T) {
 	pod := &corev1.Pod{Spec: corev1.PodSpec{NodeSelector: map[string]string{
 		"node.kubernetes.io/instance-type": "g6.12xlarge",
 	}}}
-	require.True(t, mergeKarpenterRequirements(spec, podKarpenterRequirementValues(pod, nil)))
+	require.True(t, mergeKarpenterRequirements(spec, podKarpenterRequirementValues(pod)))
 	require.Equal(t, []string{"g6.12xlarge"}, spec.Requirements[0].Values)
 	require.Equal(t, []string{"us-east-1a", "us-east-1b"}, spec.Requirements[1].Values)
 }
@@ -128,8 +126,9 @@ func TestPodKarpenterRequirementValuesIntersectsSelectorAndAffinity(t *testing.T
 			}}},
 		}},
 	}}
-	values := podKarpenterRequirementValues(pod, nil)
-	require.Equal(t, []string{"g6.12xlarge"}, values[corev1.LabelInstanceTypeStable])
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 1)
+	require.Equal(t, []string{"g6.12xlarge"}, candidates[0].requirements[corev1.LabelInstanceTypeStable])
 }
 
 func TestPodKarpenterRequirementValuesIncludesRegion(t *testing.T) {
@@ -137,8 +136,80 @@ func TestPodKarpenterRequirementValuesIncludesRegion(t *testing.T) {
 		NodeSelector: map[string]string{corev1.LabelTopologyRegion: "us-west-2"},
 	}}
 
-	values := podKarpenterRequirementValues(pod, nil)
+	values := podKarpenterRequirementValues(pod)
 	require.Equal(t, []string{"us-west-2"}, values[corev1.LabelTopologyRegion])
+}
+
+func TestMergeRegionRequirementMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		podRegions  []string
+		poolRegions []string
+		wantRegions []string
+		wantValid   bool
+	}{
+		{
+			name:        "pod and pool use intersection",
+			podRegions:  []string{"us-east-1", "eu-west-1"},
+			poolRegions: []string{"us-east-1", "us-west-2"},
+			wantRegions: []string{"us-east-1"},
+			wantValid:   true,
+		},
+		{
+			name:        "pod region without pool region",
+			podRegions:  []string{"us-west-2"},
+			wantRegions: []string{"us-west-2"},
+			wantValid:   true,
+		},
+		{
+			name:        "single pool region without pod region",
+			poolRegions: []string{"us-east-1"},
+			wantRegions: []string{"us-east-1"},
+			wantValid:   true,
+		},
+		{
+			name:        "multiple pool regions stay in one requirement",
+			poolRegions: []string{"us-east-1", "us-west-2"},
+			wantRegions: []string{"us-east-1", "us-west-2"},
+			wantValid:   true,
+		},
+		{
+			name:      "no pod or pool region",
+			wantValid: true,
+		},
+		{
+			name:        "empty intersection is invalid",
+			podRegions:  []string{"us-west-2"},
+			poolRegions: []string{"us-east-1"},
+			wantValid:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &karpv1.NodeClaimSpec{}
+			if len(tt.poolRegions) > 0 {
+				spec.Requirements = []karpv1.NodeSelectorRequirementWithMinValues{{
+					Key: corev1.LabelTopologyRegion, Operator: corev1.NodeSelectorOpIn, Values: tt.poolRegions,
+				}}
+			}
+			podRequirements := make(map[string][]string)
+			if len(tt.podRegions) > 0 {
+				podRequirements[corev1.LabelTopologyRegion] = tt.podRegions
+			}
+
+			require.Equal(t, tt.wantValid, mergeKarpenterRequirements(spec, podRequirements))
+			if !tt.wantValid {
+				return
+			}
+			regions, exists := requirementValuesByKey(spec.Requirements)[corev1.LabelTopologyRegion]
+			if len(tt.wantRegions) == 0 {
+				require.False(t, exists)
+				return
+			}
+			require.ElementsMatch(t, tt.wantRegions, regions)
+		})
+	}
 }
 
 func TestPreferredExpansionCandidatesFollowWeight(t *testing.T) {
@@ -179,6 +250,87 @@ func TestPreferredExpansionCandidatesIncludeRegion(t *testing.T) {
 	require.Equal(t, relaxedExpansionCandidate, candidates[1].candidate)
 }
 
+func TestRequiredExpansionCandidatesPreserveTermOrderAndCorrelation(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{MatchExpressions: []corev1.NodeSelectorRequirement{
+				{Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"}},
+				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"}},
+			}},
+			{MatchExpressions: []corev1.NodeSelectorRequirement{
+				{Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"}},
+				{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1b"}},
+			}},
+		}},
+	}}}}
+
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 2)
+	require.Equal(t, []string{"g6.2xlarge"}, candidates[0].requirements[corev1.LabelInstanceTypeStable])
+	require.Equal(t, []string{"us-east-1a"}, candidates[0].requirements[corev1.LabelTopologyZone])
+	require.Equal(t, []string{"g6.12xlarge"}, candidates[1].requirements[corev1.LabelInstanceTypeStable])
+	require.Equal(t, []string{"us-east-1b"}, candidates[1].requirements[corev1.LabelTopologyZone])
+}
+
+func TestExpansionCandidatesCombinePreferredWeightWithRequiredTerms(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"},
+			}}},
+			{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1b"},
+			}}},
+		}},
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+			{Weight: 50, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+			}}}},
+			{Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}}},
+		},
+	}}}}
+
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 6)
+	want := [][2]string{
+		{"g6.2xlarge", "us-east-1a"},
+		{"g6.2xlarge", "us-east-1b"},
+		{"g6.12xlarge", "us-east-1a"},
+		{"g6.12xlarge", "us-east-1b"},
+		{"", "us-east-1a"},
+		{"", "us-east-1b"},
+	}
+	for i, expected := range want {
+		require.Equal(t, expected[1], candidates[i].requirements[corev1.LabelTopologyZone][0])
+		if expected[0] == "" {
+			require.NotContains(t, candidates[i].requirements, corev1.LabelInstanceTypeStable)
+		} else {
+			require.Equal(t, expected[0], candidates[i].requirements[corev1.LabelInstanceTypeStable][0])
+		}
+	}
+}
+
+func TestExpansionCandidatesSkipConflictingRequiredAndPreferredCombination(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+			MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+			}},
+		}}},
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
+			Weight: 100, Preference: corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}}},
+		}},
+	}}}}
+
+	candidates := podExpansionCandidates(pod)
+	require.Len(t, candidates, 1)
+	require.Equal(t, []string{"g6.12xlarge"}, candidates[0].requirements[corev1.LabelInstanceTypeStable])
+}
+
 func TestFailedExpansionCandidateState(t *testing.T) {
 	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "worker", UID: types.UID("worker-uid")}}
@@ -193,25 +345,54 @@ func TestFailedExpansionCandidateState(t *testing.T) {
 		},
 	}}
 	podKey := client.ObjectKeyFromObject(pod)
-	remaining := expander.expansionPreferencesToTry(pod)
+	remaining := expander.expansionCandidatesToTry(pod)
 	require.Len(t, remaining, 3)
 	high := remaining[0]
 	require.Equal(t, []string{"g6.2xlarge"}, high.requirements[corev1.LabelInstanceTypeStable])
 
 	expander.addFailedExpansionCandidate(podKey, pod.UID, high.candidate)
-	remaining = expander.expansionPreferencesToTry(pod)
+	remaining = expander.expansionCandidatesToTry(pod)
 	require.Len(t, remaining, 2)
 	low := remaining[0]
 	require.Equal(t, []string{"g6.12xlarge"}, low.requirements[corev1.LabelInstanceTypeStable])
 
 	expander.addFailedExpansionCandidate(podKey, pod.UID, low.candidate)
-	remaining = expander.expansionPreferencesToTry(pod)
+	remaining = expander.expansionCandidatesToTry(pod)
 	require.Len(t, remaining, 1)
 	relaxed := remaining[0]
 	require.Equal(t, relaxedExpansionCandidate, relaxed.candidate)
 
 	expander.addFailedExpansionCandidate(podKey, pod.UID, relaxed.candidate)
-	require.Empty(t, expander.expansionPreferencesToTry(pod))
+	require.Empty(t, expander.expansionCandidatesToTry(pod))
+}
+
+func TestFailedExpansionCandidateStateExhaustsRequiredTerms(t *testing.T) {
+	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "worker", UID: types.UID("worker-uid")},
+		Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+				}}},
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+				}}},
+			}},
+		}}},
+	}
+	podKey := client.ObjectKeyFromObject(pod)
+
+	candidates := expander.expansionCandidatesToTry(pod)
+	require.Len(t, candidates, 2)
+	expander.addFailedExpansionCandidate(podKey, pod.UID, candidates[0].candidate)
+
+	candidates = expander.expansionCandidatesToTry(pod)
+	require.Len(t, candidates, 1)
+	require.Equal(t, []string{"g6.12xlarge"}, candidates[0].requirements[corev1.LabelInstanceTypeStable])
+	expander.addFailedExpansionCandidate(podKey, pod.UID, candidates[0].candidate)
+
+	require.Empty(t, expander.expansionCandidatesToTry(pod))
 }
 
 func TestFailedExpansionCandidateStateIsScopedByPodUID(t *testing.T) {
@@ -232,12 +413,12 @@ func TestFailedExpansionCandidateStateIsScopedByPodUID(t *testing.T) {
 		},
 	}}
 
-	first := expander.expansionPreferencesToTry(pod)[0]
+	first := expander.expansionCandidatesToTry(pod)[0]
 	expander.addFailedExpansionCandidate(client.ObjectKeyFromObject(pod), pod.UID, first.candidate)
 
 	recreated := pod.DeepCopy()
 	recreated.UID = types.UID("new-uid")
-	require.Equal(t, first.candidate, expander.expansionPreferencesToTry(recreated)[0].candidate)
+	require.Equal(t, first.candidate, expander.expansionCandidatesToTry(recreated)[0].candidate)
 	require.NotContains(t, expander.failedExpansionCandidates, expansionPodKey(pod.Namespace, pod.Name, pod.UID))
 }
 


### PR DESCRIPTION
 ## 背景

  补充 Karpenter NodeClaim 扩容回退逻辑，支持 Pod 配置多个 required affinity term 时，按候选组合依次尝试，避免单个机型或可用区库存不足后扩容停滞。

  ## 主要改动

  - 支持多个 requiredDuringSchedulingIgnoredDuringExecution term 按声明顺序回退。
  - 仅配置 preferred affinity 时，按权重从高到低尝试，最后执行 relaxed fallback。
  - required 和 preferred 同时存在时，按组合依次尝试。
  - 跳过冲突、重复及与 NodePool 无交集的候选项。
  - 所有容量失败候选耗尽后停止重复创建 NodeClaim。
  - 不继承源 NodeClaim 固化的实例类型、zone 和 region。
  - 正确计算 Pod 与 NodePool 的 region 交集；Pod 未指定时保留 NodePool 的全部 region。

  ## 验证

  - make lint 通过。
  - make test 通过。
  - 集群端到端验证以下场景：
      - 多个 required terms
      - 仅 preferred 权重回退
      - required 与 preferred 组合
      - 非容量原因删除后重试当前候选
      - InsufficientCapacityError 后切换候选
      - 候选耗尽后停止扩容
      - Pod/NodePool region 交集及无交集场景