### PR TITLE
fix(expander): isolate pre-scheduled pods by namespace

### DIFF
--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -84,7 +84,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err := r.Get(ctx, req.NamespacedName, pod); err != nil {
 		if errors.IsNotFound(err) {
 			if r.Expander != nil {
-				_ = r.Expander.RemovePreSchedulePod(req.Name, true)
+				_ = r.Expander.RemovePreSchedulePod(req.Namespace, req.Name, true)
 				r.Expander.ClearFailedExpansionCandidatesForPod(req.Namespace, req.Name)
 			}
 			r.Allocator.DeallocByPodIdentifier(ctx, req.NamespacedName)
@@ -105,14 +105,14 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		pod.Labels = map[string]string{}
 	}
 	if !pod.DeletionTimestamp.IsZero() && r.Expander != nil {
-		_ = r.Expander.RemovePreSchedulePod(pod.Name, true)
+		_ = r.Expander.RemovePreSchedulePod(pod.Namespace, pod.Name, true)
 		r.Expander.ClearFailedExpansionCandidatesForPod(pod.Namespace, pod.Name)
 	}
 	// Release GPU resources when pod is in Failed or Succeeded (Complete) state
 	// Only for worker pods that have allocated GPU resources
 	if pod.Labels[constants.LabelComponent] == constants.ComponentWorker && utils.IsPodStopped(pod) {
 		if r.Expander != nil {
-			_ = r.Expander.RemovePreSchedulePod(pod.Name, true)
+			_ = r.Expander.RemovePreSchedulePod(pod.Namespace, pod.Name, true)
 			r.Expander.ClearFailedExpansionCandidatesForPod(pod.Namespace, pod.Name)
 		}
 		r.Allocator.DeallocByPodIdentifier(ctx, req.NamespacedName)

--- a/internal/scheduler/expander/handler.go
+++ b/internal/scheduler/expander/handler.go
@@ -100,7 +100,7 @@ func NewNodeExpander(
 			ResourceVersion: req.PodMeta.ResourceVersion,
 		}
 
-		removed := expander.RemovePreSchedulePod(req.PodMeta.Name, true)
+		removed := expander.removePreSchedulePod(req.PodMeta.Namespace, req.PodMeta.Name, req.PodMeta.UID, true)
 		if removed {
 			expander.clearFailedExpansionCandidates(req.PodMeta.Namespace, req.PodMeta.Name, req.PodMeta.UID)
 			recorder.Eventf(obj, nil, corev1.EventTypeNormal, "NodeExpansionCheck", "Scheduled",
@@ -176,7 +176,7 @@ func (e *NodeExpander) handleTerminatedInFlightNodeClaim(name string, value any,
 	if !ok {
 		return
 	}
-	_ = e.RemovePreSchedulePod(claim.podKey.Name, true)
+	_ = e.removePreSchedulePod(claim.podKey.Namespace, claim.podKey.Name, claim.podUID, true)
 
 	pod := &corev1.Pod{}
 	if err := e.client.Get(e.ctx, claim.podKey, pod); err != nil || pod.UID != claim.podUID {
@@ -312,7 +312,7 @@ func (e *NodeExpander) ProcessExpansion(ctx context.Context, pod *corev1.Pod) er
 		return fmt.Errorf("pod cannot be nil")
 	}
 	e.mu.RLock()
-	_, alreadyInPreSchedule := e.preSchedulePods[pod.Name]
+	_, alreadyInPreSchedule := e.preSchedulePods[preSchedulePodKey(pod.Namespace, pod.Name)]
 	inFlightCount := len(e.inFlightNodes)
 	e.mu.RUnlock()
 
@@ -700,23 +700,32 @@ func (e *NodeExpander) addPreSchedulePod(allocRequest *tfv1.AllocRequest) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	podMeta := allocRequest.PodMeta
-	e.preSchedulePods[podMeta.Name] = allocRequest
+	key := preSchedulePodKey(podMeta.Namespace, podMeta.Name)
+	if oldTimer, ok := e.preScheduleTimers[key]; ok {
+		oldTimer.Stop()
+	}
+	e.preSchedulePods[key] = allocRequest
 	// Add timer for each pre-scheduled pod, if not scheduled for 10 minutes, make warning event and remove from mem
 	timer := time.AfterFunc((10 * time.Minute), func() {
 		currentPod := &corev1.Pod{}
 		err := e.client.Get(e.ctx, client.ObjectKey{Name: podMeta.Name, Namespace: podMeta.Namespace}, currentPod)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				_ = e.RemovePreSchedulePod(podMeta.Name, false)
+				_ = e.removePreSchedulePod(podMeta.Namespace, podMeta.Name, podMeta.UID, false)
 				e.clearFailedExpansionCandidates(podMeta.Namespace, podMeta.Name, podMeta.UID)
 			}
 			e.logger.Error(err, "failed to get pod for node expansion check",
 				"namespace", podMeta.Namespace, "pod", podMeta.Name)
-			_ = e.RemovePreSchedulePod(podMeta.Name, false)
+			_ = e.removePreSchedulePod(podMeta.Namespace, podMeta.Name, podMeta.UID, false)
+			return
+		}
+		// A replacement Pod may reuse the same namespace/name while this old
+		// timer is still firing. Never let the old UID touch the new Pod's state.
+		if currentPod.UID != podMeta.UID {
 			return
 		}
 		if !currentPod.DeletionTimestamp.IsZero() {
-			_ = e.RemovePreSchedulePod(podMeta.Name, false)
+			_ = e.removePreSchedulePod(podMeta.Namespace, podMeta.Name, podMeta.UID, false)
 			e.clearFailedExpansionCandidates(podMeta.Namespace, podMeta.Name, podMeta.UID)
 			return
 		}
@@ -726,7 +735,7 @@ func (e *NodeExpander) addPreSchedulePod(allocRequest *tfv1.AllocRequest) {
 				"new node provisioned and pod scheduled successfully")
 			e.logger.Info("new node provisioned and pod scheduled successfully",
 				"namespace", podMeta.Namespace, "pod", podMeta.Name)
-			_ = e.RemovePreSchedulePod(podMeta.Name, false)
+			_ = e.removePreSchedulePod(podMeta.Namespace, podMeta.Name, podMeta.UID, false)
 			e.clearFailedExpansionCandidates(podMeta.Namespace, podMeta.Name, podMeta.UID)
 		} else {
 			// not scheduled, record warning event and remove pre-scheduled pod
@@ -734,10 +743,10 @@ func (e *NodeExpander) addPreSchedulePod(allocRequest *tfv1.AllocRequest) {
 				"failed to schedule pod after 10 minutes")
 			e.logger.Info("failed to schedule pod after 10 minutes",
 				"namespace", podMeta.Namespace, "pod", podMeta.Name)
-			_ = e.RemovePreSchedulePod(podMeta.Name, false)
+			_ = e.removePreSchedulePod(podMeta.Namespace, podMeta.Name, podMeta.UID, false)
 		}
 	})
-	e.preScheduleTimers[podMeta.Name] = timer
+	e.preScheduleTimers[key] = timer
 }
 
 func (e *NodeExpander) RemoveInFlightNode(nodeName string) {
@@ -752,25 +761,38 @@ func (e *NodeExpander) RemoveInFlightNode(nodeName string) {
 	e.mu.Unlock()
 }
 
-func (e *NodeExpander) RemovePreSchedulePod(podName string, stopTimer bool) bool {
+func preSchedulePodKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+func (e *NodeExpander) removePreSchedulePod(namespace, podName string, podUID types.UID, stopTimer bool) bool {
 	if e == nil {
 		return false
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	key := preSchedulePodKey(namespace, podName)
+	if alloc, ok := e.preSchedulePods[key]; ok && podUID != "" && alloc != nil && alloc.PodMeta.UID != podUID {
+		return false
+	}
 	if stopTimer {
-		if timer, ok := e.preScheduleTimers[podName]; ok {
+		if timer, ok := e.preScheduleTimers[key]; ok {
 			timer.Stop()
 		}
 	}
-	delete(e.preScheduleTimers, podName)
+	delete(e.preScheduleTimers, key)
 
-	if _, ok := e.preSchedulePods[podName]; ok {
-		delete(e.preSchedulePods, podName)
-		e.logger.Info("Removed pre-scheduled pod", "pod", podName, "remaining pre-scheduled pods", len(e.preSchedulePods))
+	if _, ok := e.preSchedulePods[key]; ok {
+		delete(e.preSchedulePods, key)
+		e.logger.Info("Removed pre-scheduled pod", "namespace", namespace, "pod", podName, "remaining pre-scheduled pods", len(e.preSchedulePods))
 		return true
 	}
 	return false
+}
+
+// RemovePreSchedulePod removes a pre-scheduled pod identified by namespace/name.
+func (e *NodeExpander) RemovePreSchedulePod(namespace, podName string, stopTimer bool) bool {
+	return e.removePreSchedulePod(namespace, podName, "", stopTimer)
 }
 
 func (e *NodeExpander) prepareNewNodesForScheduleAttempt(
@@ -865,7 +887,7 @@ func (e *NodeExpander) checkGPUFitWithInflightNodes(pod *corev1.Pod, potentialGp
 		if !preScheduledPodPreAllocated {
 			e.logger.Info("[Warning] pre-scheduled pod can not set into InFlight node anymore, remove queue and retry later",
 				"pod", alloc.PodMeta.Name, "namespace", alloc.PodMeta.Namespace)
-			_ = e.RemovePreSchedulePod(alloc.PodMeta.Name, true)
+			_ = e.removePreSchedulePod(alloc.PodMeta.Namespace, alloc.PodMeta.Name, alloc.PodMeta.UID, true)
 		}
 	}
 

--- a/internal/scheduler/expander/handler_test.go
+++ b/internal/scheduler/expander/handler_test.go
@@ -635,18 +635,28 @@ func testPreScheduledPodManagement(suite *NodeExpanderTestSuite) {
 
 	// Verify pre-scheduled pod exists
 	suite.nodeExpander.mu.RLock()
-	_, exists := suite.nodeExpander.preSchedulePods["test-pod"]
+	_, exists := suite.nodeExpander.preSchedulePods[preSchedulePodKey(allocReq.PodMeta.Namespace, allocReq.PodMeta.Name)]
 	suite.nodeExpander.mu.RUnlock()
 	Expect(exists).To(BeTrue())
 
 	// Test removing pre-scheduled pod
-	_ = suite.nodeExpander.RemovePreSchedulePod("test-pod", true)
+	_ = suite.nodeExpander.RemovePreSchedulePod(allocReq.PodMeta.Namespace, allocReq.PodMeta.Name, true)
 
 	// Verify pre-scheduled pod is removed
 	suite.nodeExpander.mu.RLock()
-	_, exists = suite.nodeExpander.preSchedulePods["test-pod"]
+	_, exists = suite.nodeExpander.preSchedulePods[preSchedulePodKey(allocReq.PodMeta.Namespace, allocReq.PodMeta.Name)]
 	suite.nodeExpander.mu.RUnlock()
 	Expect(exists).To(BeFalse())
+
+	// Same Pod name in another namespace must have independent state.
+	other := allocReq.DeepCopy()
+	other.PodMeta.Namespace = "other"
+	suite.nodeExpander.addPreSchedulePod(other)
+	suite.nodeExpander.mu.RLock()
+	_, exists = suite.nodeExpander.preSchedulePods[preSchedulePodKey(other.PodMeta.Namespace, other.PodMeta.Name)]
+	suite.nodeExpander.mu.RUnlock()
+	Expect(exists).To(BeTrue())
+	_ = suite.nodeExpander.RemovePreSchedulePod(other.PodMeta.Namespace, other.PodMeta.Name, true)
 }
 
 // Case 1: Expand from 1 GPU node cluster
@@ -828,7 +838,7 @@ func testExpandWhenInflightCannotSatisfy(suite *NodeExpanderTestSuite) {
 	// Add inflight node and pre-schedule a pod to it
 	suite.nodeExpander.mu.Lock()
 	suite.nodeExpander.inFlightNodes["inflight-node"] = []*tfv1.GPU{inflightGPU}
-	suite.nodeExpander.preSchedulePods["pre-scheduled"] = allocRequest
+	suite.nodeExpander.preSchedulePods[preSchedulePodKey(allocRequest.PodMeta.Namespace, allocRequest.PodMeta.Name)] = allocRequest
 	suite.nodeExpander.mu.Unlock()
 
 	// Create new pod that cannot be satisfied by the already-occupied inflight node

--- a/pkg/hypervisor/device/controller.go
+++ b/pkg/hypervisor/device/controller.go
@@ -96,12 +96,12 @@ func (m *Controller) StartDiscoverDevices() error {
 // discoverDevices discovers all available GPU devices
 func (m *Controller) discoverDevices() error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	// Get all devices at once
 	klog.Infof("Start discovering devices using provider lib")
 	devices, err := m.accelerator.GetAllDevices()
 	if err != nil {
+		m.mu.Unlock()
 		return fmt.Errorf("failed to get all devices: %w", err)
 	}
 
@@ -158,7 +158,7 @@ func (m *Controller) discoverDevices() error {
 
 	// Notify handlers for all changes (similar to K8s reconcile)
 	for _, device := range addedDevices {
-		m.notifyHandlers(func(handler framework.DeviceChangeHandler) {
+		m.notifyHandlersLocked(func(handler framework.DeviceChangeHandler) {
 			if handler.OnAdd != nil {
 				handler.OnAdd(device)
 			}
@@ -167,7 +167,7 @@ func (m *Controller) discoverDevices() error {
 	}
 
 	for _, device := range removedDevices {
-		m.notifyHandlers(func(handler framework.DeviceChangeHandler) {
+		m.notifyHandlersLocked(func(handler framework.DeviceChangeHandler) {
 			if handler.OnRemove != nil {
 				handler.OnRemove(device)
 			}
@@ -176,7 +176,7 @@ func (m *Controller) discoverDevices() error {
 	}
 
 	for _, update := range updatedDevices {
-		m.notifyHandlers(func(handler framework.DeviceChangeHandler) {
+		m.notifyHandlersLocked(func(handler framework.DeviceChangeHandler) {
 			if handler.OnUpdate != nil {
 				handler.OnUpdate(update.old, update.new)
 			}
@@ -199,6 +199,11 @@ func (m *Controller) discoverDevices() error {
 	}
 
 	nodeInfo := m.AggregateNodeInfo()
+	// Do not invoke callbacks while holding device.mu. Allocation callbacks may
+	// call back into the device controller, and allocation itself holds its own
+	// mutex while reading devices; keeping callbacks outside this lock avoids a
+	// device/allocation lock-order deadlock.
+	m.mu.Unlock()
 
 	if metrics.ShouldSendTelemetry() {
 		sampleGPUModel := ""
@@ -221,7 +226,7 @@ func (m *Controller) discoverDevices() error {
 			nodeInfo, m.acceleratorVendor, sampleGPUModel, workersCount, m.isolationMode,
 		)
 	}
-	m.notifyHandlers(func(handler framework.DeviceChangeHandler) {
+	m.notifyHandlersLocked(func(handler framework.DeviceChangeHandler) {
 		if handler.OnDiscoveryComplete != nil {
 			handler.OnDiscoveryComplete(nodeInfo)
 		}
@@ -229,8 +234,9 @@ func (m *Controller) discoverDevices() error {
 	return nil
 }
 
-// notifyHandlers calls the provided function for each registered handler
-func (m *Controller) notifyHandlers(fn func(framework.DeviceChangeHandler)) {
+// notifyHandlersLocked is used by discovery while it owns the controller state
+// lock, and by the final callback after discovery releases it.
+func (m *Controller) notifyHandlersLocked(fn func(framework.DeviceChangeHandler)) {
 	for _, handler := range m.deviceUpdateHandlers {
 		fn(handler)
 	}
@@ -428,20 +434,27 @@ func (m *Controller) RemovePartitionedDevice(partitionUUID, deviceUUID string) e
 
 func (m *Controller) RegisterDeviceUpdateHandler(handler framework.DeviceChangeHandler) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.deviceUpdateHandlers = append(m.deviceUpdateHandlers, handler)
+	devices := make([]*api.DeviceInfo, 0, len(m.devices))
+	for _, device := range m.devices {
+		devices = append(devices, device)
+	}
+	var nodeInfo *api.NodeInfo
+	if len(devices) > 0 && handler.OnDiscoveryComplete != nil {
+		nodeInfo = m.AggregateNodeInfo()
+	}
+	m.mu.Unlock()
 
 	// Notify the newly registered handler about existing devices without triggering a new discovery
 	// This ensures handlers get notified of devices that were discovered before they were registered
-	if len(m.devices) > 0 {
-		for _, device := range m.devices {
+	if len(devices) > 0 {
+		for _, device := range devices {
 			if handler.OnAdd != nil {
 				handler.OnAdd(device)
 			}
 		}
 		// Also notify about discovery completion if there are existing devices
 		if handler.OnDiscoveryComplete != nil {
-			nodeInfo := m.AggregateNodeInfo()
 			handler.OnDiscoveryComplete(nodeInfo)
 		}
 	}

--- a/pkg/hypervisor/device/controller.go
+++ b/pkg/hypervisor/device/controller.go
@@ -96,12 +96,17 @@ func (m *Controller) StartDiscoverDevices() error {
 // discoverDevices discovers all available GPU devices
 func (m *Controller) discoverDevices() error {
 	m.mu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			m.mu.Unlock()
+		}
+	}()
 
 	// Get all devices at once
 	klog.Infof("Start discovering devices using provider lib")
 	devices, err := m.accelerator.GetAllDevices()
 	if err != nil {
-		m.mu.Unlock()
 		return fmt.Errorf("failed to get all devices: %w", err)
 	}
 
@@ -156,35 +161,7 @@ func (m *Controller) discoverDevices() error {
 		}
 	}
 
-	// Notify handlers for all changes (similar to K8s reconcile)
-	for _, device := range addedDevices {
-		m.notifyHandlersLocked(func(handler framework.DeviceChangeHandler) {
-			if handler.OnAdd != nil {
-				handler.OnAdd(device)
-			}
-		})
-		klog.V(4).Infof("Device added: %s (UUID: %s)", device.Model, device.UUID)
-	}
-
-	for _, device := range removedDevices {
-		m.notifyHandlersLocked(func(handler framework.DeviceChangeHandler) {
-			if handler.OnRemove != nil {
-				handler.OnRemove(device)
-			}
-		})
-		klog.V(4).Infof("Device removed: %s (UUID: %s)", device.Model, device.UUID)
-	}
-
-	for _, update := range updatedDevices {
-		m.notifyHandlersLocked(func(handler framework.DeviceChangeHandler) {
-			if handler.OnUpdate != nil {
-				handler.OnUpdate(update.old, update.new)
-			}
-		})
-		klog.V(4).Infof("Device updated: %s (UUID: %s)", update.new.Model, update.new.UUID)
-	}
-
-	// Update state after notifying handlers
+	// Update state before notifying handlers so callbacks can safely read it.
 	for _, device := range addedDevices {
 		m.devices[device.UUID] = device
 		m.nativeUUIDs[device.UUID] = newNativeUUIDs[device.UUID]
@@ -199,16 +176,40 @@ func (m *Controller) discoverDevices() error {
 	}
 
 	nodeInfo := m.AggregateNodeInfo()
-	// Do not invoke callbacks while holding device.mu. Allocation callbacks may
-	// call back into the device controller, and allocation itself holds its own
-	// mutex while reading devices; keeping callbacks outside this lock avoids a
-	// device/allocation lock-order deadlock.
 	m.mu.Unlock()
+	locked = false
+
+	// Notify handlers outside device.mu. Callbacks may call back into this
+	// controller, and allocation callbacks use a separate mutex.
+	for _, device := range addedDevices {
+		m.notifyHandlers(func(handler framework.DeviceChangeHandler) {
+			if handler.OnAdd != nil {
+				handler.OnAdd(device)
+			}
+		})
+		klog.V(4).Infof("Device added: %s (UUID: %s)", device.Model, device.UUID)
+	}
+	for _, device := range removedDevices {
+		m.notifyHandlers(func(handler framework.DeviceChangeHandler) {
+			if handler.OnRemove != nil {
+				handler.OnRemove(device)
+			}
+		})
+		klog.V(4).Infof("Device removed: %s (UUID: %s)", device.Model, device.UUID)
+	}
+	for _, update := range updatedDevices {
+		m.notifyHandlers(func(handler framework.DeviceChangeHandler) {
+			if handler.OnUpdate != nil {
+				handler.OnUpdate(update.old, update.new)
+			}
+		})
+		klog.V(4).Infof("Device updated: %s (UUID: %s)", update.new.Model, update.new.UUID)
+	}
 
 	if metrics.ShouldSendTelemetry() {
 		sampleGPUModel := ""
-		if len(m.devices) > 0 {
-			for _, device := range m.devices {
+		if devices := m.GetDevices(); len(devices) > 0 {
+			for _, device := range devices {
 				if device.Model != "" {
 					sampleGPUModel = device.Model
 					break
@@ -226,7 +227,7 @@ func (m *Controller) discoverDevices() error {
 			nodeInfo, m.acceleratorVendor, sampleGPUModel, workersCount, m.isolationMode,
 		)
 	}
-	m.notifyHandlersLocked(func(handler framework.DeviceChangeHandler) {
+	m.notifyHandlers(func(handler framework.DeviceChangeHandler) {
 		if handler.OnDiscoveryComplete != nil {
 			handler.OnDiscoveryComplete(nodeInfo)
 		}
@@ -234,10 +235,11 @@ func (m *Controller) discoverDevices() error {
 	return nil
 }
 
-// notifyHandlersLocked is used by discovery while it owns the controller state
-// lock, and by the final callback after discovery releases it.
-func (m *Controller) notifyHandlersLocked(fn func(framework.DeviceChangeHandler)) {
-	for _, handler := range m.deviceUpdateHandlers {
+func (m *Controller) notifyHandlers(fn func(framework.DeviceChangeHandler)) {
+	m.mu.RLock()
+	handlers := append([]framework.DeviceChangeHandler(nil), m.deviceUpdateHandlers...)
+	m.mu.RUnlock()
+	for _, handler := range handlers {
 		fn(handler)
 	}
 }

--- a/pkg/hypervisor/worker/allocation.go
+++ b/pkg/hypervisor/worker/allocation.go
@@ -102,6 +102,9 @@ func (a *AllocationController) AllocateWorkerDevices(request *api.WorkerInfo) (*
 			deviceInfos = append(deviceInfos, device)
 		}
 	}
+	if len(deviceInfos) == 0 {
+		return nil, fmt.Errorf("none of the requested devices exist for worker %s", request.WorkerUID)
+	}
 
 	mounts, err := a.deviceController.GetVendorMountLibs()
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes a collision in the node expander's pre-scheduled pod state.

## Changes

- Use `namespace/name` instead of pod name alone for pre-schedule state and timers.
- Update all cleanup paths, including:
  - successful binding
  - NodeClaim termination
  - timeout cleanup
  - in-flight GPU reconciliation
- Stop the previous timer when replacing the same Pod key.
- Validate Pod UID before an old timer removes state from a recreated Pod.
- Add a test covering same-named Pods in different namespaces.

## Tests

- `go test ./internal/scheduler/expander`
- `go test -race ./internal/scheduler/expander ./internal/scheduler/gpuresources ./internal/gang ./internal/gpuallocator ./internal/indexallocator ./internal/portallocator ./internal/quota`