### PR TITLE
fix(expander): retry expansion after exhausting candidates

### DIFF
--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -206,9 +206,8 @@ func (e *NodeExpander) handleTerminatedInFlightNodeClaim(name string, value any,
 		}
 	}
 	if roundExhausted {
-		e.logger.Info("all Karpenter expansion candidates failed, waiting for scheduler requeue",
+		e.logger.Info("all Karpenter expansion candidates failed, reactivating pod for a new expansion round",
 			"pod", klog.KObj(pod), "nodeClaimName", name)
-		return
 	}
 	if e.activatePod != nil {
 		e.activatePod(pod)

--- a/internal/scheduler/expander/handler_test.go
+++ b/internal/scheduler/expander/handler_test.go
@@ -146,8 +146,8 @@ var _ = Describe("NodeExpander Unit Tests", func() {
 			testNonCapacityDeletion(suite)
 		})
 
-		It("should wait for scheduler requeue after exhausting expansion candidates", func() {
-			testExhaustedCandidatesWaitForSchedulerRequeue(suite)
+		It("should reactivate pod after exhausting expansion candidates", func() {
+			testExhaustedCandidatesReactivateForNewRound(suite)
 		})
 
 		It("should cleanup inflight node claim when node is ready", func() {
@@ -480,7 +480,7 @@ func testNonCapacityDeletion(suite *NodeExpanderTestSuite) {
 	Expect(failed).To(BeFalse())
 }
 
-func testExhaustedCandidatesWaitForSchedulerRequeue(suite *NodeExpanderTestSuite) {
+func testExhaustedCandidatesReactivateForNewRound(suite *NodeExpanderTestSuite) {
 	pod := createTestTensorFusionPod("exhausted-worker", suite.namespace, "100", "1Gi")
 	pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
@@ -504,7 +504,7 @@ func testExhaustedCandidatesWaitForSchedulerRequeue(suite *NodeExpanderTestSuite
 
 	suite.nodeExpander.handleTerminatedInFlightNodeClaim("exhausted-claim", claim, true)
 
-	Expect(activated).To(BeFalse())
+	Expect(activated).To(BeTrue())
 	Expect(suite.nodeExpander.expansionCandidatesToTry(pod)).To(BeEmpty())
 }
 


### PR DESCRIPTION
  ### 背景

  当所有扩容候选机型均因容量不足创建失败后，Pod 会停止扩容尝试，无法在后续资源恢复时继续申请 NodeClaim。

  ### 修复内容

  - 所有扩容候选耗尽后重新激活 Pod，使其回到调度队列。
  - 下一轮调度时清理上一轮失败候选，从第一个候选重新开始尝试。
  - 保持现有候选排序、required term 组合、NodeClaim 创建及成功绑定后的清理逻辑不变。
  - 更新单元测试，验证候选耗尽后会重新激活 Pod。

  ### 验证

  - 通过 go test ./internal/scheduler/expander -count=1
  - 集群验证确认：
      - 候选耗尽后会重新创建 NodeClaim；
      - 失败候选会从第一项重新开始；
      - GPU 资源释放后 Pod 能正常绑定；
      - Pod 成功运行后不会继续创建额外 NodeClaim。