### PR TITLE
fix(expander): 修复 Karpenter 扩容候选耗尽后的重新调度

### DIFF
--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -193,10 +193,22 @@ func (e *NodeExpander) handleTerminatedInFlightNodeClaim(name string, value any,
 		e.clearFailedExpansionCandidates(claim.podKey.Namespace, claim.podKey.Name, claim.podUID)
 		return
 	}
+	roundExhausted := false
 	if insufficientCapacity {
 		e.addFailedExpansionCandidate(claim.podKey, claim.podUID, claim.candidate)
-		e.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "NodeExpansionCandidateFailed",
-			"Karpenter NodeClaim %s failed due to insufficient capacity; trying the next expansion candidate", name)
+		roundExhausted = len(e.expansionCandidatesToTry(pod)) == 0
+		if roundExhausted {
+			e.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "NodeExpansionCandidatesExhausted",
+				"Karpenter NodeClaim %s failed due to insufficient capacity; all expansion candidates have failed, waiting for scheduler requeue", name)
+		} else {
+			e.eventRecorder.Eventf(pod, corev1.EventTypeWarning, "NodeExpansionCandidateFailed",
+				"Karpenter NodeClaim %s failed due to insufficient capacity; trying the next expansion candidate", name)
+		}
+	}
+	if roundExhausted {
+		e.logger.Info("all Karpenter expansion candidates failed, waiting for scheduler requeue",
+			"pod", klog.KObj(pod), "nodeClaimName", name)
+		return
 	}
 	if e.activatePod != nil {
 		e.activatePod(pod)
@@ -665,6 +677,34 @@ func (e *NodeExpander) expansionCandidatesToTry(pod *corev1.Pod) []expansionCand
 		}
 	}
 	return remaining
+}
+
+// resetExpansionCandidatesForNewRound clears a fully exhausted candidate set.
+// It is called only after the scheduler retries and rejects the Pod again, so
+// one expansion round does not immediately restart itself.
+func (e *NodeExpander) resetExpansionCandidatesForNewRound(pod *corev1.Pod) bool {
+	if e == nil || pod == nil {
+		return false
+	}
+	candidates := podExpansionCandidates(pod)
+	if len(candidates) == 0 {
+		return false
+	}
+
+	podKey := expansionPodKey(pod.Namespace, pod.Name, pod.UID)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	failed, exists := e.failedExpansionCandidates[podKey]
+	if !exists {
+		return false
+	}
+	for _, candidate := range candidates {
+		if _, exists := failed[candidate.candidate]; !exists {
+			return false
+		}
+	}
+	delete(e.failedExpansionCandidates, podKey)
+	return true
 }
 
 func (e *NodeExpander) addInFlightNode(node *corev1.Node, gpus []*tfv1.GPU) {

--- a/internal/scheduler/expander/handler_test.go
+++ b/internal/scheduler/expander/handler_test.go
@@ -146,6 +146,10 @@ var _ = Describe("NodeExpander Unit Tests", func() {
 			testNonCapacityDeletion(suite)
 		})
 
+		It("should wait for scheduler requeue after exhausting expansion candidates", func() {
+			testExhaustedCandidatesWaitForSchedulerRequeue(suite)
+		})
+
 		It("should cleanup inflight node claim when node is ready", func() {
 			testCleanupReadyInFlightNodeClaim(suite)
 		})
@@ -474,6 +478,34 @@ func testNonCapacityDeletion(suite *NodeExpanderTestSuite) {
 	_, failed := suite.nodeExpander.failedExpansionCandidates[expansionPodKey(pod.Namespace, pod.Name, pod.UID)]
 	suite.nodeExpander.mu.RUnlock()
 	Expect(failed).To(BeFalse())
+}
+
+func testExhaustedCandidatesWaitForSchedulerRequeue(suite *NodeExpanderTestSuite) {
+	pod := createTestTensorFusionPod("exhausted-worker", suite.namespace, "100", "1Gi")
+	pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+			MatchExpressions: []corev1.NodeSelectorRequirement{{
+				Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+			}},
+		}}},
+	}}
+	Expect(suite.k8sClient.Create(suite.ctx, pod)).To(Succeed())
+	defer func() { _ = suite.k8sClient.Delete(suite.ctx, pod) }()
+
+	candidates := suite.nodeExpander.expansionCandidatesToTry(pod)
+	Expect(candidates).To(HaveLen(1))
+	claim := inFlightNodeClaim{
+		podKey:    client.ObjectKeyFromObject(pod),
+		podUID:    pod.UID,
+		candidate: candidates[0].candidate,
+	}
+	activated := false
+	suite.nodeExpander.activatePod = func(*corev1.Pod) { activated = true }
+
+	suite.nodeExpander.handleTerminatedInFlightNodeClaim("exhausted-claim", claim, true)
+
+	Expect(activated).To(BeFalse())
+	Expect(suite.nodeExpander.expansionCandidatesToTry(pod)).To(BeEmpty())
 }
 
 func testCleanupReadyInFlightNodeClaim(suite *NodeExpanderTestSuite) {

--- a/internal/scheduler/expander/requirements_test.go
+++ b/internal/scheduler/expander/requirements_test.go
@@ -395,6 +395,36 @@ func TestFailedExpansionCandidateStateExhaustsRequiredTerms(t *testing.T) {
 	require.Empty(t, expander.expansionCandidatesToTry(pod))
 }
 
+func TestResetExpansionCandidatesForNewRoundOnlyAfterExhaustion(t *testing.T) {
+	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "worker", UID: types.UID("worker-uid")},
+		Spec: corev1.PodSpec{Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.2xlarge"},
+				}}},
+				{MatchExpressions: []corev1.NodeSelectorRequirement{{
+					Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpIn, Values: []string{"g6.12xlarge"},
+				}}},
+			}},
+		}}},
+	}
+	podKey := client.ObjectKeyFromObject(pod)
+	candidates := expander.expansionCandidatesToTry(pod)
+	require.Len(t, candidates, 2)
+
+	expander.addFailedExpansionCandidate(podKey, pod.UID, candidates[0].candidate)
+	require.False(t, expander.resetExpansionCandidatesForNewRound(pod))
+	require.Len(t, expander.expansionCandidatesToTry(pod), 1)
+
+	expander.addFailedExpansionCandidate(podKey, pod.UID, candidates[1].candidate)
+	require.Empty(t, expander.expansionCandidatesToTry(pod))
+	require.True(t, expander.resetExpansionCandidatesForNewRound(pod))
+	require.Len(t, expander.expansionCandidatesToTry(pod), 2)
+	require.False(t, expander.resetExpansionCandidatesForNewRound(pod))
+}
+
 func TestFailedExpansionCandidateStateIsScopedByPodUID(t *testing.T) {
 	expander := &NodeExpander{failedExpansionCandidates: make(map[string]map[string]struct{})}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "worker", UID: types.UID("old-uid")}}

--- a/internal/scheduler/expander/unsched_queue.go
+++ b/internal/scheduler/expander/unsched_queue.go
@@ -71,6 +71,10 @@ func (h *UnscheduledPodHandler) HandleRejectedPod(ctx context.Context, podInfo *
 
 	// take snapshot to avoid modify origin Pod info
 	pod = pod.DeepCopy()
+	if h.nodeExpander.resetExpansionCandidatesForNewRound(pod) {
+		h.logger.Info("scheduler requeued pod after all Karpenter expansion candidates failed, starting a new expansion round",
+			"pod", klog.KObj(pod))
+	}
 
 	h.mu.Lock()
 	if _, ok := h.pending[string(pod.UID)]; ok {


### PR DESCRIPTION
 ## 问题

  当 Pod 的所有 Karpenter 扩容候选项都因容量不足失败后，TensorFusion 会记录所有失败候选，但不会立即重新创建 NodeClaim。此前候选状态可能无法在后
  续调度轮次正确恢复，导致 Pod 长时间无法继续尝试扩容。

  ## 修改内容

  - 所有扩容候选失败后，保留 Pod 在 scheduler unschedulable queue；
  - 增加 `NodeExpansionCandidatesExhausted` 事件；
  - 避免在同一轮扩容中立即从第一个候选重新开始；
  - Pod 被 scheduler 再次拒绝时，清理已耗尽的候选状态；
  - 下一轮从首个候选重新尝试创建 NodeClaim；
  - 增加候选耗尽及新一轮重试的单元测试。

  ## 验证

  - `go test ./internal/scheduler/expander/...` 通过；
  - 已验证候选全部失败后等待 scheduler requeue，并在下一轮重新创建首选 NodeClaim。