### PR TITLE
fix(worker): increase default shared memory

### DIFF
--- a/internal/constants/env.go
+++ b/internal/constants/env.go
@@ -69,7 +69,7 @@ const (
 	ConnectionNameEnv       = "TENSOR_FUSION_CONNECTION_NAME"
 	ConnectionNamespaceEnv  = "TENSOR_FUSION_CONNECTION_NAMESPACE"
 	DisableVMSharedMemEnv   = "TF_USE_IVSHMEM"
-	ConnectionSharedMemSize = "1024"
+	ConnectionSharedMemSize = "2048"
 	ConnectionSharedMemName = "tf_shm"
 
 	RealNvmlLibPathValue = "/lib/x86_64-linux-gnu/libnvidia-ml.so.1"

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -187,7 +187,7 @@ func TestSetWorkerContainerSpec(t *testing.T) {
 			expectCommand: []string{
 				"/bin/bash",
 				"-c",
-				"touch /dev/shm/tf_shm && chmod 666 /dev/shm/tf_shm && exec ./tensor-fusion-worker -n shmem -m tf_shm -M 1024",
+				"touch /dev/shm/tf_shm && chmod 666 /dev/shm/tf_shm && exec ./tensor-fusion-worker -n shmem -m tf_shm -M 2048",
 			},
 		},
 		{
@@ -232,7 +232,7 @@ func TestSetWorkerContainerSpec(t *testing.T) {
 				require.Contains(t, container.Command[2], "exec ./tensor-fusion-worker", "should exec worker")
 				require.Contains(t, container.Command[2], "-n shmem", "should use shmem mode")
 				require.Contains(t, container.Command[2], "-m tf_shm", "should specify shared memory name")
-				require.Contains(t, container.Command[2], "-M 1024", "should specify shared memory size")
+				require.Contains(t, container.Command[2], "-M "+constants.ConnectionSharedMemSize, "should specify shared memory size")
 			}
 		})
 	}
@@ -319,11 +319,11 @@ func TestAddTFDefaultClientConfBeforePatchMergesWorkerTemplateEnvIntoSidecar(t *
 			SidecarWorker: true,
 		},
 	}
-
 	utils.AddTFDefaultClientConfBeforePatch(context.Background(), pod, pool, tfInfo, []int{0})
 
 	require.Len(t, pod.Spec.Containers, 2)
 	worker := pod.Spec.Containers[1]
+	require.Contains(t, worker.Command[2], "-M "+constants.ConnectionSharedMemSize)
 	require.Equal(t, constants.TFContainerNameWorker, worker.Name)
 	require.Contains(t, worker.Env, corev1.EnvVar{Name: "CUSTOM_WORKER_ENV", Value: "custom-value"})
 	require.Contains(t, worker.Env, corev1.EnvVar{


### PR DESCRIPTION
 ### 背景

  local + hard 隔离模式下，TensorFusion worker 的共享内存大小默认为 1024MiB。启动较大模型时共享内存不足，可能导致 vLLM 初始化异常。

  ### 修改内容

  - 将 ConnectionSharedMemSize 默认值从 1024 调整为 2048。
  - worker 启动参数自动使用新的默认值：

  -M 2048

  - 更新相关单测，确认生成的 worker 命令使用 2048MiB。
  - 不新增 annotation，不改变现有配置方式。

  ### 验证

  go test ./internal/utils ./internal/webhook/v1

  测试已通过。