### PR TITLE
fix(expander): reactivate pod after exhausting Karpenter candidates

### DIFF
--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -183,17 +183,21 @@ func (e *NodeExpander) handleTerminatedInFlightNodeClaim(name string, value any,
 		e.clearFailedExpansionCandidates(claim.podKey.Namespace, claim.podKey.Name, claim.podUID)
 		return
 	}
+	roundExhausted := false
 	if insufficientCapacity {
 		e.addFailedExpansionCandidate(claim.podKey, claim.podUID, claim.candidate)
-		if len(e.expansionCandidatesToTry(pod)) == 0 {
+		roundExhausted = len(e.expansionCandidatesToTry(pod)) == 0
+		if roundExhausted {
 			e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, "NodeExpansionCandidatesExhausted", "InsufficientCapacity",
 				"Karpenter NodeClaim %s failed due to insufficient capacity; all expansion candidates have failed, waiting for scheduler requeue", name)
-			e.logger.Info("all Karpenter expansion candidates failed, waiting for scheduler requeue",
-				"pod", klog.KObj(pod), "nodeClaimName", name)
-			return
+		} else {
+			e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, "NodeExpansionCandidateFailed", "InsufficientCapacity",
+				"Karpenter NodeClaim %s failed due to insufficient capacity; trying the next expansion preference", name)
 		}
-		e.eventRecorder.Eventf(pod, nil, corev1.EventTypeWarning, "NodeExpansionCandidateFailed", "InsufficientCapacity",
-			"Karpenter NodeClaim %s failed due to insufficient capacity; trying the next expansion preference", name)
+	}
+	if roundExhausted {
+		e.logger.Info("all Karpenter expansion candidates failed, reactivating pod for a new expansion round",
+			"pod", klog.KObj(pod), "nodeClaimName", name)
 	}
 	if e.activatePod != nil {
 		e.activatePod(pod)

--- a/internal/scheduler/expander/handler_test.go
+++ b/internal/scheduler/expander/handler_test.go
@@ -147,8 +147,8 @@ var _ = Describe("NodeExpander Unit Tests", func() {
 			testNonCapacityDeletion(suite)
 		})
 
-		It("should wait for scheduler requeue after exhausting expansion candidates", func() {
-			testExhaustedCandidatesWaitForSchedulerRequeue(suite)
+		It("should reactivate pod after exhausting expansion candidates", func() {
+			testExhaustedCandidatesReactivateForNewRound(suite)
 		})
 
 		It("should cleanup inflight node claim when node is ready", func() {
@@ -481,7 +481,7 @@ func testNonCapacityDeletion(suite *NodeExpanderTestSuite) {
 	Expect(failed).To(BeFalse())
 }
 
-func testExhaustedCandidatesWaitForSchedulerRequeue(suite *NodeExpanderTestSuite) {
+func testExhaustedCandidatesReactivateForNewRound(suite *NodeExpanderTestSuite) {
 	pod := createTestTensorFusionPod("exhausted-worker", suite.namespace, "100", "1Gi")
 	pod.Spec.Affinity = &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{{
@@ -505,7 +505,7 @@ func testExhaustedCandidatesWaitForSchedulerRequeue(suite *NodeExpanderTestSuite
 
 	suite.nodeExpander.handleTerminatedInFlightNodeClaim("exhausted-claim", claim, true)
 
-	Expect(activated).To(BeFalse())
+	Expect(activated).To(BeTrue())
 	Expect(suite.nodeExpander.expansionCandidatesToTry(pod)).To(BeEmpty())
 }
 


### PR DESCRIPTION
 ### 背景

  当 Karpenter 扩容的所有候选机型和区域都因容量不足失败后，Pod 会停留在等待状态，无法立即进入下一轮扩容尝试。只有依赖调度器后续重新入队，重试时机不确
  定。

  ### 修改内容

  - 所有扩容候选耗尽后，主动重新激活对应 Pod。
  - 让 Pod 重新进入调度队列。
  - 下一轮调度时清理上一轮失败候选，从第一个候选重新开始。
  - 保留单个候选失败后切换下一个候选的现有逻辑。
  - 更新单元测试，验证候选耗尽后 Pod 会被重新激活。

  ### 与相关 PR 的关系

  - PR 774 的共享内存修复已在 main 中存在。
  - PR 775 的 in-flight GPU 多卡资源预留逻辑已在 main 中存在。
  - 本 PR 补充 PR 776 在 main 中缺失的候选耗尽后重试逻辑。

  ### 验证

  - make test 通过
  - make lint 通过
  - 测试结果：37 个测试套件全部通过，golangci-lint 报告 0 issues。