### PR TITLE
fix(expander): reserve all GPUs for in-flight pods

### DIFF
--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -802,6 +802,10 @@ func (e *NodeExpander) prepareNewNodesForScheduleAttempt(
 	for _, gpu := range templateGPUs {
 		gpuCopy := gpu.DeepCopy()
 		gpuCopy.Name = "gpu-" + rand.String(12)
+		if gpuCopy.Status.NodeSelector == nil {
+			gpuCopy.Status.NodeSelector = make(map[string]string, 1)
+		}
+		gpuCopy.Status.NodeSelector[constants.KubernetesHostNameLabel] = newPreparedNode.Name
 		gpuCopy.Status.Available = gpuCopy.Status.Capacity.DeepCopy()
 		newPreparedGPUs = append(newPreparedGPUs, gpuCopy)
 	}
@@ -875,20 +879,7 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 	e.mu.RUnlock()
 
 	for _, alloc := range preScheduleSnapshot {
-		preScheduledPodPreAllocated := false
-		for _, gpu := range inflightSnapshot {
-			reqTflops := alloc.Request.Tflops
-			if !alloc.Request.ComputePercent.IsZero() {
-				reqTflops = *utils.ComputePercentToTflops(gpu.Status.Capacity.Tflops, alloc.Request)
-			}
-			if gpu.Status.Available.Tflops.Cmp(reqTflops) >= 0 &&
-				gpu.Status.Available.Vram.Cmp(alloc.Request.Vram) >= 0 {
-				gpu.Status.Available.Tflops.Sub(reqTflops)
-				gpu.Status.Available.Vram.Sub(alloc.Request.Vram)
-				preScheduledPodPreAllocated = true
-				break
-			}
-		}
+		preScheduledPodPreAllocated := e.reserveInflightGPUs(alloc, inflightSnapshot)
 		// this is unexpected, all pre-scheduled pod should be able to place into inFlight node
 		// possible happen when new node added to cluster and removed from inFlight nodes, simultaneously,
 		// new Pods added and also unschedulable, trigger node expansion before previous Pod scheduled
@@ -950,6 +941,67 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 		}
 	}
 	return allocRequest, true, false, onlyCanBeFlightGPU
+}
+
+// reserveInflightGPUs reserves all GPUs required by a pre-scheduled Pod from
+// one in-flight node. Resource accounting must honor AllocRequest.Count; a
+// multi-GPU Pod cannot be represented by reserving only its first GPU.
+func (e *NodeExpander) reserveInflightGPUs(alloc *tfv1.AllocRequest, inflightSnapshot map[string]*tfv1.GPU) bool {
+	if e == nil || e.allocator == nil || alloc == nil {
+		return false
+	}
+
+	count := int(alloc.Count)
+	if count == 0 {
+		count = 1
+	}
+
+	candidates := make([]*tfv1.GPU, 0, len(inflightSnapshot))
+	for _, gpu := range inflightSnapshot {
+		if gpu != nil {
+			candidates = append(candidates, gpu)
+		}
+	}
+	filtered, _, err := e.allocator.Filter(alloc, candidates, false)
+	if err != nil {
+		return false
+	}
+
+	byNode := make(map[string][]*tfv1.GPU)
+	for _, gpu := range filtered {
+		if gpu == nil || gpu.Status.Available == nil || gpu.Status.Capacity == nil {
+			continue
+		}
+		nodeName := gpu.Status.NodeSelector[constants.KubernetesHostNameLabel]
+		if nodeName == "" {
+			continue
+		}
+		byNode[nodeName] = append(byNode[nodeName], gpu)
+	}
+
+	for _, nodeGPUs := range byNode {
+		selected := make([]*tfv1.GPU, 0, count)
+		for _, gpu := range nodeGPUs {
+			selected = append(selected, gpu)
+			if len(selected) == count {
+				break
+			}
+		}
+		if len(selected) < count {
+			continue
+		}
+
+		for _, gpu := range selected {
+			reqTflops := alloc.Request.Tflops
+			if !alloc.Request.ComputePercent.IsZero() {
+				reqTflops = *utils.ComputePercentToTflops(gpu.Status.Capacity.Tflops, alloc.Request)
+			}
+			gpu.Status.Available.Tflops.Sub(reqTflops)
+			gpu.Status.Available.Vram.Sub(alloc.Request.Vram)
+		}
+		return true
+	}
+	return false
 }
 
 func (e *NodeExpander) checkGPUFitForNewNode(pod *corev1.Pod, gpus []*tfv1.GPU) bool {

--- a/internal/scheduler/expander/requirements_test.go
+++ b/internal/scheduler/expander/requirements_test.go
@@ -1,15 +1,19 @@
 package expander
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/internal/gpuallocator"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
@@ -92,6 +96,39 @@ func TestMergeKarpenterRequirementsUsesKarpenterOperatorSemantics(t *testing.T) 
 	require.False(t, mergeKarpenterRequirements(spec, map[string][]string{
 		"capacity": {"reserved"},
 	}))
+}
+
+func TestReserveInflightGPUsHonorsAllocationCount(t *testing.T) {
+	allocator := gpuallocator.NewGpuAllocator(context.Background(), fake.NewClientBuilder().Build(), time.Second)
+	expander := &NodeExpander{allocator: allocator}
+	inflight := map[string]*tfv1.GPU{
+		"gpu-a": createTestGPU("gpu-a", "inflight-node", "1000", "24Gi"),
+		"gpu-b": createTestGPU("gpu-b", "inflight-node", "1000", "24Gi"),
+	}
+	for _, gpu := range inflight {
+		gpu.Status.Phase = tfv1.TensorFusionGPUPhaseRunning
+	}
+	alloc := &tfv1.AllocRequest{
+		Count: 2,
+		Request: tfv1.Resource{
+			Tflops: resource.MustParse("100"),
+			Vram:   resource.MustParse("20Gi"),
+		},
+	}
+
+	require.True(t, expander.reserveInflightGPUs(alloc, inflight))
+	for _, gpu := range inflight {
+		require.Equal(t, "4Gi", gpu.Status.Available.Vram.String())
+	}
+
+	followUp := &tfv1.AllocRequest{
+		Count: 1,
+		Request: tfv1.Resource{
+			Tflops: resource.MustParse("100"),
+			Vram:   resource.MustParse("8Gi"),
+		},
+	}
+	require.False(t, expander.reserveInflightGPUs(followUp, inflight))
 }
 
 func TestMergeKarpenterRequirementsPreservesMinValues(t *testing.T) {


### PR DESCRIPTION
 ## 背景

  当 Pod A 触发 GPU 扩容后，Pod B 在 A 的 NodeClaim 尚未 Ready 时到达，调度器可能因为以
  下问题错误判断 A 的 in-flight 节点仍有可用资源：

  - 多 GPU Pod 只预留了第一张 GPU；
  - 新创建的 in-flight GPU 继承了源节点 hostname，多个 in-flight 节点可能被错误合并。

  这会导致 B 错误收到：

  `fit in-flight GPU resources, pod should be scheduled after new node is provisioned`

  而不是为 B 创建独立的 NodeClaim。

  ## 修改内容

  - 按 `AllocRequest.Count` 预留 Pod 所需的全部 GPU；
  - 确保多张 GPU 来自同一个 in-flight 节点；
  - 为准备中的新节点设置独立 hostname，避免不同 in-flight 节点的 GPU 被合并；
  - 增加多 GPU in-flight 资源预留回归测试。

  ## 验证结果

  - `go test ./internal/scheduler/expander -count=1` 通过；
  - 集群验证：
    - Pod A 申请 2 张 GPU，Pod B 申请 2 张 GPU：B 创建独立 NodeClaim；
    - Pod A 申请 2 张 GPU，Pod B 申请 1 张 GPU：B 创建独立 NodeClaim；
    - A 等待自己创建的节点时出现 in-flight 等待事件，属于预期行为；
    - B 未再错误收到该事件。