### PR TITLE
fix(scheduler): clean stale GPU indexes and NodeClaim metadata

### DIFF
--- a/internal/gpuallocator/gpu_index_update_unit_test.go
+++ b/internal/gpuallocator/gpu_index_update_unit_test.go
@@ -1,0 +1,67 @@
+package gpuallocator
+
+import (
+	"context"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/NexusGPU/tensor-fusion/pkg/constants"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestHandleGPUUpdateRefreshesNodeAndPoolIndexes(t *testing.T) {
+	oldGPU := &tfv1.GPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "gpu-1",
+			Labels: map[string]string{constants.GpuPoolKey: "pool-old"},
+		},
+		Status: tfv1.GPUStatus{
+			NodeSelector: map[string]string{constants.KubernetesHostNameLabel: "node-old"},
+			Capacity: &tfv1.Resource{
+				Tflops: resource.MustParse("10"),
+				Vram:   resource.MustParse("1Gi"),
+			},
+			Available: &tfv1.Resource{
+				Tflops: resource.MustParse("10"),
+				Vram:   resource.MustParse("1Gi"),
+			},
+		},
+	}
+	newGPU := oldGPU.DeepCopy()
+	newGPU.Labels[constants.GpuPoolKey] = "pool-new"
+	newGPU.Status.NodeSelector[constants.KubernetesHostNameLabel] = "node-new"
+
+	allocator := &GpuAllocator{
+		gpuStore: map[types.NamespacedName]*tfv1.GPU{
+			{Name: oldGPU.Name}: oldGPU,
+		},
+		nodeGpuStore: map[string]map[string]*tfv1.GPU{
+			"node-old": {oldGPU.Name: oldGPU},
+		},
+		poolGpuStore: map[string]map[string]*tfv1.GPU{
+			"pool-old": {oldGPU.Name: oldGPU},
+		},
+		nodeWorkerStore: map[string]map[types.NamespacedName]struct{}{
+			"node-old": {},
+		},
+	}
+
+	allocator.handleGPUUpdate(context.Background(), newGPU)
+
+	_, oldNodeExists := allocator.nodeGpuStore["node-old"][oldGPU.Name]
+	_, oldPoolExists := allocator.poolGpuStore["pool-old"][oldGPU.Name]
+	newNodeGPU, newNodeExists := allocator.nodeGpuStore["node-new"][oldGPU.Name]
+	newPoolGPU, newPoolExists := allocator.poolGpuStore["pool-new"][oldGPU.Name]
+
+	require.False(t, oldNodeExists)
+	require.False(t, oldPoolExists)
+	require.True(t, newNodeExists)
+	require.True(t, newPoolExists)
+	require.Same(t, oldGPU, newNodeGPU)
+	require.Same(t, oldGPU, newPoolGPU)
+	_, oldWorkerExists := allocator.nodeWorkerStore["node-old"]
+	require.False(t, oldWorkerExists)
+}

--- a/internal/gpuallocator/gpuallocator.go
+++ b/internal/gpuallocator/gpuallocator.go
@@ -2390,40 +2390,8 @@ func (s *GpuAllocator) handleGPUDelete(ctx context.Context, gpu *tfv1.GPU) {
 
 	// Remove GPU from store
 	delete(s.gpuStore, key)
-
-	if gpu.Status.NodeSelector != nil {
-		gpuNodeName := gpu.Status.NodeSelector[constants.KubernetesHostNameLabel]
-		if s.nodeGpuStore[gpuNodeName] != nil {
-			delete(s.nodeGpuStore[gpuNodeName], gpu.Name)
-			// A node's last GPU being removed almost always means the node
-			// itself is gone (terminated/scaled down). Drop the now-empty
-			// entry too, otherwise it lingers in nodeGpuStore forever and
-			// keeps showing up as a defunct defrag budget target.
-			if len(s.nodeGpuStore[gpuNodeName]) == 0 {
-				delete(s.nodeGpuStore, gpuNodeName)
-				// GPU CR deletion doesn't guarantee the node's workers are
-				// gone too (e.g. cascade-delete on node termination races
-				// ahead of pod cleanup, or RunningApps hasn't synced to the
-				// GPU CR yet when node-discovery decides to delete it) so
-				// only reap nodeWorkerStore here if it's already empty;
-				// otherwise leave live worker bookkeeping for Dealloc /
-				// the cleanup checker to retire pod-by-pod.
-				if len(s.nodeWorkerStore[gpuNodeName]) == 0 {
-					delete(s.nodeWorkerStore, gpuNodeName)
-				}
-			}
-		}
-	}
-
-	if gpu.Labels != nil {
-		pool := gpu.Labels[constants.GpuPoolKey]
-		if pool != "" {
-			delete(s.poolGpuStore[pool], gpu.Name)
-			if len(s.poolGpuStore[pool]) == 0 {
-				delete(s.poolGpuStore, pool)
-			}
-		}
-	}
+	// Remove all secondary indexes using the last known metadata.
+	s.removeGPUFromMaps(gpu)
 	log.Info("Removed GPU from store", "name", key.Name)
 }
 
@@ -2436,6 +2404,10 @@ func (s *GpuAllocator) handleGPUUpdate(ctx context.Context, gpu *tfv1.GPU) {
 	defer s.storeMutex.Unlock()
 
 	if old, ok := s.gpuStore[key]; ok && old != nil {
+		// The node and pool indexes are keyed by mutable GPU metadata. Remove
+		// the old entries before syncing the new metadata, otherwise a GPU that
+		// moves nodes or pools remains reachable through its old index.
+		s.removeGPUFromMaps(old)
 		s.handleGPUUpdateCapacityDiff(old, gpu)
 
 		// should never update available and runningApps here, to avoid circular update
@@ -2454,6 +2426,45 @@ func (s *GpuAllocator) handleGPUUpdate(ctx context.Context, gpu *tfv1.GPU) {
 	}
 
 	s.addOrUpdateGPUMaps(s.gpuStore[key])
+}
+
+// removeGPUFromMaps removes a GPU from the secondary node and pool indexes.
+// Callers must hold storeMutex.
+func (s *GpuAllocator) removeGPUFromMaps(gpu *tfv1.GPU) {
+	if gpu == nil {
+		return
+	}
+
+	if gpu.Status.NodeSelector != nil {
+		nodeName := gpu.Status.NodeSelector[constants.KubernetesHostNameLabel]
+		if gpuMap := s.nodeGpuStore[nodeName]; gpuMap != nil {
+			delete(gpuMap, gpu.Name)
+			// A node's last GPU being removed almost always means the node
+			// itself is gone (terminated/scaled down). Drop the now-empty
+			// entry too, otherwise it lingers in nodeGpuStore forever and
+			// keeps showing up as a defunct defrag budget target.
+			if len(gpuMap) == 0 {
+				delete(s.nodeGpuStore, nodeName)
+				// GPU removal does not guarantee that worker bookkeeping has
+				// already drained, so only reap an empty worker map here.
+				if len(s.nodeWorkerStore[nodeName]) == 0 {
+					delete(s.nodeWorkerStore, nodeName)
+				}
+			}
+		}
+	}
+
+	if gpu.Labels != nil {
+		pool := gpu.Labels[constants.GpuPoolKey]
+		if pool != "" {
+			if gpuMap := s.poolGpuStore[pool]; gpuMap != nil {
+				delete(gpuMap, gpu.Name)
+				if len(gpuMap) == 0 {
+					delete(s.poolGpuStore, pool)
+				}
+			}
+		}
+	}
 }
 
 func (s *GpuAllocator) addOrUpdateGPUMaps(gpuInMem *tfv1.GPU) {
@@ -3227,7 +3238,7 @@ func removeRunningApp(ctx context.Context, gpu *tfv1.GPU, allocRequest *tfv1.All
 		if item.Count == 0 {
 			// scale down to zero, not running any more
 			gpu.Status.RunningApps = lo.Filter(gpu.Status.RunningApps, func(app *tfv1.RunningAppDetail, _ int) bool {
-				return app.Name != workloadNameNamespace.Name && app.Namespace != workloadNameNamespace.Namespace
+				return app.Name != workloadNameNamespace.Name || app.Namespace != workloadNameNamespace.Namespace
 			})
 		} else {
 			item.Pods = lo.Filter(item.Pods, func(pod *tfv1.PodGPUInfo, _ int) bool {

--- a/internal/gpuallocator/running_apps_unit_test.go
+++ b/internal/gpuallocator/running_apps_unit_test.go
@@ -1,0 +1,32 @@
+package gpuallocator
+
+import (
+	"context"
+	"testing"
+
+	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveRunningAppRemovesOnlyMatchingWorkload(t *testing.T) {
+	gpu := &tfv1.GPU{
+		Status: tfv1.GPUStatus{
+			RunningApps: []*tfv1.RunningAppDetail{
+				{Name: "app-a", Namespace: "ns-a", Count: 1},
+				{Name: "app-b", Namespace: "ns-a", Count: 1},
+				{Name: "app-a", Namespace: "ns-b", Count: 1},
+				{Name: "app-b", Namespace: "ns-b", Count: 1},
+			},
+		},
+	}
+
+	removeRunningApp(context.Background(), gpu, &tfv1.AllocRequest{
+		WorkloadNameNamespace: tfv1.NameNamespace{Name: "app-a", Namespace: "ns-a"},
+	})
+
+	remaining := make([]string, 0, len(gpu.Status.RunningApps))
+	for _, app := range gpu.Status.RunningApps {
+		remaining = append(remaining, app.Namespace+"/"+app.Name)
+	}
+	require.ElementsMatch(t, []string{"ns-a/app-b", "ns-b/app-a", "ns-b/app-b"}, remaining)
+}

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -1154,10 +1154,13 @@ func (e *NodeExpander) createKarpenterNodeClaimDirect(ctx context.Context, pod *
 			if _, exists := poolKeys[requirement.Key]; exists {
 				continue
 			}
-			// A source NodeClaim contains the concrete instance type and zone
-			// selected for that node. The replacement must use the NodePool's
-			// alternatives so Karpenter can select another available offering.
-			if requirement.Key == corev1.LabelInstanceTypeStable || requirement.Key == corev1.LabelTopologyZone {
+			// A source NodeClaim contains the concrete instance type, zone, and
+			// region selected for that node. The replacement must use the
+			// NodePool's alternatives so Karpenter can select another available
+			// offering.
+			if requirement.Key == corev1.LabelInstanceTypeStable ||
+				requirement.Key == corev1.LabelTopologyZone ||
+				requirement.Key == corev1.LabelTopologyRegion {
 				continue
 			}
 			poolRequirements = append(poolRequirements, requirement)

--- a/internal/scheduler/expander/handler_test.go
+++ b/internal/scheduler/expander/handler_test.go
@@ -238,6 +238,7 @@ func testKarpenterNodeClaimCreation(suite *NodeExpanderTestSuite) {
 		Spec: karpv1.NodeClaimSpec{Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
 			testKarpenterRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, []string{"g6.12xlarge"}),
 			testKarpenterRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, []string{"us-east-1a"}),
+			testKarpenterRequirement(corev1.LabelTopologyRegion, corev1.NodeSelectorOpIn, []string{"us-east-1"}),
 			testKarpenterRequirement("team", corev1.NodeSelectorOpIn, []string{"source-value"}),
 		}, Resources: karpv1.ResourceRequirements{Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("4760m"),
@@ -302,6 +303,7 @@ func testKarpenterNodeClaimCreation(suite *NodeExpanderTestSuite) {
 	}
 	Expect(createdRequirements[corev1.LabelInstanceTypeStable]).To(Equal([]string{"g6.2xlarge"}))
 	Expect(createdRequirements[corev1.LabelTopologyZone]).To(Equal([]string{"us-east-1a", "us-east-1b"}))
+	Expect(createdRequirements).NotTo(HaveKey(corev1.LabelTopologyRegion))
 	Expect(created.Spec.Resources.Requests.Cpu().String()).To(Equal("1"))
 	Expect(created.Spec.Resources.Requests.Memory().String()).To(Equal("4Gi"))
 	Expect(created.Spec.Resources.Requests.Pods().String()).To(Equal("1"))


### PR DESCRIPTION
 ## 背景

  GPU 更新时如果节点或 GPU Pool 发生变化，旧的二级索引可能残留，导致调度器继续看到幽灵 GPU。
  同时，直建 Karpenter NodeClaim 时可能继承源 NodeClaim 的旧 region。

  ## 修改内容

  - GPU 更新前清理旧的 `nodeGpuStore` 和 `poolGpuStore` 索引，再写入新索引。
  - GPU 删除流程复用统一的二级索引清理逻辑。
  - 修复 `RunningApps` 清理条件，避免误删同名不同 namespace 或同 namespace 不同名称的 workload。
  - 创建直建 Karpenter NodeClaim 时跳过源 NodeClaim 的：
    - `node.kubernetes.io/instance-type`
    - `topology.kubernetes.io/zone`
    - `topology.kubernetes.io/region`
  - 补充 GPU 节点/Pool 迁移及 RunningApps 清理测试。
  - 补充 region 不继承测试。

  ## 验证

  - `go test ./internal/gpuallocator ./internal/scheduler/expander`
  - `go test -race ./internal/gpuallocator ./internal/scheduler/expander`
  - `git diff --check`