### PR TITLE
 fix(hypervisor): 兼容旧启动命令并支持 NVIDIA 驱动库自动发现

### DIFF
--- a/charts/tensor-fusion/templates/controller-deployment.yaml
+++ b/charts/tensor-fusion/templates/controller-deployment.yaml
@@ -38,6 +38,9 @@ spec:
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           command: 
             {{- toYaml .Values.controller.command | nindent 12 }}
+            {{- if .Values.controller.compatibleWithNvidiaContainerToolkit }}
+            - --compatible-with-nvidia-container-toolkit=true
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.controller.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/tensor-fusion/values.schema.json
+++ b/charts/tensor-fusion/values.schema.json
@@ -67,6 +67,11 @@
           "minimum": 1,
           "default": 1
         },
+        "compatibleWithNvidiaContainerToolkit": {
+          "type": "boolean",
+          "description": "Enable NVIDIA Container Toolkit validation and driver-library compatibility handling",
+          "default": false
+        },
         "image": {
           "type": "object",
           "description": "Container image configuration for the controller",

--- a/charts/tensor-fusion/values.yaml
+++ b/charts/tensor-fusion/values.yaml
@@ -32,6 +32,11 @@ controller:
   # existing worker Pod annotations. Older images safely ignore this env var.
   isolationModePolicy: dynamic
 
+  # Set true when NVIDIA Container Toolkit validation files are available on
+  # GPU nodes. This enables the existing toolkit-ready gate and driver-library
+  # contract mounts for NVIDIA Hypervisor Pods.
+  compatibleWithNvidiaContainerToolkit: false
+
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:
     repository: tensorfusion/tensor-fusion-operator
@@ -169,8 +174,8 @@ providerConfigs:
     privilegedHypervisor: true
     images:
       middleware: tensorfusion/vgpu-provider-nvidia:1.3.9
-      remoteClient: tensorfusion/tensor-fusion-client:v2.15.0
-      remoteWorker: tensorfusion/tensor-fusion-worker:v2.15.0
+      remoteClient: tensorfusion/tensor-fusion-client:v2.25.0
+      remoteWorker: tensorfusion/tensor-fusion-worker:v2.25.0
     inUseResourceNames:
       - nvidia.com/gpu
       # MIG profile names — device-plugin only reports what physically exists on
@@ -784,6 +789,13 @@ providerConfigs:
         value: all
       - name: NVIDIA_MIG_MONITOR_DEVICES
         value: all
+      # Usually leave TF_CUDA_LIB_PATH and TF_NVML_LIB_PATH unset so the
+      # Hypervisor can discover NVIDIA GPU Operator driver paths. Set them only
+      # when the libraries live at known custom paths, for example:
+      # - name: TF_CUDA_LIB_PATH
+      #   value: /custom/driver/libcuda.so.1
+      # - name: TF_NVML_LIB_PATH
+      #   value: /custom/driver/libnvidia-ml.so.1
     # Optional device mount policy for the hypervisor (spec.hypervisor.deviceMount).
     # Empty ({}) = builtin default device mounting, which is correct for almost all
     # clusters. Only set this for special setups that need to filter/override which

--- a/cmd/hypervisor/main.go
+++ b/cmd/hypervisor/main.go
@@ -53,7 +53,15 @@ func main() {
 		return
 	}
 
-	flag.Parse()
+	// Keep the v1 image command compatible. v1 invokes the binary as
+	// `hypervisor daemon`; v2 has a single daemon process and does not need a
+	// subcommand. Strip the legacy token before parsing flags so flags following
+	// it are still honored when a wrapper does forward them.
+	*isolationMode = envOrDefault(constants.TFIsolationModeEnv, *isolationMode)
+	*isolationPolicy = envOrDefault(constants.IsolationModePolicyEnv, *isolationPolicy)
+	if err := flag.CommandLine.Parse(legacyCompatibleFlagArgs(os.Args[1:])); err != nil {
+		klog.Fatalf("failed to parse hypervisor flags: %v", err)
+	}
 	policy := tfv1.IsolationModePolicyStatic
 	switch strings.ToLower(strings.TrimSpace(*isolationPolicy)) {
 	case "static":
@@ -82,6 +90,7 @@ func main() {
 		acceleratorVendor = ptr.To(vendor)
 		klog.Infof("Hardware vendor from env: %s", vendor)
 	}
+	configureNvidiaDriverLibraries(*acceleratorVendor, constants.NvidiaDriverReadyPath)
 
 	// Create and start device controller
 	deviceController, err := device.NewController(ctx, libPath, *acceleratorVendor, *discoveryInterval, *isolationMode)
@@ -186,4 +195,21 @@ func main() {
 
 	cancel()
 	klog.Info("Hypervisor stopped")
+}
+
+// legacyCompatibleFlagArgs removes the v1 daemon subcommand. The v2 binary
+// has a single daemon process, but accepting this token keeps existing TFC pod
+// templates usable when only the Hypervisor image is changed.
+func legacyCompatibleFlagArgs(args []string) []string {
+	if len(args) > 0 && args[0] == "daemon" {
+		return args[1:]
+	}
+	return args
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
 }

--- a/cmd/hypervisor/main_test.go
+++ b/cmd/hypervisor/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import "testing"
+
+const (
+	testIsolationPolicyDynamic = "dynamic"
+	testIsolationPolicyStatic  = "static"
+)
+
+func TestLegacyCompatibleFlagArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "legacy daemon",
+			args: []string{"daemon", "--isolation-policy=" + testIsolationPolicyDynamic},
+			want: []string{"--isolation-policy=" + testIsolationPolicyDynamic},
+		},
+		{
+			name: "normal flags",
+			args: []string{"--isolation-policy=" + testIsolationPolicyDynamic},
+			want: []string{"--isolation-policy=" + testIsolationPolicyDynamic},
+		},
+		{name: "empty", args: nil, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := legacyCompatibleFlagArgs(tt.args)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestEnvOrDefault(t *testing.T) {
+	t.Setenv("TF_TEST_HYPERVISOR_VALUE", "  "+testIsolationPolicyDynamic+" ")
+	if got := envOrDefault("TF_TEST_HYPERVISOR_VALUE", testIsolationPolicyStatic); got != testIsolationPolicyDynamic {
+		t.Fatalf("envOrDefault() = %q, want %q", got, testIsolationPolicyDynamic)
+	}
+	t.Setenv("TF_TEST_HYPERVISOR_VALUE", " ")
+	if got := envOrDefault("TF_TEST_HYPERVISOR_VALUE", testIsolationPolicyStatic); got != testIsolationPolicyStatic {
+		t.Fatalf("envOrDefault() = %q, want %q", got, testIsolationPolicyStatic)
+	}
+}

--- a/cmd/hypervisor/nvidia_driver.go
+++ b/cmd/hypervisor/nvidia_driver.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	"k8s.io/klog/v2"
+)
+
+const (
+	nvidiaDriverRootEnv   = "NVIDIA_DRIVER_ROOT"
+	driverRootCtrPathEnv  = "DRIVER_ROOT_CTR_PATH"
+	nvidiaCudaLibraryName = "libcuda.so.1"
+	nvidiaNvmlLibraryName = "libnvidia-ml.so.1"
+)
+
+func configureNvidiaDriverLibraries(vendor, contractPath string) {
+	if !strings.EqualFold(strings.TrimSpace(vendor), constants.AcceleratorVendorNvidia) {
+		return
+	}
+	if os.Getenv(constants.TFCudaLibPathEnv) != "" && os.Getenv(constants.TFNvmlLibPathEnv) != "" {
+		return
+	}
+
+	driverRoot, err := nvidiaDriverRootFromContract(contractPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			klog.Warningf("Failed to read NVIDIA driver contract %s: %v", contractPath, err)
+		}
+		return
+	}
+
+	setNvidiaLibraryEnvIfMissing(constants.TFCudaLibPathEnv, driverRoot, nvidiaCudaLibraryName)
+	setNvidiaLibraryEnvIfMissing(constants.TFNvmlLibPathEnv, driverRoot, nvidiaNvmlLibraryName)
+}
+
+func setNvidiaLibraryEnvIfMissing(envName, driverRoot, libraryName string) {
+	if os.Getenv(envName) != "" {
+		return
+	}
+	libraryPath, err := findNvidiaDriverLibrary(driverRoot, libraryName)
+	if err != nil {
+		klog.Warningf("NVIDIA driver contract root %s does not contain %s: %v", driverRoot, libraryName, err)
+		return
+	}
+	if err := os.Setenv(envName, libraryPath); err != nil {
+		klog.Warningf("Failed to set %s: %v", envName, err)
+		return
+	}
+	klog.Infof("Using NVIDIA driver library from %s=%s", envName, libraryPath)
+}
+
+func nvidiaDriverRootFromContract(contractPath string) (string, error) {
+	file, err := os.Open(contractPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close() //nolint:errcheck
+
+	values := make(map[string]string, 2)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key == driverRootCtrPathEnv || key == nvidiaDriverRootEnv {
+			values[key] = strings.Trim(strings.TrimSpace(value), `"'`)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan driver contract: %w", err)
+	}
+
+	if root := validDriverRoot(values[driverRootCtrPathEnv]); root != "" {
+		switch root {
+		case "/", constants.NvidiaHostRootMountPath:
+			return constants.NvidiaHostRootMountPath, nil
+		case constants.NvidiaDriverRootHostPath, constants.NvidiaDriverRootMountPath:
+			return constants.NvidiaDriverRootMountPath, nil
+		default:
+			return root, nil
+		}
+	}
+	switch root := filepath.Clean(values[nvidiaDriverRootEnv]); root {
+	case "/":
+		return constants.NvidiaHostRootMountPath, nil
+	case constants.NvidiaDriverRootHostPath:
+		return constants.NvidiaDriverRootMountPath, nil
+	default:
+		if root := validDriverRoot(root); root != "" {
+			return filepath.Join(constants.NvidiaHostRootMountPath, root), nil
+		}
+	}
+	return "", fmt.Errorf("driver contract does not contain a valid driver root")
+}
+
+func validDriverRoot(root string) string {
+	root = filepath.Clean(strings.TrimSpace(root))
+	if root == "." || !filepath.IsAbs(root) {
+		return ""
+	}
+	return root
+}
+
+func findNvidiaDriverLibrary(driverRoot, libraryName string) (string, error) {
+	archDir := map[string]string{
+		"amd64": "x86_64-linux-gnu",
+		"arm64": "aarch64-linux-gnu",
+	}[runtime.GOARCH]
+	searchDirs := []string{"", "usr/lib64", "lib64"}
+	if archDir != "" {
+		searchDirs = append(searchDirs, filepath.Join("usr/lib", archDir), filepath.Join("lib", archDir))
+	}
+	searchDirs = append(searchDirs, "usr/lib", "lib")
+
+	for _, dir := range searchDirs {
+		candidate := filepath.Join(driverRoot, dir, libraryName)
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			// Keep the path in the container namespace. EvalSymlinks can
+			// incorrectly resolve an absolute target outside a /host mount.
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("could not locate %s", libraryName)
+}

--- a/cmd/hypervisor/nvidia_driver_test.go
+++ b/cmd/hypervisor/nvidia_driver_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+)
+
+func TestConfigureNvidiaDriverLibraries(t *testing.T) {
+	driverRoot := t.TempDir()
+	archDir := map[string]string{
+		"amd64": "x86_64-linux-gnu",
+		"arm64": "aarch64-linux-gnu",
+	}[runtime.GOARCH]
+	if archDir == "" {
+		t.Skipf("unsupported test architecture %s", runtime.GOARCH)
+	}
+	libraryDir := filepath.Join(driverRoot, "usr", "lib", archDir)
+	if err := os.MkdirAll(libraryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cudaPath := filepath.Join(libraryDir, nvidiaCudaLibraryName)
+	nvmlPath := filepath.Join(libraryDir, nvidiaNvmlLibraryName)
+	for _, path := range []string{cudaPath, nvmlPath} {
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	contractPath := filepath.Join(t.TempDir(), "driver-ready")
+	contract := "IS_HOST_DRIVER=false\n" + driverRootCtrPathEnv + "=" + driverRoot + "\n"
+	if err := os.WriteFile(contractPath, []byte(contract), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(constants.TFCudaLibPathEnv, "")
+	t.Setenv(constants.TFNvmlLibPathEnv, "")
+
+	configureNvidiaDriverLibraries(constants.AcceleratorVendorNvidia, contractPath)
+
+	if got := os.Getenv(constants.TFCudaLibPathEnv); got != cudaPath {
+		t.Fatalf("%s = %q, want %q", constants.TFCudaLibPathEnv, got, cudaPath)
+	}
+	if got := os.Getenv(constants.TFNvmlLibPathEnv); got != nvmlPath {
+		t.Fatalf("%s = %q, want %q", constants.TFNvmlLibPathEnv, got, nvmlPath)
+	}
+}
+
+func TestConfigureNvidiaDriverLibrariesPreservesExplicitPaths(t *testing.T) {
+	t.Setenv(constants.TFCudaLibPathEnv, "/custom/libcuda.so.1")
+	t.Setenv(constants.TFNvmlLibPathEnv, "/custom/libnvidia-ml.so.1")
+
+	configureNvidiaDriverLibraries(constants.AcceleratorVendorNvidia, "/missing/driver-ready")
+
+	if got := os.Getenv(constants.TFCudaLibPathEnv); got != "/custom/libcuda.so.1" {
+		t.Fatalf("explicit CUDA path was changed to %q", got)
+	}
+	if got := os.Getenv(constants.TFNvmlLibPathEnv); got != "/custom/libnvidia-ml.so.1" {
+		t.Fatalf("explicit NVML path was changed to %q", got)
+	}
+}
+
+func TestConfigureNvidiaDriverLibrariesFillsOnlyMissingPath(t *testing.T) {
+	driverRoot := t.TempDir()
+	libraryDir := filepath.Join(driverRoot, "usr", "lib64")
+	if err := os.MkdirAll(libraryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nvmlPath := filepath.Join(libraryDir, nvidiaNvmlLibraryName)
+	if err := os.WriteFile(nvmlPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	contractPath := filepath.Join(t.TempDir(), "driver-ready")
+	if err := os.WriteFile(contractPath, []byte(driverRootCtrPathEnv+"="+driverRoot+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(constants.TFCudaLibPathEnv, "/custom/libcuda.so.1")
+	t.Setenv(constants.TFNvmlLibPathEnv, "")
+
+	configureNvidiaDriverLibraries(constants.AcceleratorVendorNvidia, contractPath)
+
+	if got := os.Getenv(constants.TFCudaLibPathEnv); got != "/custom/libcuda.so.1" {
+		t.Fatalf("explicit CUDA path was changed to %q", got)
+	}
+	if got := os.Getenv(constants.TFNvmlLibPathEnv); got != nvmlPath {
+		t.Fatalf("%s = %q, want %q", constants.TFNvmlLibPathEnv, got, nvmlPath)
+	}
+}
+
+func TestConfigureNvidiaDriverLibrariesIgnoresOtherVendors(t *testing.T) {
+	t.Setenv(constants.TFCudaLibPathEnv, "")
+	t.Setenv(constants.TFNvmlLibPathEnv, "")
+
+	configureNvidiaDriverLibraries("Ascend", "/missing/driver-ready")
+
+	if got := os.Getenv(constants.TFCudaLibPathEnv); got != "" {
+		t.Fatalf("unexpected CUDA path %q", got)
+	}
+	if got := os.Getenv(constants.TFNvmlLibPathEnv); got != "" {
+		t.Fatalf("unexpected NVML path %q", got)
+	}
+}
+
+func TestNvidiaDriverRootFromContractFallbacks(t *testing.T) {
+	tests := []struct {
+		name     string
+		contract string
+		want     string
+	}{
+		{
+			name:     "legacy container driver contract",
+			contract: driverRootCtrPathEnv + "=" + constants.NvidiaDriverRootHostPath + "\n",
+			want:     constants.NvidiaDriverRootMountPath,
+		},
+		{
+			name:     "host driver",
+			contract: nvidiaDriverRootEnv + "=/\n",
+			want:     constants.NvidiaHostRootMountPath,
+		},
+		{
+			name:     "containerized driver",
+			contract: nvidiaDriverRootEnv + "=" + constants.NvidiaDriverRootHostPath + "\n",
+			want:     constants.NvidiaDriverRootMountPath,
+		},
+		{
+			name:     "custom host driver root",
+			contract: nvidiaDriverRootEnv + "=/opt/nvidia/driver\n",
+			want:     "/host/opt/nvidia/driver",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "driver-ready")
+			if err := os.WriteFile(path, []byte(tt.contract), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := nvidiaDriverRootFromContract(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("root = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/samples/provider-nvidia.yaml
+++ b/config/samples/provider-nvidia.yaml
@@ -1,5 +1,5 @@
 # Real-world NVIDIA ProviderConfig example (full hardware catalog + MIG-ready hypervisor).
-# Image tags default to :latest; pin them for production.
+# Pin image tags to versions validated for the target TensorFusion release.
 apiVersion: tensor-fusion.ai/v1
 kind: ProviderConfig
 metadata:
@@ -8,8 +8,8 @@ spec:
   vendor: NVIDIA
   images:
     middleware: tensorfusion/vgpu-provider-nvidia:latest
-    remoteClient: tensorfusion/tensor-fusion-client:latest
-    remoteWorker: tensorfusion/tensor-fusion-worker:latest
+    remoteClient: tensorfusion/tensor-fusion-client:v2.25.0
+    remoteWorker: tensorfusion/tensor-fusion-worker:v2.25.0
   hypervisor:
     privilegedHypervisor: true
     extraEnv:
@@ -17,6 +17,13 @@ spec:
       value: all
     - name: NVIDIA_MIG_MONITOR_DEVICES
       value: all
+    # Usually leave TF_CUDA_LIB_PATH and TF_NVML_LIB_PATH unset so the
+    # Hypervisor can discover NVIDIA GPU Operator driver paths. Set them only
+    # when the libraries live at known custom paths.
+    # - name: TF_CUDA_LIB_PATH
+    #   value: /custom/driver/libcuda.so.1
+    # - name: TF_NVML_LIB_PATH
+    #   value: /custom/driver/libnvidia-ml.so.1
   devicePluginDetection:
     resourceNamePrefixes:
     - nvidia.com/gpu

--- a/config/samples/tensorfusioncluster-nvidia.yaml
+++ b/config/samples/tensorfusioncluster-nvidia.yaml
@@ -1,5 +1,5 @@
 # Real-world NVIDIA TensorFusionCluster example (single NVIDIA pool, from a running cluster).
-# Image tags normalized to :latest; pin them for production.
+# Pin image tags to versions validated for the target TensorFusion release.
 apiVersion: tensor-fusion.ai/v1
 kind: TensorFusionCluster
 metadata:
@@ -31,8 +31,8 @@ spec:
           vram: 5Gi
       componentConfig:
         client:
-          embeddedModeImage: tensorfusion/tensor-fusion-client:latest
-          image: tensorfusion/tensor-fusion-client:latest
+          embeddedModeImage: tensorfusion/tensor-fusion-client:v2.25.0
+          image: tensorfusion/tensor-fusion-client:v2.25.0
           operatorEndpoint: http://tensor-fusion-sys.tensor-fusion-sys:8080
           patchToContainer:
             env:
@@ -42,7 +42,7 @@ spec:
               value: /tmp/tf.log
           patchToPod:
             spec: {}
-          remoteModeImage: tensorfusion/tensor-fusion-client:latest
+          remoteModeImage: tensorfusion/tensor-fusion-client:v2.25.0
         hypervisor:
           image: docker.io/tensorfusion/tensor-fusion-hypervisor:latest
           vectorImage: docker.m.daocloud.io/timberio/vector:latest-alpine
@@ -76,7 +76,7 @@ spec:
                 containers:
                 - name: tensorfusion-node-discovery
         worker:
-          image: tensorfusion/tensor-fusion-worker:latest
+          image: tensorfusion/tensor-fusion-worker:v2.25.0
           podTemplate:
             template:
               spec:

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -2,6 +2,10 @@
 
 本文档说明如何在 Kubernetes 集群中安装 TensorFusion 控制面，并完成最小业务 Pod 验证。
 
+TensorFusion 官方镜像发布在 [Docker Hub](https://hub.docker.com/u/tensorfusion)。需要使用最新
+版本时，可在该页面确认 operator、hypervisor、client 和 worker 的可用 tag，再覆盖 Helm
+values 或 TensorFusionCluster/ProviderConfig 中的镜像字段。
+
 适用假设：
 
 - 使用本仓库 Helm chart 安装，chart 路径为 `charts/tensor-fusion`。
@@ -94,10 +98,22 @@ helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
 | `controller.image.repository` | operator 镜像仓库 | `tensorfusion/tensor-fusion-operator` |
 | `controller.image.tag` | operator 镜像 tag；空值时使用 Chart `appVersion` | `""`（当前解析为 `2.15.0`） |
 | `controller.replicaCount` | controller 副本数 | `1` |
+| `controller.compatibleWithNvidiaContainerToolkit` | 启用 NVIDIA Container Toolkit 校验及驱动库兼容挂载 | `false` |
 | `greptime.installStandalone` | 是否安装内置 GreptimeDB standalone | `true` |
 | `greptime.host` | GreptimeDB MySQL endpoint host | `greptimedb-standalone.greptimedb.svc.cluster.local` |
 | `alert.enabled` | 是否安装 alertmanager | `true` |
 | `controller.admissionWebhooks.failurePolicy` | webhook 失败策略 | `Fail` |
+
+安装了 NVIDIA GPU Operator，且 GPU 节点提供
+`/run/nvidia/validations/toolkit-ready` 和 `driver-ready` 时，可设置：
+
+```bash
+--set controller.compatibleWithNvidiaContainerToolkit=true
+```
+
+这会启用 Toolkit 就绪检查和非标准驱动目录发现。没有这些 validation 文件的集群应保持默认
+`false`。如需覆盖自动发现，可通过 `ProviderConfig.spec.hypervisor.extraEnv` 显式设置
+`TF_CUDA_LIB_PATH` 和 `TF_NVML_LIB_PATH`。
 
 ### 2.4 指定组件版本
 
@@ -111,8 +127,8 @@ helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
   --set controller.image.tag=2.15.0 \
   --set cluster.hypervisorImage=tensorfusion/tensor-fusion-hypervisor:2.15.0 \
   --set providerConfigs.nvidia.images.middleware=tensorfusion/vgpu-provider-nvidia:1.3.9 \
-  --set providerConfigs.nvidia.images.remoteClient=tensorfusion/tensor-fusion-client:v2.15.0 \
-  --set providerConfigs.nvidia.images.remoteWorker=tensorfusion/tensor-fusion-worker:v2.15.0
+  --set providerConfigs.nvidia.images.remoteClient=tensorfusion/tensor-fusion-client:v2.25.0 \
+  --set providerConfigs.nvidia.images.remoteWorker=tensorfusion/tensor-fusion-worker:v2.25.0
 ```
 
 各组件对应的 values 键：
@@ -122,8 +138,8 @@ helm upgrade --install tensor-fusion-sys ./charts/tensor-fusion \
 | operator | `controller.image.repository` + `controller.image.tag` | 仓库与 tag 分开两个键 |
 | hypervisor | `cluster.hypervisorImage` | **完整镜像**（含仓库+tag），默认 `tensorfusion/tensor-fusion-hypervisor:2.15.0` |
 | vgpu-provider | `providerConfigs.nvidia.images.middleware` | 默认 `tensorfusion/vgpu-provider-nvidia:1.3.9` |
-| client | `providerConfigs.nvidia.images.remoteClient` | 默认 `tensorfusion/tensor-fusion-client:v2.15.0` |
-| worker | `providerConfigs.nvidia.images.remoteWorker` | 默认 `tensorfusion/tensor-fusion-worker:v2.15.0` |
+| client | `providerConfigs.nvidia.images.remoteClient` | 默认 `tensorfusion/tensor-fusion-client:v2.25.0` |
+| worker | `providerConfigs.nvidia.images.remoteWorker` | 默认 `tensorfusion/tensor-fusion-worker:v2.25.0` |
 
 > 注意：`cluster.hypervisorImage` 传的是完整镜像引用（`仓库:tag`），而 operator 用 `repository` + `tag` 两个独立键。
 

--- a/internal/controller/gpunode_controller.go
+++ b/internal/controller/gpunode_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path/filepath"
 	"strings"
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
@@ -601,12 +602,13 @@ func (r *GPUNodeReconciler) createHypervisorPod(
 	if err != nil {
 		return fmt.Errorf("failed to resolve isolation mode for node %s: %w", node.Name, err)
 	}
-	applyHypervisorIsolationModeArg(&spec, string(isolationMode))
 	policy := r.IsolationModePolicy
 	if policy == "" {
 		policy = tfv1.IsolationModePolicyStatic
 	}
-	applyHypervisorIsolationPolicyArg(&spec, string(policy))
+	// Keep the TFC command and args unchanged. The Hypervisor receives the
+	// effective isolation settings through environment variables.
+	setHypervisorIsolationEnv(&spec, string(isolationMode), string(policy))
 
 	// add vendor-specific env vars for multi-vendor support
 	if node.Labels != nil && node.Labels[constants.AcceleratorLabelVendor] != "" {
@@ -1152,84 +1154,88 @@ func hypervisorPolicyUpdatePending(pool *tfv1.GPUPool) bool {
 	return status.HypervisorVersion != utils.HypervisorTemplateHash(pool) || !status.HypervisorConfigSynced
 }
 
-func applyHypervisorIsolationModeArg(spec *corev1.PodSpec, isolationMode string) {
-	if spec == nil || len(spec.Containers) == 0 || isolationMode == "" {
-		return
-	}
-	spec.Containers[0].Args = upsertHypervisorIsolationModeArg(spec.Containers[0].Args, isolationMode)
-}
-
-func applyHypervisorIsolationPolicyArg(spec *corev1.PodSpec, policy string) {
-	if spec == nil || len(spec.Containers) == 0 || policy == "" {
-		return
-	}
-	policy = strings.ToLower(strings.TrimSpace(policy))
-	const policyFlag = "--isolation-policy"
-	args := spec.Containers[0].Args
-	for i := 0; i < len(args); i++ {
-		if strings.HasPrefix(args[i], policyFlag+"=") {
-			args[i] = policyFlag + "=" + policy
-			spec.Containers[0].Args = args
-			return
-		}
-		if args[i] == policyFlag {
-			if i+1 < len(args) {
-				args[i+1] = policy
-			} else {
-				args = append(args, policy)
-			}
-			spec.Containers[0].Args = args
-			return
-		}
-	}
-	spec.Containers[0].Args = append(args, policyFlag+"="+policy)
-}
-
-func upsertHypervisorIsolationModeArg(args []string, isolationMode string) []string {
-	const isolationModeFlag = "--isolation-mode"
-	if isolationMode == "" {
-		return args
-	}
-
-	for i := 0; i < len(args); i++ {
-		if strings.HasPrefix(args[i], isolationModeFlag+"=") {
-			args[i] = isolationModeFlag + "=" + isolationMode
-			return args
-		}
-		if args[i] == isolationModeFlag {
-			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				args[i+1] = isolationMode
-			} else {
-				args = append(args, isolationMode)
-			}
-			return args
-		}
-	}
-	return append(args, isolationModeFlag+"="+isolationMode)
-}
-
 func isHypervisorIsolationModeConfigured(pod *corev1.Pod, desiredIsolationMode string) bool {
 	if pod == nil || len(pod.Spec.Containers) == 0 {
 		return false
 	}
 
-	actualIsolationMode, found, valid := extractHypervisorIsolationModeArg(pod.Spec.Containers[0].Args)
-	if desiredIsolationMode == "" {
-		// When label is absent, hypervisor args should not carry explicit isolation mode.
-		return !found
+	container := pod.Spec.Containers[0]
+	if actualIsolationMode, found := extractEnvValue(container.Env, constants.TFIsolationModeEnv); found {
+		return desiredIsolationMode != "" &&
+			strings.EqualFold(actualIsolationMode, desiredIsolationMode)
 	}
-	return found && valid && actualIsolationMode == desiredIsolationMode
+	if !usesShellCommand(container.Command) {
+		actualIsolationMode, found, valid := extractHypervisorIsolationModeArg(container.Args)
+		if found {
+			return desiredIsolationMode != "" &&
+				valid && strings.EqualFold(actualIsolationMode, desiredIsolationMode)
+		}
+	}
+	return desiredIsolationMode == ""
 }
 
 func isHypervisorIsolationPolicyConfigured(pod *corev1.Pod, desiredPolicy string) bool {
 	if pod == nil || len(pod.Spec.Containers) == 0 {
 		return false
 	}
-	actual, found := extractHypervisorIsolationPolicyArg(pod.Spec.Containers[0].Args)
-	if desiredPolicy == "" {
-		return !found
+	container := pod.Spec.Containers[0]
+	if actual, found := extractEnvValue(container.Env, constants.IsolationModePolicyEnv); found {
+		return desiredPolicy != "" && strings.EqualFold(actual, desiredPolicy)
 	}
-	return found && strings.EqualFold(actual, desiredPolicy)
+	if !usesShellCommand(container.Command) {
+		actual, found := extractHypervisorIsolationPolicyArg(container.Args)
+		if found {
+			return desiredPolicy != "" && strings.EqualFold(actual, desiredPolicy)
+		}
+	}
+	return desiredPolicy == ""
+}
+
+func setHypervisorIsolationEnv(spec *corev1.PodSpec, isolationMode, policy string) {
+	if spec == nil || len(spec.Containers) == 0 {
+		return
+	}
+	setEnvValue(&spec.Containers[0].Env, constants.TFIsolationModeEnv, isolationMode)
+	setEnvValue(&spec.Containers[0].Env, constants.IsolationModePolicyEnv, policy)
+}
+
+func setEnvValue(envs *[]corev1.EnvVar, name, value string) {
+	if envs == nil || name == "" || value == "" {
+		return
+	}
+	for i := range *envs {
+		if (*envs)[i].Name == name {
+			(*envs)[i].Value = value
+			(*envs)[i].ValueFrom = nil
+			return
+		}
+	}
+	*envs = append(*envs, corev1.EnvVar{Name: name, Value: value})
+}
+
+func extractEnvValue(envs []corev1.EnvVar, name string) (string, bool) {
+	for _, env := range envs {
+		if env.Name == name && env.Value != "" {
+			return env.Value, true
+		}
+	}
+	return "", false
+}
+
+func usesShellCommand(command []string) bool {
+	if len(command) == 0 {
+		return false
+	}
+	executable := strings.ToLower(filepath.Base(command[0]))
+	if executable != "sh" && executable != "bash" && executable != "dash" {
+		return false
+	}
+	for _, arg := range command[1:] {
+		if arg == "-c" {
+			return true
+		}
+	}
+	return false
 }
 
 func extractHypervisorIsolationPolicyArg(args []string) (string, bool) {

--- a/internal/controller/gpunode_controller_test.go
+++ b/internal/controller/gpunode_controller_test.go
@@ -160,43 +160,6 @@ var _ = Describe("GPUNode Controller", func() {
 			Expect(hypervisorPolicyUpdatePending(pool)).To(BeFalse())
 		})
 
-		It("should append the configured partitioned isolation mode arg", func() {
-			spec := &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name: constants.TFContainerNameHypervisor,
-					},
-				},
-			}
-
-			applyHypervisorIsolationModeArg(spec, string(tfv1.IsolationModePartitioned))
-			Expect(spec.Containers[0].Args).To(ContainElement("--isolation-mode=partitioned"))
-		})
-
-		It("should append and detect the Dynamic isolation policy arg", func() {
-			spec := &corev1.PodSpec{Containers: []corev1.Container{{Name: constants.TFContainerNameHypervisor}}}
-			applyHypervisorIsolationPolicyArg(spec, string(tfv1.IsolationModePolicyDynamic))
-			Expect(spec.Containers[0].Args).To(ContainElement("--isolation-policy=dynamic"))
-			pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: spec.Containers}}
-			Expect(isHypervisorIsolationPolicyConfigured(pod, string(tfv1.IsolationModePolicyDynamic))).To(BeTrue())
-			Expect(isHypervisorIsolationPolicyConfigured(pod, string(tfv1.IsolationModePolicyStatic))).To(BeFalse())
-		})
-
-		It("should replace an existing isolation mode arg with the configured mode", func() {
-			spec := &corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name: constants.TFContainerNameHypervisor,
-						Args: []string{"--foo=bar", "--isolation-mode=shared"},
-					},
-				},
-			}
-
-			applyHypervisorIsolationModeArg(spec, string(tfv1.IsolationModePartitioned))
-			Expect(spec.Containers[0].Args).To(ContainElement("--isolation-mode=partitioned"))
-			Expect(spec.Containers[0].Args).NotTo(ContainElement("--isolation-mode=shared"))
-		})
-
 		It("should require pod recreation when desired isolation mode is missing", func() {
 			pod := &corev1.Pod{
 				Spec: corev1.PodSpec{
@@ -257,12 +220,6 @@ var _ = Describe("GPUNode Controller", func() {
 			}
 
 			Expect(isHypervisorIsolationModeConfigured(pod, string(tfv1.IsolationModePartitioned))).To(BeFalse())
-		})
-
-		It("should not change args when upsert isolation mode is empty", func() {
-			args := []string{"--port=9000"}
-			got := upsertHypervisorIsolationModeArg(args, "")
-			Expect(got).To(Equal(args))
 		})
 
 		It("should require pod recreation when label is removed but arg still exists", func() {

--- a/internal/controller/gpunode_controller_unit_test.go
+++ b/internal/controller/gpunode_controller_unit_test.go
@@ -31,6 +31,72 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestSetHypervisorIsolationEnv(t *testing.T) {
+	spec := &corev1.PodSpec{Containers: []corev1.Container{{
+		Command: []string{"bash", "-c", "exec /usr/local/bin/hypervisor daemon"},
+		Args:    []string{"--custom-arg"},
+		Env: []corev1.EnvVar{
+			{Name: constants.TFIsolationModeEnv, ValueFrom: &corev1.EnvVarSource{}},
+			{Name: constants.IsolationModePolicyEnv, Value: string(tfv1.IsolationModePolicyStatic)},
+		},
+	}}}
+
+	setHypervisorIsolationEnv(spec, string(tfv1.IsolationModeSoft), string(tfv1.IsolationModePolicyDynamic))
+
+	env := spec.Containers[0].Env
+	if len(env) != 2 {
+		t.Fatalf("expected two env vars, got %d", len(env))
+	}
+	if env[0].Value != string(tfv1.IsolationModeSoft) || env[0].ValueFrom != nil {
+		t.Fatalf("isolation mode was not replaced: %+v", env[0])
+	}
+	if env[1].Value != string(tfv1.IsolationModePolicyDynamic) {
+		t.Fatalf("isolation policy = %q, want %q", env[1].Value, tfv1.IsolationModePolicyDynamic)
+	}
+	if got := spec.Containers[0].Command; len(got) != 3 || got[2] != "exec /usr/local/bin/hypervisor daemon" {
+		t.Fatalf("command was modified: %v", got)
+	}
+	if len(spec.Containers[0].Args) != 1 || spec.Containers[0].Args[0] != "--custom-arg" {
+		t.Fatalf("args were modified: %v", spec.Containers[0].Args)
+	}
+}
+
+func TestHypervisorIsolationConfigurationUsesEnvForShellCommand(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+		Command: []string{"bash", "-c"},
+		Args:    []string{"exec /usr/local/bin/hypervisor daemon", "--isolation-policy=dynamic"},
+		Env: []corev1.EnvVar{
+			{Name: constants.TFIsolationModeEnv, Value: "soft"},
+			{Name: constants.IsolationModePolicyEnv, Value: "dynamic"},
+		},
+	}}}}
+
+	if !isHypervisorIsolationModeConfigured(pod, string(tfv1.IsolationModeSoft)) {
+		t.Fatal("expected shell command to use the isolation mode env")
+	}
+	if !isHypervisorIsolationPolicyConfigured(pod, string(tfv1.IsolationModePolicyDynamic)) {
+		t.Fatal("expected shell command to use the isolation policy env")
+	}
+
+	pod.Spec.Containers[0].Env = nil
+	if isHypervisorIsolationPolicyConfigured(pod, string(tfv1.IsolationModePolicyDynamic)) {
+		t.Fatal("shell command positional args must not be treated as Hypervisor flags")
+	}
+}
+
+func TestHypervisorIsolationConfigurationUsesArgsForDirectCommand(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+		Args: []string{"--isolation-mode=soft", "--isolation-policy=dynamic"},
+	}}}}
+
+	if !isHypervisorIsolationModeConfigured(pod, string(tfv1.IsolationModeSoft)) {
+		t.Fatal("expected direct command isolation mode arg")
+	}
+	if !isHypervisorIsolationPolicyConfigured(pod, string(tfv1.IsolationModePolicyDynamic)) {
+		t.Fatal("expected direct command isolation policy arg")
+	}
+}
+
 // TestGPUNodeReconcileInitializesEmptyPhaseToPending covers the safety net for
 // pre-existing GPUNodes with an empty phase: the reconciler must set it to
 // Pending before any early-return gate (here the driver-upgrade gate), so the

--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -392,11 +393,16 @@ func AddTFDefaultClientConfBeforePatch(
 					Name:      constants.TFLibsVolumeName,
 					MountPath: constants.TFLibsVolumeMountPath,
 				})
-			pod.Spec.Containers[injectContainerIndex].VolumeMounts = appendRemoteVendorToolMounts(
-				pod.Spec.Containers[injectContainerIndex].VolumeMounts,
-				tfInfo.Profile.GPUVendor,
-				constants.TFLibsVolumeName,
-			)
+			// The local soft path adds its own nvidia-smi wrapper from the
+			// soft-limiter volume below. Do not also add the remote client
+			// wrapper, since Kubernetes requires mountPath values to be unique.
+			if !useLocalSoftIsolation(tfInfo.Profile) {
+				pod.Spec.Containers[injectContainerIndex].VolumeMounts = appendRemoteVendorToolMounts(
+					pod.Spec.Containers[injectContainerIndex].VolumeMounts,
+					tfInfo.Profile.GPUVendor,
+					constants.TFLibsVolumeName,
+				)
+			}
 		}
 	}
 
@@ -834,6 +840,9 @@ func AddTFHypervisorConfAfterTemplate(ctx context.Context, spec *v1.PodSpec, poo
 
 	composeHypervisorInitContainer(ctx, spec, pool, vendor, compatibleWithNvidiaContainerToolkit)
 	composeHypervisorContainer(spec, pool, vendor, enableVector, enablePodResourcesProxy)
+	if compatibleWithNvidiaContainerToolkit && strings.EqualFold(vendor, constants.AcceleratorVendorNvidia) {
+		addNvidiaDriverContractMounts(spec)
+	}
 
 	if enableVector {
 		composeVectorContainer(spec, pool)
@@ -917,8 +926,8 @@ func composeHypervisorInitContainer(
 			},
 			VolumeMounts: []v1.VolumeMount{
 				{
-					Name:             "run-nvidia-validations",
-					MountPath:        "/run/nvidia/validations",
+					Name:             constants.NvidiaValidationsVolumeName,
+					MountPath:        constants.NvidiaValidationsHostPath,
 					MountPropagation: ptr.To(v1.MountPropagationHostToContainer),
 				},
 			},
@@ -928,14 +937,71 @@ func composeHypervisorInitContainer(
 
 		// Add volume for NVIDIA validations
 		spec.Volumes = appendVolumesIfNotExists(spec.Volumes, v1.Volume{
-			Name: "run-nvidia-validations",
+			Name: constants.NvidiaValidationsVolumeName,
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
-					Path: "/run/nvidia/validations",
+					Path: constants.NvidiaValidationsHostPath,
 					Type: ptr.To(v1.HostPathDirectoryOrCreate),
 				},
 			},
 		})
+	}
+}
+
+func addNvidiaDriverContractMounts(spec *v1.PodSpec) {
+	if spec == nil || len(spec.Containers) == 0 {
+		return
+	}
+
+	bindings := []struct {
+		volume v1.Volume
+		mount  v1.VolumeMount
+	}{
+		{
+			volume: v1.Volume{
+				Name: constants.NvidiaValidationsVolumeName,
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{
+					Path: constants.NvidiaValidationsHostPath,
+					Type: ptr.To(v1.HostPathDirectoryOrCreate),
+				}},
+			},
+			mount: v1.VolumeMount{
+				Name: constants.NvidiaValidationsVolumeName, MountPath: constants.NvidiaValidationsHostPath, ReadOnly: true,
+			},
+		},
+		{
+			volume: v1.Volume{
+				Name: constants.NvidiaHostRootVolumeName,
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{
+					Path: constants.NvidiaHostRootHostPath,
+					Type: ptr.To(v1.HostPathDirectory),
+				}},
+			},
+			mount: v1.VolumeMount{
+				Name: constants.NvidiaHostRootVolumeName, MountPath: constants.NvidiaHostRootMountPath, ReadOnly: true,
+			},
+		},
+		{
+			volume: v1.Volume{
+				Name: constants.NvidiaDriverRootVolumeName,
+				VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{
+					Path: constants.NvidiaDriverRootHostPath,
+					Type: ptr.To(v1.HostPathDirectoryOrCreate),
+				}},
+			},
+			mount: v1.VolumeMount{
+				Name: constants.NvidiaDriverRootVolumeName, MountPath: constants.NvidiaDriverRootMountPath, ReadOnly: true,
+			},
+		},
+	}
+	for _, binding := range bindings {
+		if slices.ContainsFunc(spec.Containers[0].VolumeMounts, func(existing v1.VolumeMount) bool {
+			return existing.Name == binding.mount.Name || existing.MountPath == binding.mount.MountPath
+		}) {
+			continue
+		}
+		spec.Volumes = appendVolumesIfNotExists(spec.Volumes, binding.volume)
+		spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, binding.mount)
 	}
 }
 

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -72,6 +72,16 @@ func hasVolumeMountWithSubPath(mounts []corev1.VolumeMount, name, path, subPath 
 	return false
 }
 
+func countVolumeMountPath(mounts []corev1.VolumeMount, path string) int {
+	count := 0
+	for _, mount := range mounts {
+		if mount.MountPath == path {
+			count++
+		}
+	}
+	return count
+}
+
 func hasHostPathVolume(volumes []corev1.Volume, name, path string) bool {
 	for _, volume := range volumes {
 		if volume.Name == name && volume.HostPath != nil && volume.HostPath.Path == path {
@@ -152,6 +162,69 @@ var _ = Describe("Compose Utils", func() {
 			Expect(validationVolumes[0].HostPath).NotTo(BeNil())
 			Expect(validationVolumes[0].HostPath.Path).To(Equal("/run/nvidia/validations"))
 			Expect(validationVolumes[0].HostPath.Type).To(BeNil(), "the existing template volume must win")
+			Expect(slices.ContainsFunc(spec.Containers[0].VolumeMounts, func(m corev1.VolumeMount) bool {
+				return m.Name == constants.NvidiaValidationsVolumeName &&
+					m.MountPath == constants.NvidiaValidationsHostPath && m.ReadOnly
+			})).To(BeTrue())
+			Expect(slices.ContainsFunc(spec.Containers[0].VolumeMounts, func(m corev1.VolumeMount) bool {
+				return m.Name == constants.NvidiaHostRootVolumeName &&
+					m.MountPath == constants.NvidiaHostRootMountPath && m.ReadOnly
+			})).To(BeTrue())
+			Expect(slices.ContainsFunc(spec.Containers[0].VolumeMounts, func(m corev1.VolumeMount) bool {
+				return m.Name == constants.NvidiaDriverRootVolumeName &&
+					m.MountPath == constants.NvidiaDriverRootMountPath && m.ReadOnly
+			})).To(BeTrue())
+			Expect(slices.ContainsFunc(spec.Volumes, func(v corev1.Volume) bool {
+				return v.Name == constants.NvidiaHostRootVolumeName && v.HostPath != nil &&
+					v.HostPath.Path == constants.NvidiaHostRootHostPath
+			})).To(BeTrue())
+			Expect(slices.ContainsFunc(spec.Volumes, func(v corev1.Volume) bool {
+				return v.Name == constants.NvidiaDriverRootVolumeName && v.HostPath != nil &&
+					v.HostPath.Path == constants.NvidiaDriverRootHostPath
+			})).To(BeTrue())
+		})
+
+		It("does not add NVIDIA driver contract mounts for another vendor", func() {
+			ctx := context.Background()
+			spec := &corev1.PodSpec{}
+			pool := &tfv1.GPUPool{Spec: tfv1.GPUPoolSpec{ComponentConfig: &tfv1.ComponentConfig{
+				Hypervisor: &tfv1.HypervisorConfig{Image: "test-image:latest"},
+			}}}
+
+			utils.AddTFHypervisorConfAfterTemplate(ctx, spec, pool, "Ascend", true)
+
+			for _, mount := range spec.Containers[0].VolumeMounts {
+				Expect(mount.Name).NotTo(Equal(constants.NvidiaHostRootVolumeName))
+				Expect(mount.Name).NotTo(Equal(constants.NvidiaDriverRootVolumeName))
+			}
+		})
+
+		It("preserves a user-provided host root mount", func() {
+			ctx := context.Background()
+			spec := &corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "tensor-fusion-hypervisor",
+					VolumeMounts: []corev1.VolumeMount{{
+						Name: "custom-host-root", MountPath: constants.NvidiaHostRootMountPath, ReadOnly: true,
+					}},
+				}},
+				Volumes: []corev1.Volume{{
+					Name: "custom-host-root",
+					VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+						Path: constants.NvidiaHostRootHostPath,
+					}},
+				}},
+			}
+			pool := &tfv1.GPUPool{Spec: tfv1.GPUPoolSpec{ComponentConfig: &tfv1.ComponentConfig{
+				Hypervisor: &tfv1.HypervisorConfig{Image: "test-image:latest"},
+			}}}
+
+			utils.AddTFHypervisorConfAfterTemplate(ctx, spec, pool, "NVIDIA", true)
+
+			Expect(countVolumeMountPath(spec.Containers[0].VolumeMounts, constants.NvidiaHostRootMountPath)).To(Equal(1))
+			Expect(slices.ContainsFunc(spec.Volumes, func(v corev1.Volume) bool {
+				return v.Name == constants.NvidiaHostRootVolumeName
+			})).To(BeFalse())
 		})
 
 		It("injects the pod-resources-tf volume/mount only when the proxy is enabled", func() {
@@ -317,6 +390,7 @@ var _ = Describe("Compose Utils", func() {
 
 			// Business container has limiter volume and shared memory volume
 			Expect(hasVolumeMount(pod.Spec.Containers[0].VolumeMounts, constants.TFSoftLimiterVolumeName, constants.TFSoftLimiterVolumeMountPath)).To(BeTrue())
+			Expect(countVolumeMountPath(pod.Spec.Containers[0].VolumeMounts, "/usr/local/bin/nvidia-smi")).To(Equal(1))
 			Expect(hasVolumeMount(
 				pod.Spec.Containers[0].VolumeMounts,
 				constants.DataVolumeName,

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -2,7 +2,9 @@ package constants
 
 // Controller itself envs
 const (
-	NamespaceEnv           = "OPERATOR_NAMESPACE"
+	NamespaceEnv = "OPERATOR_NAMESPACE"
+	// IsolationModePolicyEnv configures both the scheduling-domain policy in
+	// the Operator and the policy passed to generated Hypervisor Pods.
 	IsolationModePolicyEnv = "TF_ISOLATION_MODE_POLICY"
 )
 
@@ -33,6 +35,8 @@ const (
 	NvidiaVisibleAllDeviceEnv   = "NVIDIA_VISIBLE_DEVICES"
 	NvidiaVisibleAllDeviceValue = "all"
 	CudaVisibleDevicesEnv       = "CUDA_VISIBLE_DEVICES"
+	TFCudaLibPathEnv            = "TF_CUDA_LIB_PATH"
+	TFNvmlLibPathEnv            = "TF_NVML_LIB_PATH"
 
 	// Per-vendor visible-devices envs honored by the matching OCI runtime hook
 	// (mthreads-container-runtime / ascend-docker-runtime). For non-partitioned
@@ -81,6 +85,18 @@ const (
 	TensorFusionLogPath      = "/logs"
 
 	DefaultHttpBindIP = "0.0.0.0"
+)
+
+const (
+	NvidiaValidationsVolumeName = "run-nvidia-validations"
+	NvidiaValidationsHostPath   = "/run/nvidia/validations"
+	NvidiaDriverReadyPath       = NvidiaValidationsHostPath + "/driver-ready"
+	NvidiaHostRootVolumeName    = "nvidia-host-root"
+	NvidiaHostRootHostPath      = "/"
+	NvidiaHostRootMountPath     = "/host"
+	NvidiaDriverRootVolumeName  = "nvidia-driver-root"
+	NvidiaDriverRootHostPath    = "/run/nvidia/driver"
+	NvidiaDriverRootMountPath   = "/driver-root"
 )
 
 const (


### PR DESCRIPTION
 ## 背景

  部分使用 NVIDIA GPU Operator 的集群会将驱动安装在非标准目录，并通过
  `/run/nvidia/validations/driver-ready` 暴露驱动路径。

  同时，v1 TensorFusionCluster 可能为 Hypervisor 配置了自定义 shell command。
  升级到 v2 时，如果 Operator直接修改 command/args，可能造成启动参数丢失或
  `isolationPolicy` 配置错误。

  ## 修改内容

  - 保持 TensorFusionCluster 中原有 Hypervisor `command/args` 不变。
  - 通过以下环境变量向 Hypervisor 传递隔离配置：
    - `TF_ISOLATION_MODE`
    - `TF_ISOLATION_MODE_POLICY`
  - v2 Hypervisor 兼容 v1 的 `hypervisor daemon` 启动形式。
  - 开启 `--compatible-with-nvidia-container-toolkit=true` 且厂商为 NVIDIA 时：
    - 挂载 NVIDIA validation、宿主机根目录和 driver root。
    - 读取 `driver-ready` 中的 `DRIVER_ROOT_CTR_PATH` 或 `NVIDIA_DRIVER_ROOT`。
    - 自动定位 `libcuda.so.1` 和 `libnvidia-ml.so.1`。
    - 自动补充 `TF_CUDA_LIB_PATH` 和 `TF_NVML_LIB_PATH`。
  - `ProviderConfig.spec.hypervisor.extraEnv` 中的显式路径优先，不会被自动发现覆盖。
  - 修复 local soft 模式下 `/usr/local/bin/nvidia-smi` 重复挂载。
  - Helm 增加 `controller.compatibleWithNvidiaContainerToolkit` 配置，默认关闭，避免没有 NVIDIA validation 文件的集群启动阻塞。
  - NVIDIA client/worker 默认及示例镜像更新为 `v2.25.0`。
  - 安装文档补充 TensorFusion Docker Hub 地址及相关配置说明。

  ## 兼容性

  - 不配置兼容开关时，保持现有行为。
  - 使用旧 Hypervisor 自定义 command 的集群可直接升级 v2 镜像。
  - v2 回退到 v1 时，原有 command 不受 Operator 修改。
  - 非 NVIDIA 厂商不会增加 NVIDIA 驱动目录挂载。

  ## 验证

  - `make lint` 通过，0 issues。
  - `make test` 通过，38 个 Ginkgo suites 全部成功。
  - `helm lint charts/tensor-fusion` 通过。
  - 验证 Helm 默认不会添加兼容参数。
  - 验证显式开启后仅添加一次 `--compatible-with-nvidia-container-toolkit=true`。
  - 验证 ProviderConfig 和 TensorFusionCluster 渲染出的 client/worker 镜像均为 `v2.25.0`。