### PR TITLE
fix(worker): support legacy worker template name

### DIFF
--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -29,6 +29,8 @@ var injectLibResource v1.ResourceList = v1.ResourceList{
 	v1.ResourceMemory: resource.MustParse("256Mi"),
 }
 
+const legacyTFContainerNameWorker = "tensor-fusion-worker"
+
 var hypervisorDefaultRequests v1.ResourceList = v1.ResourceList{
 	v1.ResourceCPU:    resource.MustParse("50m"),
 	v1.ResourceMemory: resource.MustParse("128Mi"),
@@ -541,15 +543,11 @@ func AddTFDefaultClientConfBeforePatch(
 			if wc := pool.Spec.ComponentConfig.Worker; wc != nil && wc.PodTemplate != nil {
 				var tmpl v1.PodTemplate
 				if err := json.Unmarshal(wc.PodTemplate.Raw, &tmpl); err == nil {
-					for _, c := range tmpl.Template.Spec.Containers {
-						if c.Name != "" && c.Name != constants.TFContainerNameWorker {
-							continue
-						}
+					if c := workerTemplateContainer(tmpl.Template.Spec.Containers); c != nil {
 						sidecar.Env = append(sidecar.Env, c.Env...)
 						if c.Resources.Requests != nil || c.Resources.Limits != nil {
 							sidecar.Resources = c.Resources
 						}
-						break
 					}
 				}
 			}
@@ -1355,6 +1353,25 @@ func composeVectorContainer(spec *v1.PodSpec, pool *tfv1.GPUPool) {
 	if len(spec.Containers[1].Resources.Limits) == 0 {
 		spec.Containers[1].Resources.Limits = vectorDefaultLimits
 	}
+}
+
+func workerTemplateContainer(containers []v1.Container) *v1.Container {
+	for i := range containers {
+		if containers[i].Name == constants.TFContainerNameWorker {
+			return &containers[i]
+		}
+	}
+	for i := range containers {
+		if containers[i].Name == legacyTFContainerNameWorker {
+			return &containers[i]
+		}
+	}
+	// v1 always used the first template container. Preserve that behavior for
+	// single-container templates without making multi-container matching ambiguous.
+	if len(containers) == 1 {
+		return &containers[0]
+	}
+	return nil
 }
 
 // SetWorkerContainerSpec configures the worker container with required settings

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	tfv1 "github.com/NexusGPU/tensor-fusion/api/v1"
 	"github.com/NexusGPU/tensor-fusion/internal/provider"
@@ -470,6 +471,41 @@ var _ = Describe("Compose Utils", func() {
 			cudaHooksValue, found := envValue(pod.Spec.Containers[0].Env, constants.EnableCudaHooksEnv)
 			Expect(found).To(BeTrue())
 			Expect(cudaHooksValue).To(Equal("false"))
+		})
+
+		It("should merge legacy worker template env into local hard sidecar", func() {
+			pool := newPool()
+			pool.Spec.ComponentConfig.Worker.PodTemplate = &runtime.RawExtension{Raw: []byte(`{
+				"template":{"spec":{"containers":[{
+					"name":"tensor-fusion-worker",
+					"env":[
+						{"name":"TF_LICENSE","value":"license-value"},
+						{"name":"TF_LICENSE_SIGN","value":"signature-value"}
+					]
+				}]}}
+			}`)}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+			}
+
+			utils.AddTFDefaultClientConfBeforePatch(context.Background(), pod, pool, utils.TensorFusionInfo{
+				Profile: &tfv1.WorkloadProfileSpec{
+					IsLocalGPU: true,
+					Isolation:  tfv1.IsolationModeHard,
+					GPUVendor:  constants.AcceleratorVendorNvidia,
+				},
+			}, []int{0})
+
+			Expect(pod.Spec.Containers).To(HaveLen(2))
+			worker := pod.Spec.Containers[1]
+			Expect(worker.Name).To(Equal(constants.TFContainerNameWorker))
+			license, found := envValue(worker.Env, constants.TFLicenseEnv)
+			Expect(found).To(BeTrue())
+			Expect(license).To(Equal("license-value"))
+			signature, found := envValue(worker.Env, constants.TFLicenseHMacEnv)
+			Expect(found).To(BeTrue())
+			Expect(signature).To(Equal("signature-value"))
 		})
 
 		It("should keep local shared mode as embedded worker without tf-data shm", func() {


### PR DESCRIPTION
 ## 背景

  v1 的 hard-local worker 配置直接读取 `worker.podTemplate` 中的第一个容器，不校验容器名称。

  升级到 main 后，worker 模板改为按标准名称 `tensorfusion-worker` 匹配。部分旧配置使用 `tensor-fusion-worker`，导
  致模板中的以下配置被静默忽略：

  - `TF_LICENSE`
  - `TF_LICENSE_SIGN`
  - 自定义环境变量
  - Worker resources

  最终生成的 `tensorfusion-worker` sidecar 无法获得 License 配置。

  ## 测试

  新增回归测试，验证使用旧名称 `tensor-fusion-worker` 时：

  - 能正常生成标准名称为 `tensorfusion-worker` 的 sidecar
  - `TF_LICENSE` 能正确注入
  - `TF_LICENSE_SIGN` 能正确注入

  已通过：

  - `go test ./internal/utils`
  - `go test -race ./internal/utils`
  - `git diff --check origin/main..HEAD`