### PR TITLE
fix(operator): reuse user-declared /dev/shm in local hard sidecar mode

### DIFF
--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -344,6 +344,52 @@ func AppendTFWorkerLabelsAndAnnotationsAfterTemplate(
 	return labels, annotations
 }
 
+func configureLocalTransportShm(ctx context.Context, pod *v1.Pod, injectContainerIndices []int) (string, string) {
+	shmVolumeName := constants.TransportShmVolumeName
+	shmSubPath := ""
+	// Local hard modes run the TensorFusion worker in a sibling container and use /dev/shm for transport.
+	//
+	// If a business container already declares its own /dev/shm mount
+	// (a common pattern: emptyDir with medium: Memory and a sizeLimit,
+	// e.g. for PyTorch DataLoader/NCCL), reuse that volume for the
+	// transport instead of appending a second mount at the same path.
+	// This keeps the user's sizeLimit in control and avoids the
+	// duplicate mount path that kubelet rejects. The transport only
+	// needs a shared tmpfs file, so any shared pod volume works as
+	// long as both the business container and the worker mount it.
+	for _, containerIndex := range injectContainerIndices {
+		userMount, found := findMountAtPath(pod.Spec.Containers[containerIndex].VolumeMounts, constants.TransportShmPath)
+		if !found {
+			continue
+		}
+		if shmVolumeName == constants.TransportShmVolumeName {
+			shmVolumeName = userMount.Name
+			shmSubPath = userMount.SubPath
+		} else if userMount.Name != shmVolumeName {
+			log.FromContext(ctx).Info(
+				"container /dev/shm volume differs from the reused transport volume; it will not share the tensor-fusion transport",
+				"container", pod.Spec.Containers[containerIndex].Name,
+				"volume", userMount.Name,
+				"sharedVolume", shmVolumeName)
+		}
+	}
+	if shmVolumeName == constants.TransportShmVolumeName {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+			Name: constants.TransportShmVolumeName,
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{
+					Medium: v1.StorageMediumMemory,
+				},
+			},
+		})
+	} else {
+		log.FromContext(ctx).Info(
+			"reusing user-declared /dev/shm volume for local hard sidecar transport",
+			"volume", shmVolumeName)
+	}
+	return shmVolumeName, shmSubPath
+}
+
 func AddTFDefaultClientConfBeforePatch(
 	ctx context.Context,
 	pod *v1.Pod,
@@ -542,46 +588,7 @@ func AddTFDefaultClientConfBeforePatch(
 				applyProviderRemoteWorkerConfigToContainerIndex(&pod.Spec, tfInfo.Profile.GPUVendor, injectContainerIndex)
 			}
 		} else if useLocalWorkerSidecar {
-			// Local hard modes run the TensorFusion worker in a sibling container and use /dev/shm for transport.
-			//
-			// If a business container already declares its own /dev/shm mount
-			// (a common pattern: emptyDir with medium: Memory and a sizeLimit,
-			// e.g. for PyTorch DataLoader/NCCL), reuse that volume for the
-			// transport instead of appending a second mount at the same path.
-			// This keeps the user's sizeLimit in control and avoids the
-			// duplicate mount path that kubelet rejects. The transport only
-			// needs a shared tmpfs file, so any shared pod volume works as
-			// long as both the business container and the worker mount it.
-			for _, containerIndex := range injectContainerIndices {
-				userMount, found := findMountAtPath(pod.Spec.Containers[containerIndex].VolumeMounts, constants.TransportShmPath)
-				if !found {
-					continue
-				}
-				if shmVolumeName == constants.TransportShmVolumeName {
-					shmVolumeName = userMount.Name
-					shmSubPath = userMount.SubPath
-				} else if userMount.Name != shmVolumeName {
-					log.FromContext(ctx).Info(
-						"container /dev/shm volume differs from the reused transport volume; it will not share the tensor-fusion transport",
-						"container", pod.Spec.Containers[containerIndex].Name,
-						"volume", userMount.Name,
-						"sharedVolume", shmVolumeName)
-				}
-			}
-			if shmVolumeName == constants.TransportShmVolumeName {
-				pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-					Name: constants.TransportShmVolumeName,
-					VolumeSource: v1.VolumeSource{
-						EmptyDir: &v1.EmptyDirVolumeSource{
-							Medium: v1.StorageMediumMemory,
-						},
-					},
-				})
-			} else {
-				log.FromContext(ctx).Info(
-					"reusing user-declared /dev/shm volume for local hard sidecar transport",
-					"volume", shmVolumeName)
-			}
+			shmVolumeName, shmSubPath = configureLocalTransportShm(ctx, pod, injectContainerIndices)
 
 			// Seed the sidecar from worker.podTemplate so user-defined env/resources
 			// (e.g. TF_LICENSE) reach the sidecar like they do for remote worker pods.

--- a/internal/utils/compose.go
+++ b/internal/utils/compose.go
@@ -120,6 +120,22 @@ func appendEnvIfMissing(envList []v1.EnvVar, envs ...v1.EnvVar) []v1.EnvVar {
 	return envList
 }
 
+// findMountAtPath returns the first volumeMount at path, if any.
+func findMountAtPath(mounts []v1.VolumeMount, path string) (v1.VolumeMount, bool) {
+	for _, mount := range mounts {
+		if mount.MountPath == path {
+			return mount, true
+		}
+	}
+	return v1.VolumeMount{}, false
+}
+
+// hasMountAtPath reports whether any volumeMount targets path.
+func hasMountAtPath(mounts []v1.VolumeMount, path string) bool {
+	_, ok := findMountAtPath(mounts, path)
+	return ok
+}
+
 func setEnv(envList []v1.EnvVar, env v1.EnvVar) []v1.EnvVar {
 	result := envList[:0]
 	for _, item := range envList {
@@ -340,6 +356,13 @@ func AddTFDefaultClientConfBeforePatch(
 	clientConfig := pool.Spec.ComponentConfig.Client
 	useLocalWorkerSidecar := UseLocalWorkerSidecar(tfInfo.Profile)
 	useInjectLib := shouldInjectClientBootstrap(tfInfo.Profile)
+	// Transport shared-memory volume for client-worker RPC in local hard
+	// sidecar mode. Defaults to a TF-managed emptyDir; when the workload
+	// already declares its own /dev/shm mount, that volume is reused instead
+	// so we never emit a duplicate mount path, which kubelet rejects
+	// ("mountPath ... must be unique").
+	shmVolumeName := constants.TransportShmVolumeName
+	shmSubPath := ""
 	if useInjectLib {
 		// Any mode that needs the client initContainer should prefer the provider-specific
 		// client image. Local shared/embedded mode skips this path entirely.
@@ -520,14 +543,45 @@ func AddTFDefaultClientConfBeforePatch(
 			}
 		} else if useLocalWorkerSidecar {
 			// Local hard modes run the TensorFusion worker in a sibling container and use /dev/shm for transport.
-			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-				Name: constants.TransportShmVolumeName,
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{
-						Medium: v1.StorageMediumMemory,
+			//
+			// If a business container already declares its own /dev/shm mount
+			// (a common pattern: emptyDir with medium: Memory and a sizeLimit,
+			// e.g. for PyTorch DataLoader/NCCL), reuse that volume for the
+			// transport instead of appending a second mount at the same path.
+			// This keeps the user's sizeLimit in control and avoids the
+			// duplicate mount path that kubelet rejects. The transport only
+			// needs a shared tmpfs file, so any shared pod volume works as
+			// long as both the business container and the worker mount it.
+			for _, containerIndex := range injectContainerIndices {
+				userMount, found := findMountAtPath(pod.Spec.Containers[containerIndex].VolumeMounts, constants.TransportShmPath)
+				if !found {
+					continue
+				}
+				if shmVolumeName == constants.TransportShmVolumeName {
+					shmVolumeName = userMount.Name
+					shmSubPath = userMount.SubPath
+				} else if userMount.Name != shmVolumeName {
+					log.FromContext(ctx).Info(
+						"container /dev/shm volume differs from the reused transport volume; it will not share the tensor-fusion transport",
+						"container", pod.Spec.Containers[containerIndex].Name,
+						"volume", userMount.Name,
+						"sharedVolume", shmVolumeName)
+				}
+			}
+			if shmVolumeName == constants.TransportShmVolumeName {
+				pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+					Name: constants.TransportShmVolumeName,
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium: v1.StorageMediumMemory,
+						},
 					},
-				},
-			})
+				})
+			} else {
+				log.FromContext(ctx).Info(
+					"reusing user-declared /dev/shm volume for local hard sidecar transport",
+					"volume", shmVolumeName)
+			}
 
 			// Seed the sidecar from worker.podTemplate so user-defined env/resources
 			// (e.g. TF_LICENSE) reach the sidecar like they do for remote worker pods.
@@ -535,8 +589,9 @@ func AddTFDefaultClientConfBeforePatch(
 				Name: constants.TFContainerNameWorker,
 				VolumeMounts: []v1.VolumeMount{
 					{
-						Name:      constants.TransportShmVolumeName,
+						Name:      shmVolumeName,
 						MountPath: constants.TransportShmPath,
+						SubPath:   shmSubPath,
 					},
 				},
 			}
@@ -582,14 +637,20 @@ func AddTFDefaultClientConfBeforePatch(
 				continue
 			}
 			if useLocalWorkerSidecar {
+				if !hasMountAtPath(pod.Spec.Containers[injectContainerIndex].VolumeMounts, constants.TransportShmPath) {
+					pod.Spec.Containers[injectContainerIndex].VolumeMounts = append(
+						pod.Spec.Containers[injectContainerIndex].VolumeMounts,
+						v1.VolumeMount{
+							Name:      shmVolumeName,
+							MountPath: constants.TransportShmPath,
+							SubPath:   shmSubPath,
+						},
+					)
+				}
+				// Local sidecar clients still need the host-backed TF shared-memory state for
+				// NVML/memory hooks, even though client-worker RPC uses /dev/shm transport.
 				pod.Spec.Containers[injectContainerIndex].VolumeMounts = append(
 					pod.Spec.Containers[injectContainerIndex].VolumeMounts,
-					v1.VolumeMount{
-						Name:      constants.TransportShmVolumeName,
-						MountPath: constants.TransportShmPath,
-					},
-					// Local sidecar clients still need the host-backed TF shared-memory state for
-					// NVML/memory hooks, even though client-worker RPC uses /dev/shm transport.
 					v1.VolumeMount{
 						Name:             constants.DataVolumeName,
 						MountPath:        constants.TFDataPath + constants.SharedMemMountSubPath,

--- a/internal/utils/compose_test.go
+++ b/internal/utils/compose_test.go
@@ -473,6 +473,98 @@ var _ = Describe("Compose Utils", func() {
 			Expect(cudaHooksValue).To(Equal("false"))
 		})
 
+		It("should reuse a user-declared /dev/shm mount in local hard mode", func() {
+			sizeLimit := resource.MustParse("2Gi")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: "dshm",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								Medium:    corev1.StorageMediumMemory,
+								SizeLimit: &sizeLimit,
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name: "main",
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "dshm",
+							MountPath: "/dev/shm",
+						}},
+					}},
+				},
+			}
+
+			utils.AddTFDefaultClientConfBeforePatch(context.Background(), pod, newPool(), utils.TensorFusionInfo{
+				Profile: &tfv1.WorkloadProfileSpec{
+					IsLocalGPU: true,
+					Isolation:  tfv1.IsolationModeHard,
+					GPUVendor:  constants.AcceleratorVendorNvidia,
+				},
+			}, []int{0})
+
+			// The TF-managed transport shm volume must not be created; the
+			// user's volume is reused so kubelet never sees a duplicated
+			// /dev/shm mountPath.
+			for _, volume := range pod.Spec.Volumes {
+				Expect(volume.Name).NotTo(Equal(constants.TransportShmVolumeName))
+			}
+			Expect(countVolumeMountPath(pod.Spec.Containers[0].VolumeMounts, constants.TransportShmPath)).To(Equal(1))
+			Expect(hasVolumeMount(pod.Spec.Containers[0].VolumeMounts, "dshm", constants.TransportShmPath)).To(BeTrue())
+			// The worker sidecar mounts the same user volume for transport.
+			Expect(pod.Spec.Containers).To(HaveLen(2))
+			Expect(pod.Spec.Containers[1].Name).To(Equal(constants.TFContainerNameWorker))
+			Expect(hasVolumeMount(pod.Spec.Containers[1].VolumeMounts, "dshm", constants.TransportShmPath)).To(BeTrue())
+			Expect(pod.Spec.Containers[1].Command[2]).To(ContainSubstring("touch /dev/shm/tf_shm"))
+		})
+
+		It("should share a user-declared /dev/shm volume across injected containers in local hard mode", func() {
+			sizeLimit := resource.MustParse("2Gi")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: "dshm",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								Medium:    corev1.StorageMediumMemory,
+								SizeLimit: &sizeLimit,
+							},
+						},
+					}},
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "dshm",
+								MountPath: "/dev/shm",
+							}},
+						},
+						{Name: "side"},
+					},
+				},
+			}
+
+			utils.AddTFDefaultClientConfBeforePatch(context.Background(), pod, newPool(), utils.TensorFusionInfo{
+				Profile: &tfv1.WorkloadProfileSpec{
+					IsLocalGPU: true,
+					Isolation:  tfv1.IsolationModeHard,
+					GPUVendor:  constants.AcceleratorVendorNvidia,
+				},
+			}, []int{0, 1})
+
+			Expect(pod.Spec.Containers).To(HaveLen(3))
+			// main keeps its own mount; side and the worker get the same volume
+			// so the transport is reachable from every injected container.
+			Expect(countVolumeMountPath(pod.Spec.Containers[0].VolumeMounts, constants.TransportShmPath)).To(Equal(1))
+			Expect(hasVolumeMount(pod.Spec.Containers[0].VolumeMounts, "dshm", constants.TransportShmPath)).To(BeTrue())
+			Expect(hasVolumeMount(pod.Spec.Containers[1].VolumeMounts, "dshm", constants.TransportShmPath)).To(BeTrue())
+			Expect(pod.Spec.Containers[2].Name).To(Equal(constants.TFContainerNameWorker))
+			Expect(hasVolumeMount(pod.Spec.Containers[2].VolumeMounts, "dshm", constants.TransportShmPath)).To(BeTrue())
+		})
+
 		It("should merge legacy worker template env into local hard sidecar", func() {
 			pool := newPool()
 			pool.Spec.ComponentConfig.Worker.PodTemplate = &runtime.RawExtension{Raw: []byte(`{


### PR DESCRIPTION
## Summary

Fix Pod creation failures when a workload in local hard sidecar mode already mounts a volume at `/dev/shm`. Previously, injection added a duplicate mount, causing Kubernetes to reject the Pod with `mountPath must be unique`.

- Reuse the workload's existing volume and subPath for the worker sidecar transport, preserving the configured sizeLimit.
- Keep the existing TF-managed emptyDir behavior when no `/dev/shm` mount is declared.
- Extract shared-memory configuration into a helper to satisfy the complexity lint limit.

## Validation

- `make test`: all 38 suites passed.
- `make lint`: 0 issues.
- Dev cluster before/after verification: the original operator rejected the test Pod; the fixed operator admitted it with a single `/dev/shm` mount per container sharing the same volume.
- GPU runtime verification remains incomplete because the cluster's GPU node was NotReady.